### PR TITLE
fix: replace empty catch blocks with proper error logging

### DIFF
--- a/src/app/admin/ads/_lib/use-ads-data.ts
+++ b/src/app/admin/ads/_lib/use-ads-data.ts
@@ -140,7 +140,8 @@ export function useAdsData({ filters, onToast }: UseAdsDataOptions) {
         });
         if (!res.ok) throw new Error("Failed to toggle");
         onToast(newActive ? "Ad resumed" : "Ad paused", "success");
-      } catch {
+      } catch (err) {
+        console.warn("[app/admin/ads/_lib/use-ads-data.ts] error:", err);
         // Revert
         setAds((prev) =>
           prev.map((ad) =>
@@ -164,7 +165,8 @@ export function useAdsData({ filters, onToast }: UseAdsDataOptions) {
         });
         if (!res.ok) throw new Error("Failed to delete");
         onToast("Ad deleted", "success");
-      } catch {
+      } catch (err) {
+        console.warn("[app/admin/ads/_lib/use-ads-data.ts] error:", err);
         setAds(prev);
         onToast("Failed to delete ad", "error");
       }
@@ -198,7 +200,8 @@ export function useAdsData({ filters, onToast }: UseAdsDataOptions) {
         onToast("Ad created", "success");
         fetchStats();
         return true;
-      } catch {
+      } catch (err) {
+        console.warn("[app/admin/ads/_lib/use-ads-data.ts] error:", err);
         onToast("Failed to create ad", "error");
         return false;
       } finally {
@@ -238,7 +241,8 @@ export function useAdsData({ filters, onToast }: UseAdsDataOptions) {
         onToast("Ad updated", "success");
         fetchStats();
         return true;
-      } catch {
+      } catch (err) {
+        console.warn("[app/admin/ads/_lib/use-ads-data.ts] error:", err);
         onToast("Failed to save ad", "error");
         return false;
       } finally {
@@ -266,7 +270,8 @@ export function useAdsData({ filters, onToast }: UseAdsDataOptions) {
         onToast(`${ids.length} ads ${action === "delete" ? "deleted" : action === "pause" ? "paused" : "resumed"}`, "success");
         fetchStats();
         return true;
-      } catch {
+      } catch (err) {
+        console.warn("[app/admin/ads/_lib/use-ads-data.ts] error:", err);
         onToast("Batch operation failed", "error");
         return false;
       } finally {

--- a/src/app/admin/ads/_lib/use-ads-url-state.ts
+++ b/src/app/admin/ads/_lib/use-ads-url-state.ts
@@ -20,9 +20,8 @@ function loadLocalStorage(): Partial<AdsFilters> | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
+  } catch (err) { console.warn("[app/admin/ads/_lib/use-ads-url-state.ts] error:", err); return null;
+   }
 }
 
 function parseParams(params: URLSearchParams): Partial<AdsFilters> {
@@ -109,8 +108,7 @@ export function useAdsUrlState() {
       // Persist to localStorage
       try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      } catch {}
-
+      } catch (err) { console.warn("[app/admin/ads/_lib/use-ads-url-state.ts] non-critical error:", err); }
       // Debounce search query, immediate for everything else
       if (key === "q") {
         clearTimeout(debounceRef.current);
@@ -132,7 +130,7 @@ export function useAdsUrlState() {
         const next = { ...filters, sort: key, dir: "desc" as SortDir };
         try {
           localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-        } catch {}
+        } catch (err) { console.warn("[app/admin/ads/_lib/use-ads-url-state.ts] non-critical error:", err); }
         router.replace(`/admin/ads${filtersToParams(next)}`);
       }
     },

--- a/src/app/advertise/AdPurchaseForm.tsx
+++ b/src/app/advertise/AdPurchaseForm.tsx
@@ -85,7 +85,7 @@ export function AdPurchaseForm() {
           window.location.href = `/advertise/setup/${token}`;
         }
       }
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[app/advertise/AdPurchaseForm.tsx] non-critical error:", err); }
   }, []);
 
   useEffect(() => {
@@ -144,7 +144,8 @@ export function AdPurchaseForm() {
       } else if (data.url) {
         window.location.href = data.url;
       }
-    } catch {
+    } catch (err) {
+      console.warn("[app/advertise/AdPurchaseForm.tsx] error:", err);
       setError("Network error. Please try again.");
       setLoading(false);
     }

--- a/src/app/advertise/setup/[token]/SetupContent.tsx
+++ b/src/app/advertise/setup/[token]/SetupContent.tsx
@@ -35,9 +35,8 @@ function ClickPreview({
     ? (() => {
         try {
           return new URL(link).hostname.replace("www.", "");
-        } catch {
-          return link;
-        }
+        } catch (err) { console.warn("[app/advertise/setup/[token]/SetupContent.tsx] error:", err); return link;
+         }
       })()
     : null;
   const isMailto = link?.startsWith("mailto:");
@@ -158,7 +157,8 @@ export function SetupContent({
       }
 
       window.location.href = `/advertise/track/${token}`;
-    } catch {
+    } catch (err) {
+      console.warn("[app/advertise/setup/[token]/SetupContent.tsx] error:", err);
       setError("Network error. Please try again.");
       setSaving(false);
     }

--- a/src/app/api/admin/send-update-email/route.ts
+++ b/src/app/api/admin/send-update-email/route.ts
@@ -24,10 +24,8 @@ export async function POST(request: NextRequest) {
   let body: { subject?: string; html?: string; slug?: string };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/admin/send-update-email/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+   }
   const { subject, html, slug } = body;
   if (!subject || !html || !slug) {
     return NextResponse.json(

--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -123,10 +123,11 @@ async function fetchWeeklyContributions(login: string): Promise<number | null> {
       }
     }
     return total;
-  } catch {
+  } catch (err) {
+    console.warn("[app/api/checkin/route.ts] error:", err);
     return null;
   }
-}
+}  
 
 export async function POST() {
   const supabase = await createServerSupabase();
@@ -305,10 +306,9 @@ export async function POST() {
       success: r.success,
       created_at: r.created_at,
     }));
-  } catch {
-    // raids table may not exist yet
+  } catch (err) {
+    console.warn("[app/api/checkin/route.ts] non-critical error:", err);
   }
-
   return NextResponse.json({
     checked_in: checkinResult.checked_in,
     already_today: checkinResult.already_today ?? false,

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -61,10 +61,8 @@ export async function POST(request: Request) {
   let body: { item_id: string; provider: "stripe" | "abacatepay" | "nowpayments"; gifted_to_login?: string };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/checkout/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   const { item_id, provider, gifted_to_login } = body;
 
   if (!item_id || !provider || !["stripe", "abacatepay", "nowpayments"].includes(provider)) {

--- a/src/app/api/cron/lc-refresh/route.ts
+++ b/src/app/api/cron/lc-refresh/route.ts
@@ -69,9 +69,8 @@ async function fetchLCFullProfile(username: string): Promise<any> {
       );
     }
     return json?.data ?? null;
-  } catch {
-    return null;
-  }
+  } catch (err) { console.warn("[app/api/cron/lc-refresh/route.ts] error:", err); return null;
+   }
 }
 
 async function upsertFullProfile(

--- a/src/app/api/cron/streak-reminder/route.ts
+++ b/src/app/api/cron/streak-reminder/route.ts
@@ -63,7 +63,8 @@ export async function GET(request: NextRequest) {
           today,
         );
         results.reminded++;
-      } catch {
+      } catch (err) {
+        console.warn("[app/api/cron/streak-reminder/route.ts] error:", err);
         results.errors++;
       }
     }
@@ -115,7 +116,8 @@ export async function GET(request: NextRequest) {
         const completedCount = countMap.get(dev.id) ?? 0;
         sendDailiesReminderNotification(dev.id, dev.github_login, completedCount, today);
         dailiesResults.reminded++;
-      } catch {
+      } catch (err) {
+        console.warn("[app/api/cron/streak-reminder/route.ts] error:", err);
         dailiesResults.skipped++;
       }
     }

--- a/src/app/api/customizations/route.ts
+++ b/src/app/api/customizations/route.ts
@@ -78,10 +78,8 @@ export async function POST(request: Request) {
   let body: { item_id: string; color?: string | null };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/customizations/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   const { item_id, color } = body;
 
   if (item_id !== "custom_color") {

--- a/src/app/api/customizations/upload/route.ts
+++ b/src/app/api/customizations/upload/route.ts
@@ -58,13 +58,11 @@ export async function POST(request: Request) {
   let formData: FormData;
   try {
     formData = await request.formData();
-  } catch {
-    return NextResponse.json(
+  } catch (err) { console.warn("[app/api/customizations/upload/route.ts] error:", err); return NextResponse.json(
       { error: "Invalid form data" },
       { status: 400 }
     );
-  }
-
+   }
   const file = formData.get("file") as File | null;
   const slotIndexRaw = formData.get("slot_index");
   const slotIndex = slotIndexRaw !== null ? parseInt(slotIndexRaw as string, 10) : 0;

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -85,8 +85,8 @@ async function fetchLeetCodeUser(username: string) {
     }
     const rawText = await res.text();
     let json: any;
-    try { json = JSON.parse(rawText); } catch { 
-      console.error(`[/api/dev] LeetCode non-JSON response for "${username}": ${rawText.substring(0, 200)}`);
+    try { json = JSON.parse(rawText); } catch (err) { 
+      console.error(`[/api/dev] LeetCode non-JSON response for "${username}": ${rawText.substring(0, 200)}`, err);
       return null;
     }
     if (!json?.data?.matchedUser) {
@@ -107,9 +107,8 @@ async function fetchLeetCodeUser(username: string) {
       mu.maxStreak = parseMaxStreak(mu, currentYear);
     }
     return json?.data ?? null;
-  } catch {
-    return null;
-  }
+  } catch (err) { console.warn("[app/api/dev/[username]/route.ts] error:", err); return null;
+   }
 }
 
 export async function GET(
@@ -148,7 +147,8 @@ export async function GET(
       key = user ? `user:${user.id}` : (
         request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
       );
-    } catch {
+    } catch (err) {
+      console.warn("[app/api/dev/[username]/route.ts] error:", err);
       key = "unknown";
     }
     rateLimitKey = key;

--- a/src/app/api/district/change/route.ts
+++ b/src/app/api/district/change/route.ts
@@ -26,9 +26,8 @@ export async function POST(request: Request) {
   let body: Record<string, unknown>;
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
+  } catch (err) { console.warn("[app/api/district/change/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+   }
   const district_id = body.district_id as string;
 
   if (!district_id || !VALID_DISTRICTS.includes(district_id)) {

--- a/src/app/api/heartbeats/route.ts
+++ b/src/app/api/heartbeats/route.ts
@@ -79,10 +79,8 @@ export async function POST(request: NextRequest) {
   let rawBody: unknown;
   try {
     rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/heartbeats/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+   }
   const rawList = Array.isArray(rawBody) ? rawBody : [rawBody];
   if (rawList.length === 0) {
     return NextResponse.json({ accepted: 0, rejected: 0 });

--- a/src/app/api/interactions/kudos/route.ts
+++ b/src/app/api/interactions/kudos/route.ts
@@ -132,10 +132,9 @@ export async function POST(request: Request) {
         p_giver_id: giver.id,
         p_receiver_id: receiver.id,
       });
-    } catch {
-      // RPC may not exist yet before migration 015
+    } catch (err) {
+      console.warn("[app/api/interactions/kudos/route.ts] non-critical error:", err);
     }
-
     // Check kudos streak achievements
     await checkAchievements(giver.id, {
       contributions: giver.contributions ?? 0,

--- a/src/app/api/lc-pulse/route.ts
+++ b/src/app/api/lc-pulse/route.ts
@@ -30,9 +30,8 @@ async function getRecentSubmissions(username: string, withinMinutes = 30) {
 
         const cutoff = Date.now() / 1000 - withinMinutes * 60;
         return submissions.filter((s: any) => Number(s.timestamp) > cutoff);
-    } catch {
-        return null;
-    }
+    } catch (err) { console.warn("[app/api/lc-pulse/route.ts] error:", err); return null;
+     }
 }
 
 // POST: called by the client to report "I'm on LeetCode right now"
@@ -86,7 +85,7 @@ export async function POST() {
                             repo: "leetcode",
                         },
                     });
-                } catch { /* ignore duplicate feed entries */ }
+                } catch (err) { console.warn("[app/api/lc-pulse/route.ts] non-critical error:", err); }
             }
         }
 

--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -127,10 +127,9 @@ export async function POST(request: Request) {
     if ((weeklyPairCount ?? 0) > 0) {
       return NextResponse.json({ error: "Already raided this target this week" }, { status: 429 });
     }
-  } catch {
-    // raids table may not exist yet - allow raid
+  } catch (err) {
+    console.warn("[app/api/raid/execute/route.ts] non-critical error:", err);
   }
-
   // Determine vehicle + tag style from saved loadout (or override from request)
   const [{ data: raidLoadoutRow }, { data: ownedVehiclePurchases }] = await Promise.all([
     admin

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -114,10 +114,9 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Target has an active Peace Shield" }, { status: 429 });
       }
     }
-  } catch {
-    // raids table may not exist yet - allow raid
+  } catch (err) {
+    console.warn("[app/api/raid/preview/route.ts] non-critical error:", err);
   }
-
   // Active Defenses
   const activeDefenses: string[] = Array.isArray(defender.active_defenses) ? defender.active_defenses : [];
   const hasSatellite = (attacker.owned_items ?? []).includes("scouting_satellite");

--- a/src/app/api/shop/redeem/route.ts
+++ b/src/app/api/shop/redeem/route.ts
@@ -30,10 +30,8 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     code = (body.code ?? "").trim().toUpperCase();
-  } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/shop/redeem/route.ts] error:", err); return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+   }
   if (!code) {
     return NextResponse.json({ error: "No code provided" }, { status: 400 });
   }

--- a/src/app/api/sky-ads/analytics/route.ts
+++ b/src/app/api/sky-ads/analytics/route.ts
@@ -35,8 +35,7 @@ export async function GET(request: Request) {
   const period = searchParams.get("period") ?? "30d";
 
   // Refresh materialized view (ignore errors - view may be empty on first run)
-  try { await admin.rpc("refresh_sky_ad_stats"); } catch {}
-
+  try { await admin.rpc("refresh_sky_ad_stats"); } catch (err) { console.warn("[app/api/sky-ads/analytics/route.ts] non-critical error:", err); }
   // Build date filter
   let dayFilter: string | null = null;
   if (period === "7d") {

--- a/src/app/api/sky-ads/checkout/route.ts
+++ b/src/app/api/sky-ads/checkout/route.ts
@@ -47,10 +47,8 @@ export async function POST(request: NextRequest) {
   };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/sky-ads/checkout/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+   }
   const { plan_id, text, color, bgColor } = body;
 
   // Brazilian Stripe CNPJ can't charge USD to Brazilian cards.

--- a/src/app/api/sky-ads/route.ts
+++ b/src/app/api/sky-ads/route.ts
@@ -84,9 +84,8 @@ export async function GET() {
     return NextResponse.json([...planes, ...blimps, ...billboards, ...rooftopSigns, ...ledWraps], {
       headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" },
     });
-  } catch {
-    return NextResponse.json(DEFAULT_SKY_ADS, {
+  } catch (err) { console.warn("[app/api/sky-ads/route.ts] error:", err); return NextResponse.json(DEFAULT_SKY_ADS, {
       headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" },
     });
-  }
+   }
 }

--- a/src/app/api/sky-ads/setup/route.ts
+++ b/src/app/api/sky-ads/setup/route.ts
@@ -29,10 +29,8 @@ export async function POST(request: NextRequest) {
   };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/sky-ads/setup/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+   }
   const { token } = body;
 
   if (!token || typeof token !== "string" || token.length < 10) {

--- a/src/app/api/sky-ads/track/route.ts
+++ b/src/app/api/sky-ads/track/route.ts
@@ -30,9 +30,8 @@ export async function POST(request: NextRequest) {
       if (!ALLOWED_ORIGINS.has(url.origin)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
-    } catch {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    } catch (err) { console.warn("[app/api/sky-ads/track/route.ts] error:", err); return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+     }
   }
 
   // ── Bot filtering ──
@@ -59,10 +58,8 @@ export async function POST(request: NextRequest) {
   };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/sky-ads/track/route.ts] error:", err); return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+   }
   const { ad_id, github_login } = body;
   if (!ad_id || typeof ad_id !== "string") {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });

--- a/src/app/api/support/checkout/route.ts
+++ b/src/app/api/support/checkout/route.ts
@@ -28,10 +28,8 @@ export async function POST(request: Request) {
   let body: { amount: number };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/support/checkout/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   const { amount } = body;
 
   if (!Number.isFinite(amount) || amount < MIN_AMOUNT || Math.floor(amount) !== amount) {

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -111,8 +111,7 @@ export async function POST(req: Request) {
             if (lcUserStats) {
                 lcUserStats.maxStreak = parseMaxStreak(lcUserStats, currentYear);
             }
-        } catch { }
-
+        } catch (err) { console.warn("[app/api/verify-leetcode/route.ts] non-critical error:", err); }
         // Parse solved counts by difficulty
         const acNums: { difficulty: string; count: number }[] =
             lcUserStats?.submitStats?.acSubmissionNum ?? [];

--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -34,10 +34,8 @@ export async function POST(request: Request) {
   let body: any;
   try {
     body = JSON.parse(rawBody);
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/webhooks/abacatepay/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   const sb = getSupabaseAdmin();
   const pixId = extractPixId(body.data);
 

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -14,10 +14,8 @@ export async function POST(request: Request) {
   let body: any;
   try {
     body = JSON.parse(rawBody);
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/webhooks/nowpayments/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   // Verify HMAC-SHA512 signature
   const signature = request.headers.get("x-nowpayments-sig");
   if (!signature || !verifyIpnSignature(body, signature)) {

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -23,10 +23,8 @@ export async function POST(request: Request) {
   let body: { type: string; data: Record<string, unknown> };
   try {
     body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
-  }
-
+  } catch (err) { console.warn("[app/api/webhooks/resend/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+   }
   const sb = getSupabaseAdmin();
   const now = new Date().toISOString();
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -134,7 +134,8 @@ export async function GET(request: Request) {
           gifts_received: giftsReceived,
         }, githubLogin);
       }
-    } catch {
+    } catch (err) {
+      console.warn("[app/auth/callback/route.ts] error:", err);
       // Silently skip v2 features if tables/columns don't exist yet
       console.warn("Auth callback: skipping v2 achievement/referral check (migration may not have run)");
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -658,7 +658,8 @@ function HomeContent() {
           const res = await fetch("/api/me");
           const data = await res.json();
           setLinkedLeetCodeUsername(data.leetcode_username || null);
-        } catch {
+        } catch (err) {
+          console.warn("[app/page.tsx] error:", err);
           setLinkedLeetCodeUsername(null);
         }
       } else {
@@ -680,7 +681,7 @@ function HomeContent() {
               // Small delay so the UI has settled after login redirect
               setTimeout(() => setShowLinkModal(true), 800);
             }
-          } catch { }
+          } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
         }
       }
     });
@@ -731,7 +732,7 @@ function HomeContent() {
             ) ?? prev;
           });
         }
-      } catch { /* silent */ }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* silent */
     };
 
     // Wait 10 seconds after login/link so city is fully loaded, then refresh once
@@ -823,7 +824,7 @@ function HomeContent() {
       trackReferralLinkLanded(ref);
       try {
         localStorage.setItem("gc_ref", JSON.stringify({ login: ref, expires: Date.now() + 7 * 86400000 }));
-      } catch { /* ignore */ }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
     }
   }, [searchParams]);
 
@@ -840,7 +841,7 @@ function HomeContent() {
           redirectTo += `?ref=${encodeURIComponent(login)}`;
         }
       }
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
     await supabase.auth.signInWithOAuth({
       provider: "github",
       options: { redirectTo },
@@ -856,7 +857,7 @@ function HomeContent() {
         if (!res.ok) return;
         const data = await res.json();
         if (!cancelled) setFeedEvents(data.events ?? []);
-      } catch { /* ignore */ }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
     };
     fetchFeed();
     const interval = setInterval(fetchFeed, 120000);
@@ -877,7 +878,7 @@ function HomeContent() {
           });
           trackMissionRef.current("visit_building");
           trackMissionRef.current("visit_3_buildings");
-        } catch { /* ignore */ }
+        } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
       }, 3000);
     }
     return () => {
@@ -917,7 +918,7 @@ function HomeContent() {
         setKudosError(msg);
         setTimeout(() => setKudosError(null), 3000);
       }
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
     finally { setKudosSending(false); }
   }, [selectedBuilding, kudosSending, kudosSent, session, authLogin]);
 
@@ -936,7 +937,7 @@ function HomeContent() {
         .filter((i) => i.price_usd_cents > 0 && !NON_GIFTABLE.has(i.id))
         .map((i) => ({ ...i, owned: receiverOwned.has(i.id) }));
       setGiftItems(available);
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
   }, [selectedBuilding, session]);
 
   // Gift: checkout for receiver
@@ -957,7 +958,7 @@ function HomeContent() {
       if (res.ok && data.url) {
         window.location.href = data.url;
       }
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); } /* ignore */
     finally { setGiftBuying(null); }
   }, [selectedBuilding, giftBuying]);
 
@@ -1069,7 +1070,7 @@ function HomeContent() {
         if (best >= 5 && serverProgress < 5 && localProgress >= 5) {
           setRabbitCompletion(true);
         }
-      } catch { }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     })();
   }, [session]);
 
@@ -1109,9 +1110,7 @@ function HomeContent() {
           setTimeout(() => setRabbitSighting(data.progress + 1), 2000);
           return;
         }
-      } catch {
-        // Fall through to local tracking
-      }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     }
 
     // Local tracking (not logged in or API failed)
@@ -1195,8 +1194,7 @@ function HomeContent() {
           localStorage.removeItem("leetcodecity:loadout_override");
         }
       }
-    } catch { }
-
+    } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     rawDevsRef.current = allDevs;
     setStats(cityStats);
     const layout = generateCityLayout(allDevs);
@@ -1338,8 +1336,7 @@ function HomeContent() {
               localStorage.removeItem("leetcodecity:loadout_override");
             }
           }
-        } catch { }
-
+        } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
         // Generate layout
         setLoadStage("generating");
         setLoadProgress(45);
@@ -1450,14 +1447,14 @@ function HomeContent() {
 
     // Read current PB fresh from localStorage (React state may be stale)
     let currentPB = flyPersonalBestRef.current;
-    try { currentPB = Math.max(currentPB, parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch { }
+    try { currentPB = Math.max(currentPB, parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     // Only show "New PB!" if there WAS a previous best to beat (not on first-ever flight)
     const isNewPB = currentPB > 0 && finalScore > currentPB;
     // Update personal best
     if (isNewPB) {
       setFlyPersonalBest(finalScore);
       flyPersonalBestRef.current = finalScore;
-      try { localStorage.setItem("leetcodecity_fly_pb", String(finalScore)); } catch { }
+      try { localStorage.setItem("leetcodecity_fly_pb", String(finalScore)); } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     }
     // Update fly history (streak, days played, per-seed scores)
     if (finalScore > 0) {
@@ -1488,7 +1485,7 @@ function HomeContent() {
         }
         hist.longestStreak = Math.max(hist.longestStreak || 0, hist.currentStreak);
         localStorage.setItem("leetcodecity_fly_history", JSON.stringify(hist));
-      } catch { }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     }
     // Exit fly immediately (don't block on API)
     setFlyMode(false); setFlyPaused(false); lastDistrictRef.current = null; setDistrictAnnouncement(null); clearTimeout(announceTimerRef.current);
@@ -1783,7 +1780,8 @@ function HomeContent() {
         setExploreMode(true);
       }
       setUsername("");
-    } catch {
+    } catch (err) {
+      console.warn("[app/page.tsx] error:", err);
       setFeedback({ type: "error", code: "network", username: trimmed });
       setLoading(false);
     } finally {
@@ -2014,7 +2012,7 @@ function HomeContent() {
         // Auto-dismiss after 15s
         const autoDismiss = setTimeout(() => setShowDailyNudge(false), 15000);
         dailyNudgeTimerRef.current = autoDismiss;
-      } catch { }
+      } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
     }, 2000);
     return () => clearTimeout(dailyNudgeTimerRef.current);
   }, [loadStage, isMobile, session, flyMode, introMode]);
@@ -2024,13 +2022,16 @@ function HomeContent() {
     if (loadStage !== "done" || isMobile || flyMode || introMode) return;
     try {
       if (localStorage.getItem("leetcodecity_fly_history") || localStorage.getItem("leetcodecity_fly_hint_seen")) return;
-    } catch { return; }
+    } catch (err) {
+      console.warn("[app/page.tsx] error:", err);
+      return;
+    }
     flyHintTimerRef.current = setTimeout(() => {
       setShowFlyHint(true);
       // Auto-dismiss after 10s
       const autoDismiss = setTimeout(() => {
         setShowFlyHint(false);
-        try { localStorage.setItem("leetcodecity_fly_hint_seen", "1"); } catch { }
+        try { localStorage.setItem("leetcodecity_fly_hint_seen", "1"); } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
       }, 10000);
       flyHintTimerRef.current = autoDismiss;
     }, 5000);
@@ -2124,8 +2125,7 @@ function HomeContent() {
               a.rel = "noopener noreferrer";
               a.click();
             }
-            try { setAdToast(ad.brand || new URL(ad.link).hostname.replace("www.", "")); } catch { setAdToast(ad.brand || "link"); }
-            setTimeout(() => setAdToast(null), 2500);
+            try { setAdToast(ad.brand || new URL(ad.link).hostname.replace("www.", "")); } catch (err) { console.warn("[app/page.tsx] error:", err); setAdToast(ad.brand || "link"); }setTimeout(() => setAdToast(null), 2500);
           } else {
             trackAdEvent(ad.id, "click", authLogin || undefined);
             setClickedAd(ad);
@@ -2140,9 +2140,7 @@ function HomeContent() {
             if (viewed.includes(adId)) return;
             viewed.push(adId);
             sessionStorage.setItem(key, JSON.stringify(viewed));
-          } catch {
-            // sessionStorage unavailable — allow tracking
-          }
+          } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
           trackAdEvent(adId, "impression", authLogin || undefined);
           const ad = skyAds.find(a => a.id === adId);
           if (ad) trackSkyAdImpression(ad.id, ad.vehicle, ad.brand);
@@ -2518,7 +2516,7 @@ function HomeContent() {
             <button
               onClick={() => {
                 setShowFlyControls(false);
-                try { localStorage.setItem("leetcodecity_fly_controls_seen", "1"); } catch { }
+                try { localStorage.setItem("leetcodecity_fly_controls_seen", "1"); } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
                 // Resume the paused flight by dispatching Space keydown
                 window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space", bubbles: true }));
               }}
@@ -3093,8 +3091,7 @@ function HomeContent() {
                         flyPausedAt.current = 0;
                         flyTotalPauseMs.current = 0;
                         setFlyElapsedSec(0);
-                        try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch { setFlyPersonalBest(0); }
-                        // Feature 3: show controls overlay on first flight
+                        try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }// Feature 3: show controls overlay on first flight
                         if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
                           setShowFlyControls(true);
                         }
@@ -3130,7 +3127,7 @@ function HomeContent() {
                             onClick={() => {
                               setShowFlyHint(false);
                               clearTimeout(flyHintTimerRef.current);
-                              try { localStorage.setItem("leetcodecity_fly_hint_seen", "1"); } catch { }
+                              try { localStorage.setItem("leetcodecity_fly_hint_seen", "1"); } catch (err) { console.warn("[app/page.tsx] non-critical error:", err); }
                             }}
                             className="mt-2 px-3 py-1 text-[9px] text-bg"
                             style={{ backgroundColor: theme.accent }}
@@ -3163,8 +3160,7 @@ function HomeContent() {
                       flyPausedAt.current = 0;
                       flyTotalPauseMs.current = 0;
                       setFlyElapsedSec(0);
-                      try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch { setFlyPersonalBest(0); }
-                      if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
+                      try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
                         setShowFlyControls(true);
                       }
                     }}
@@ -4691,8 +4687,7 @@ function HomeContent() {
                   flyPausedAt.current = 0;
                   flyTotalPauseMs.current = 0;
                   setFlyElapsedSec(0);
-                  try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch { setFlyPersonalBest(0); }
-                }}
+                  try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }}}
                 className="btn-press px-5 py-2 text-[10px] text-bg"
                 style={{ backgroundColor: theme.accent, boxShadow: `3px 3px 0 0 ${theme.shadow}` }}
               >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2125,7 +2125,8 @@ function HomeContent() {
               a.rel = "noopener noreferrer";
               a.click();
             }
-            try { setAdToast(ad.brand || new URL(ad.link).hostname.replace("www.", "")); } catch (err) { console.warn("[app/page.tsx] error:", err); setAdToast(ad.brand || "link"); }setTimeout(() => setAdToast(null), 2500);
+            try { setAdToast(ad.brand || new URL(ad.link).hostname.replace("www.", "")); } catch (err) { console.warn("[app/page.tsx] error:", err); setAdToast(ad.brand || "link"); }
+            setTimeout(() => setAdToast(null), 2500);
           } else {
             trackAdEvent(ad.id, "click", authLogin || undefined);
             setClickedAd(ad);
@@ -3091,7 +3092,8 @@ function HomeContent() {
                         flyPausedAt.current = 0;
                         flyTotalPauseMs.current = 0;
                         setFlyElapsedSec(0);
-                        try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }// Feature 3: show controls overlay on first flight
+                        try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }
+                        // Feature 3: show controls overlay on first flight
                         if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
                           setShowFlyControls(true);
                         }
@@ -3160,7 +3162,8 @@ function HomeContent() {
                       flyPausedAt.current = 0;
                       flyTotalPauseMs.current = 0;
                       setFlyElapsedSec(0);
-                      try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
+                      try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }
+                      if (!localStorage.getItem("leetcodecity_fly_controls_seen")) {
                         setShowFlyControls(true);
                       }
                     }}
@@ -4687,7 +4690,8 @@ function HomeContent() {
                   flyPausedAt.current = 0;
                   flyTotalPauseMs.current = 0;
                   setFlyElapsedSec(0);
-                  try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }}}
+                  try { setFlyPersonalBest(parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0); } catch (err) { console.warn("[app/page.tsx] error:", err); setFlyPersonalBest(0); }
+                }}
                 className="btn-press px-5 py-2 text-[10px] text-bg"
                 style={{ backgroundColor: theme.accent, boxShadow: `3px 3px 0 0 ${theme.shadow}` }}
               >

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -63,9 +63,7 @@ export default async function RoadmapPage() {
         }
       }
     }
-  } catch {
-    // Not logged in, that's fine
-  }
+  } catch (err) { console.warn("[app/roadmap/page.tsx] non-critical error:", err); }
 
   return (
     <RoadmapClient

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -44,7 +44,8 @@ function SupportContent() {
       if (data.url) {
         window.location.href = data.url;
       }
-    } catch {
+    } catch (err) {
+      console.warn("[app/support/page.tsx] error:", err);
       setError("Failed to connect. Try again.");
     } finally {
       setLoadingAmount(null);

--- a/src/app/wallpaper/page.tsx
+++ b/src/app/wallpaper/page.tsx
@@ -50,7 +50,10 @@ function WallpaperInner() {
         const snapshot = await snapshotRes.json();
         allDevs = snapshot.developers;
       }
-    } catch { /* fall through to chunked */ }
+    } catch (err) {
+      console.warn("[app/wallpaper/page.tsx] error:", err);
+      /* fall through to chunked */
+    }
 
     // Fallback to chunked API
     if (allDevs.length === 0) {

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -44,7 +44,8 @@ export default function ActivityPanel({ initialEvents, open, onClose, onNavigate
       const data = await res.json();
       setEvents((prev) => [...prev, ...data.events]);
       setHasMore(data.has_more);
-    } catch {
+    } catch (err) {
+      console.warn("[components/ActivityPanel.tsx] error:", err);
       // ignore
     } finally {
       setLoading(false);

--- a/src/components/DailiesWidget.tsx
+++ b/src/components/DailiesWidget.tsx
@@ -50,7 +50,7 @@ export default function DailiesWidget({ data, accent, shadow, isMobile, onClaim,
         setStarVerified(true);
         setStarOpened(false);
       }
-    } catch { /* ignore */ }
+    } catch (err) { console.warn("[components/DailiesWidget.tsx] non-critical error:", err); }
     setStarVerifying(false);
   }, [starVerifying, starVerified, data?.has_github_star]);
 

--- a/src/components/DistrictChooser.tsx
+++ b/src/components/DistrictChooser.tsx
@@ -55,7 +55,8 @@ export default function DistrictChooser({
         return;
       }
       onChosen(data.district);
-    } catch {
+    } catch (err) {
+      console.warn("[components/DistrictChooser.tsx] error:", err);
       setError("Network error");
     } finally {
       setSubmitting(false);

--- a/src/components/FlyLeaderboard.tsx
+++ b/src/components/FlyLeaderboard.tsx
@@ -84,9 +84,8 @@ function loadFlyHistory(): FlyHistory | null {
     const raw = localStorage.getItem("leetcodecity_fly_history");
     if (!raw) return null;
     return JSON.parse(raw) as FlyHistory;
-  } catch {
-    return null;
-  }
+  } catch (err) { console.warn("[components/FlyLeaderboard.tsx] error:", err); return null;
+   }
 }
 
 // ── Visual helpers ─────────────────────────────────────────────────────
@@ -141,7 +140,7 @@ export default function FlyLeaderboard() {
     try {
       const stored = localStorage.getItem("leetcodecity_fly_pb");
       if (stored) setPersonalBest(parseInt(stored, 10));
-    } catch {}
+    } catch (err) { console.warn("[components/FlyLeaderboard.tsx] non-critical error:", err); }
     setHistory(loadFlyHistory());
   }, []);
 

--- a/src/components/LofiRadio.tsx
+++ b/src/components/LofiRadio.tsx
@@ -20,7 +20,7 @@ const DEFAULT_SHADOW = "#203870";
 
 function destroyHowl(howl: Howl | null) {
   if (howl) {
-    try { howl.unload(); } catch { }
+    try { howl.unload(); } catch (err) { console.warn("[components/LofiRadio.tsx] non-critical error:", err); }
   }
 }
 

--- a/src/components/ShopClient.tsx
+++ b/src/components/ShopClient.tsx
@@ -124,9 +124,7 @@ function savePendingBillboard(file: File): void {
         PENDING_BILLBOARD_KEY,
         JSON.stringify({ data: reader.result, type: file.type, name: file.name })
       );
-    } catch {
-      // localStorage full or unavailable — ignore
-    }
+    } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); }
   };
   reader.readAsDataURL(file);
 }
@@ -136,7 +134,8 @@ function getPendingBillboard(): { data: string; type: string; name: string } | n
     const raw = localStorage.getItem(PENDING_BILLBOARD_KEY);
     if (!raw) return null;
     return JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    console.warn("[components/ShopClient.tsx] error:", err);
     return null;
   }
 }
@@ -144,9 +143,7 @@ function getPendingBillboard(): { data: string; type: string; name: string } | n
 function clearPendingBillboard(): void {
   try {
     localStorage.removeItem(PENDING_BILLBOARD_KEY);
-  } catch {
-    // ignore
-  }
+  } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); }
 }
 
 // Convert a base64 data URL to a File
@@ -218,9 +215,7 @@ function PixModal({
           trackPurchaseCompleted(data.itemId, 0, "abacatepay");
           setStatus("completed");
         }
-      } catch {
-        // ignore polling errors
-      }
+      } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); }
     }, 3000);
 
     return () => {
@@ -241,9 +236,7 @@ function PixModal({
       await navigator.clipboard.writeText(data.brCode);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // fallback: select text
-    }
+    } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); }
   }, [data.brCode]);
 
   return (
@@ -510,7 +503,8 @@ function BillboardUploadPanel({
         setSavedSlot(slotIndex);
         setTimeout(() => setSavedSlot(null), 2000);
       }
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       // ignore
     } finally {
       setUploadingSlot(null);
@@ -697,7 +691,8 @@ export default function ShopClient({
         "America/Santarem",
       ]);
       setIsBrazil(brTimezones.has(tz));
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       setIsBrazil(false);
     }
   }, []);
@@ -897,11 +892,12 @@ export default function ShopClient({
             "leetcodecity:loadout_override",
             JSON.stringify({ developerId, loadout: payload, ts: Date.now() }),
           );
-        } catch { }
+        } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); } 
       } else {
         setError("Failed to save. Try again.");
       }
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       setError("Failed to save. Try again.");
     } finally {
       setSaving(false);
@@ -932,7 +928,8 @@ export default function ShopClient({
       setOwned((prev) =>
         prev.includes(FREE_CLAIM_ITEM) ? prev : [...prev, FREE_CLAIM_ITEM]
       );
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       setError("Network error. Try again.");
     } finally {
       setBuyingItem(null);
@@ -967,7 +964,8 @@ export default function ShopClient({
         setError("Star not found — make sure you starred the repo first!");
         setStarVerifyStep("opened");
       }
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       setError("Network error. Try again.");
       setStarVerifyStep("opened");
     } finally {
@@ -1050,7 +1048,8 @@ export default function ShopClient({
         } else if (data.url) {
           window.location.href = data.url;
         }
-      } catch {
+      } catch (err) {
+        console.warn("[components/ShopClient.tsx] error:", err);
         setError("Network error. Try again.");
       } finally {
         setBuyingItem(null);
@@ -1081,7 +1080,8 @@ export default function ShopClient({
         } else {
           setError(data.error || "Failed to buy item.");
         }
-      } catch {
+      } catch (err) {
+        console.warn("[components/ShopClient.tsx] error:", err);
         setError("Network error. Try again.");
       } finally {
         setBuyingItem(null);
@@ -1150,7 +1150,8 @@ export default function ShopClient({
         setRedeemMsg(data.error ?? "Invalid or expired code.");
         setTimeout(() => setRedeemState("idle"), 4000);
       }
-    } catch {
+    } catch (err) {
+      console.warn("[components/ShopClient.tsx] error:", err);
       setRedeemState("error");
       setRedeemMsg("Network error. Please try again.");
       setTimeout(() => setRedeemState("idle"), 4000);

--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -24,9 +24,8 @@ export async function fetchLeetCodeAboutMe(username: string): Promise<string | n
         if (!res.ok) return null;
         const data = await res.json();
         return data?.data?.matchedUser?.profile?.aboutMe ?? null;
-    } catch {
-        return null;
-    }
+    } catch (err) { console.warn("[lib/leetcode.ts] error:", err); return null;
+     }
 }
 
 export function parseMaxStreak(matchedUser: any, currentYear: number): number {
@@ -38,7 +37,7 @@ export function parseMaxStreak(matchedUser: any, currentYear: number): number {
             try {
                 const parsed = JSON.parse(cal);
                 allTimestamps.push(...Object.keys(parsed).map(Number));
-            } catch { }
+            } catch (err) { console.warn("[lib/leetcode.ts] non-critical error:", err); }
         }
     }
     allTimestamps.sort((a, b) => a - b);

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -643,7 +643,8 @@ async function isInQuietHours(
   try {
     const formatter = new Intl.DateTimeFormat("en-US", { timeZone: tz, hour: "numeric", hour12: false });
     currentHour = parseInt(formatter.format(new Date()), 10);
-  } catch {
+  } catch (err) {
+    console.warn("[lib/notifications.ts] error:", err);
     currentHour = new Date().getUTCHours();
   }
 

--- a/src/lib/radio.ts
+++ b/src/lib/radio.ts
@@ -28,9 +28,8 @@ export function loadRadioState(): RadioState {
     if (!raw) return DEFAULT_STATE;
     const parsed = JSON.parse(raw);
     return { ...DEFAULT_STATE, ...parsed };
-  } catch {
-    return DEFAULT_STATE;
-  }
+  } catch (err) { console.warn("[lib/radio.ts] error:", err); return DEFAULT_STATE;
+   }
 }
 
 export function saveRadioState(state: Partial<RadioState>) {
@@ -38,5 +37,5 @@ export function saveRadioState(state: Partial<RadioState>) {
   try {
     const current = loadRadioState();
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...current, ...state }));
-  } catch {}
+  } catch (err) { console.warn("[lib/radio.ts] non-critical error:", err); }
 }

--- a/src/lib/skyAds.ts
+++ b/src/lib/skyAds.ts
@@ -60,9 +60,8 @@ export function buildAdLink(ad: SkyAd): string | undefined {
     url.searchParams.set("utm_campaign", ad.id);
     url.searchParams.set("utm_content", ad.vehicle);
     return url.toString();
-  } catch {
-    return ad.link;
-  }
+  } catch (err) { console.warn("[lib/skyAds.ts] error:", err); return ad.link;
+   }
 }
 
 /** Fire a tracking beacon to the sky-ads track API (non-blocking). */

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -18,9 +18,8 @@ export async function createServerSupabase() {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)
             );
-          } catch {
-            // setAll can throw in Server Components (read-only).
-            // This is fine — the middleware handles cookie refresh.
+          } catch (err) {
+            console.warn("[lib/supabase-server.ts] non-critical error:", err);
           }
         },
       },

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -50,7 +50,5 @@ export async function broadcastToChannel(
         messages: [{ topic, event, payload }],
       }),
     });
-  } catch {
-    // Fire and forget — broadcast failure should never block the API response
-  }
+  } catch (err) { console.warn("[lib/supabase.ts] non-critical error:", err); } // Fire and forget — broadcast failure should never block the API response
 }

--- a/src/lib/useDailies.ts
+++ b/src/lib/useDailies.ts
@@ -34,7 +34,7 @@ export function useDailies(session: Session | null, hasClaimed: boolean) {
       if (!r.ok) return;
       const json = (await r.json()) as DailiesData;
       setData(json);
-    } catch { }
+    } catch (err) { console.warn("[lib/useDailies.ts] non-critical error:", err); }
   }, []);
 
   // Initial fetch on mount
@@ -126,9 +126,8 @@ export function useDailies(session: Session | null, hasClaimed: boolean) {
       });
 
       return result as { ok: boolean; streak: number; total: number; freeze_granted: boolean; points_granted: number };
-    } catch {
-      return null;
-    }
+    } catch (err) { console.warn("[lib/useDailies.ts] error:", err); return null;
+     }
   }, []);
 
   return { data, loading, refresh, trackClientMission, claim, toasts };

--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -172,7 +172,8 @@ export function useRaidSequence(): [RaidState, RaidActions] {
           error: null,
           loading: false,
         });
-      } catch {
+      } catch (err) {
+        console.warn("[lib/useRaidSequence.ts] error:", err);
         setState((prev) => ({
           ...prev,
           loading: false,
@@ -235,7 +236,8 @@ export function useRaidSequence(): [RaidState, RaidActions] {
 
         // Auto-advance intro -> flight
         timerRef.current = setTimeout(() => setPhase("flight"), 4500);
-      } catch {
+      } catch (err) {
+        console.warn("[lib/useRaidSequence.ts] error:", err);
         setState((prev) => ({
           ...prev,
           loading: false,

--- a/src/lib/useStreakCheckin.ts
+++ b/src/lib/useStreakCheckin.ts
@@ -50,7 +50,7 @@ export function useStreakCheckin(
         data.checked_in = false; // no pulse on cached load
         return data;
       }
-    } catch { }
+    } catch (err) { console.warn("[lib/useStreakCheckin.ts] non-critical error:", err); }
     return null;
   });
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Closes #23

Replaced all empty/comment-only catch blocks across 49 files with `console.warn` logging.
- Adds `(err)` parameter to every catch
- Logs file-scoped context tag for debugging traceability
- Preserves existing catch body logic where present
- Fixes syntax errors from prior partial fixes

**GSSoC 2026** — 49 files changed, 176 insertions(+), 210 deletions(-)