### PR TITLE
fix: clarify error message for missing GitHub username in claim API (#17)

### DIFF
--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -20,7 +20,7 @@ export async function POST() {
 
   if (!githubLogin) {
     return NextResponse.json(
-      { error: "No LeetCode username in profile" },
+      { error: "Could not determine your username from GitHub. Please try logging in again." },
       { status: 400 }
     );
   }


### PR DESCRIPTION
﻿## Summary
Changed misleading error message "No LeetCode username in profile" to "Could not determine your username from GitHub. Please try logging in again." since the variable being checked is the GitHub login from OAuth metadata, not a LeetCode username.

Fixes #17
