### PR TITLE
fix: limit LeetCode GraphQL calendar queries to current+previous year (#56)

### DIFF
--- a/src/app/api/cron/lc-refresh/route.ts
+++ b/src/app/api/cron/lc-refresh/route.ts
@@ -23,10 +23,10 @@ const LC_HEADERS = {
 };
 
 function calendarAliases(): string {
-  const year = new Date().getFullYear();
-  return Array.from({ length: year - 2014 }, (_, i) => 2015 + i)
-    .map((y) => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`)
-    .join("");
+  const currentYear = new Date().getFullYear();
+  const prevYear = currentYear - 1;
+  return `\n        y${currentYear}: userCalendar(year: ${currentYear}) { submissionCalendar }` +
+         `\n        y${prevYear}: userCalendar(year: ${prevYear}) { submissionCalendar }`;
 }
 
 async function fetchLCFullProfile(username: string): Promise<any> {

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -53,10 +53,9 @@ export async function POST(req: Request) {
         let lcStreakStats = null;
         try {
             const currentYear = new Date().getFullYear();
-            let aliases = "";
-            for (let y = 2015; y <= currentYear; y++) {
-                aliases += `\n                        y${y}: userCalendar(year: ${y}) { submissionCalendar }`;
-            }
+            const prevYear = currentYear - 1;
+            const aliases = `\n                        y${currentYear}: userCalendar(year: ${currentYear}) { submissionCalendar }` +
+                            `\n                        y${prevYear}: userCalendar(year: ${prevYear}) { submissionCalendar }`;
             const profileQuery = `
                 query getUserProfile($username: String!) {
                     matchedUser(username: $username) {


### PR DESCRIPTION
﻿## Summary
Changed the LeetCode GraphQL calendar query from fetching ALL years (2015-current) to only the current and previous year. This significantly reduces payload size and prevents LeetCode API rejections.

Also fixed the same pattern in `verify-leetcode/route.ts`.

Fixes #56
