### PR TITLE
fix: remove hardcoded username check in bungalow building style (#26)

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -519,7 +519,7 @@ export function generateCityLayout(devs: DeveloperRecord[]): {
         litPercentage = 0.2 + composite * 0.7;
 
         // BUNGALOW OVERRIDE
-        if (dev.github_login.toLowerCase() === "ishant_27" && dev.building_style === "bungalow") {
+        if (dev.building_style === "bungalow") {
           w = 80;
           d = 60;
           height = 25;


### PR DESCRIPTION
﻿## Summary
Removed the hardcoded `dev.github_login.toLowerCase() === "ishant_27"` check in `src/lib/github.ts:522` so the bungalow building style applies to any user with `building_style === "bungalow"` instead of only a specific user.

Fixes #26
