### PR TITLE
fix: add periodic cleanup to checkout rate limiter to prevent memory leak (#76)

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -11,6 +11,13 @@ import { createCryptoInvoice } from "@/lib/nowpayments";
 // Note: in-memory – resets on deploy / cold-start.  Acceptable because
 // the middleware already provides the primary protection layer.
 const lastCheckout = new Map<string, number>();
+// Cleanup stale entries older than 10s, runs every 30s
+setInterval(() => {
+  const cutoff = Date.now() - 10000;
+  for (const [key, ts] of lastCheckout) {
+    if (ts < cutoff) lastCheckout.delete(key);
+  }
+}, 30000);
 
 export async function POST(request: Request) {
   // Auth required


### PR DESCRIPTION
﻿## Summary
Added a setInterval-based cleanup that removes entries older than 10 seconds from the Map every 30 seconds, preventing unbounded memory growth.

Fixes #76
