### PR TITLE
fix: improve error message for unregistered users in raid preview (#74)

### DIFF
--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -156,7 +156,10 @@ export async function POST() {
 
   const githubLogin = dev?.github_login ?? "";
 
-  if (!dev || !dev.claimed) {
+  if (!dev) {
+    return NextResponse.json({ error: "Your LeetCode stats are still being synced. Please check back in a few minutes!" }, { status: 403 });
+  }
+  if (!dev.claimed) {
     return NextResponse.json({ error: "Must claim building first" }, { status: 403 });
   }
 

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -77,7 +77,10 @@ export async function POST(request: Request) {
     }
   }
 
-  if (!attacker || !attacker.claimed) {
+  if (!attacker) {
+    return NextResponse.json({ error: "Your LeetCode stats are still being synced. Please check back in a few minutes!" }, { status: 403 });
+  }
+  if (!attacker.claimed) {
     return NextResponse.json({ error: "Must claim building first" }, { status: 403 });
   }
 


### PR DESCRIPTION
﻿## Summary
Distinguishes between "building doesn't exist yet" (user's LeetCode stats haven't been synced) and "building not claimed", providing a clearer error message for new users.

Also fixed the same pattern in the check-in route for consistency.

Fixes #74
