### PR TITLE
fix: remove duplicate takeoff audio trigger in raid sequence (#19)

### DIFF
--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -226,16 +226,10 @@ export function useRaidSequence(): [RaidState, RaidActions] {
             ...prev,
             raidData,
             loading: false,
-            phase: "intro",
           };
         });
 
-        // Start audio
-        preloadRaidAudio();
-        playRaidSound("takeoff");
-
-        // Auto-advance intro -> flight
-        timerRef.current = setTimeout(() => setPhase("flight"), 4500);
+        setPhase("intro");
       } catch (err) {
         console.warn("[lib/useRaidSequence.ts] error:", err);
         setState((prev) => ({


### PR DESCRIPTION
﻿## Summary
Removed duplicate `preloadRaidAudio()`, `playRaidSound("takeoff")`, and timer setup in `executeRaid` since `setPhase("intro")` already handles all of those. Changed `setState` to use `setPhase("intro")` instead.

Fixes #19
