### PR TITLE
feat: make rate limiter configurable via environment variables (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Generate one at: https://github.com/settings/tokens
 GITHUB_TOKEN=
 
+# ── Rate Limiting & Cache ────────────────────────────────────
+# Max API requests per hour per IP (default: 15)
+RATE_LIMIT_PER_HOUR=15
+# Cache TTL in hours for developer profiles (default: 12)
+CACHE_TTL_HOURS=12
+
 # ── Optional Keys (only if working on these features) ───────
 # Stripe (payment features)
 STRIPE_SECRET_KEY=

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -21,7 +21,8 @@ async function isRateLimited(key: string): Promise<boolean> {
     .eq("ip_hash", ipHash)
     .gte("created_at", oneHourAgo);
 
-  return (count ?? 0) >= 15; // increased limit
+  const RATE_LIMIT = parseInt(process.env.RATE_LIMIT_PER_HOUR ?? "15");
+  return (count ?? 0) >= RATE_LIMIT;
 }
 
 async function recordRateLimitRequest(key: string): Promise<void> {
@@ -129,7 +130,8 @@ export async function GET(
 
   if (cached) {
     const age = Date.now() - new Date(cached.fetched_at).getTime();
-    if (!forceRefresh && age < 12 * 60 * 60 * 1000) { // 12h cache
+    const CACHE_TTL_MS = parseInt(process.env.CACHE_TTL_HOURS ?? "12") * 3600000;
+    if (!forceRefresh && age < CACHE_TTL_MS) { // 12h cache
       cachedRecord = cached;
     }
   }


### PR DESCRIPTION
﻿## Summary
Made the rate limiter configurable via environment variables instead of hardcoded values:
- `RATE_LIMIT_PER_HOUR` (default 15) replaces hardcoded `15` requests/hour
- `CACHE_TTL_HOURS` (default 12) replaces hardcoded `12` hour cache TTL

Updated `.env.example` to document the new variables.

Fixes #55
