### PR TITLE
⚡ perf: limit LeetCode calendar queries to recent years

### DIFF
--- a/scripts/lc-hourly-fetcher.ts
+++ b/scripts/lc-hourly-fetcher.ts
@@ -42,11 +42,9 @@ function sleep(ms: number) {
 
 function calendarAliases(): string {
     const currentYear = new Date().getFullYear();
-    const START_YEAR = currentYear - 2;
+    const prevYear = currentYear - 1;
 
-    return Array.from({ length: currentYear - START_YEAR + 1 },
-        (_, i) => START_YEAR + i
-    )
+    return [currentYear, prevYear]
         .map((y) => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`)
         .join("");
 }

--- a/scripts/lc-hourly-fetcher.ts
+++ b/scripts/lc-hourly-fetcher.ts
@@ -41,8 +41,12 @@ function sleep(ms: number) {
 }
 
 function calendarAliases(): string {
-    const year = new Date().getFullYear();
-    return Array.from({ length: year - 2014 }, (_, i) => 2015 + i)
+    const currentYear = new Date().getFullYear();
+    const START_YEAR = currentYear - 2;
+
+    return Array.from({ length: currentYear - START_YEAR + 1 },
+        (_, i) => START_YEAR + i
+    )
         .map((y) => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`)
         .join("");
 }

--- a/scripts/seed-lc-infinite.ts
+++ b/scripts/seed-lc-infinite.ts
@@ -69,6 +69,9 @@ async function fetchRankingPage(page: number): Promise<string[]> {
 
 // 2. Fetch rich user stats
 async function fetchLCUserStats(username: string) {
+    const currentYear = new Date().getFullYear();
+    const START_YEAR = currentYear - 2;
+    
     const query = `
     query($username: String!) {
       matchedUser(username: $username) {
@@ -79,7 +82,10 @@ async function fetchLCUserStats(username: string) {
           totalSubmissionNum { difficulty count }
         }
         userCalendar { streak totalActiveDays }${
-            Array.from({ length: new Date().getFullYear() - 2014 }, (_, i) => 2015 + i)
+            Array.from(
+                { length: currentYear - START_YEAR + 1 },
+                (_, i) => START_YEAR + i
+            )
                 .map(y => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`).join("")
         }
       }

--- a/scripts/seed-lc-infinite.ts
+++ b/scripts/seed-lc-infinite.ts
@@ -70,7 +70,7 @@ async function fetchRankingPage(page: number): Promise<string[]> {
 // 2. Fetch rich user stats
 async function fetchLCUserStats(username: string) {
     const currentYear = new Date().getFullYear();
-    const START_YEAR = currentYear - 2;
+    const prevYear = currentYear - 1;
     
     const query = `
     query($username: String!) {
@@ -82,10 +82,7 @@ async function fetchLCUserStats(username: string) {
           totalSubmissionNum { difficulty count }
         }
         userCalendar { streak totalActiveDays }${
-            Array.from(
-                { length: currentYear - START_YEAR + 1 },
-                (_, i) => START_YEAR + i
-            )
+            [currentYear, prevYear]
                 .map(y => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`).join("")
         }
       }

--- a/scripts/seed-lc.ts
+++ b/scripts/seed-lc.ts
@@ -68,7 +68,7 @@ async function sleep(ms: number) {
 
 async function fetchLCUser(username: string) {
     const currentYear = new Date().getFullYear();
-    const START_YEAR = currentYear - 2;
+    const prevYear = currentYear - 1;
 
     const query = `
     query($username: String!) {
@@ -80,10 +80,7 @@ async function fetchLCUser(username: string) {
           totalSubmissionNum { difficulty count }
         }
         userCalendar { streak totalActiveDays }${
-        Array.from(
-            { length: currentYear - START_YEAR + 1 },
-            (_, i) => START_YEAR + i
-        )
+        [currentYear, prevYear]
             .map(y => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`).join("")
     }
       }

--- a/scripts/seed-lc.ts
+++ b/scripts/seed-lc.ts
@@ -67,6 +67,9 @@ async function sleep(ms: number) {
 }
 
 async function fetchLCUser(username: string) {
+    const currentYear = new Date().getFullYear();
+    const START_YEAR = currentYear - 2;
+
     const query = `
     query($username: String!) {
       matchedUser(username: $username) {
@@ -77,7 +80,10 @@ async function fetchLCUser(username: string) {
           totalSubmissionNum { difficulty count }
         }
         userCalendar { streak totalActiveDays }${
-        Array.from({ length: new Date().getFullYear() - 2014 }, (_, i) => 2015 + i)
+        Array.from(
+            { length: currentYear - START_YEAR + 1 },
+            (_, i) => START_YEAR + i
+        )
             .map(y => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`).join("")
     }
       }


### PR DESCRIPTION
## Description

## Related issue
Fixes #56 

Optimized LeetCode calendar GraphQL query generation by limiting fetched calendar data to the most recent 3 years instead of querying all years since 2015.

## What does this PR do?

1. Updated calendar alias generation in:

  'scripts/[seed-lc.ts](http://seed-lc.ts/)'
  'scripts/[lc-hourly-fetcher.ts](http://lc-hourly-fetcher.ts/)'
  'scripts/[seed-lc-infinite.ts](http://seed-lc-infinite.ts/)'

2. Matched the existing API implementation used in src/app/api/dev/[username]/route.ts
3. Reduced unnecessary GraphQL payload size and request overhead
4. Kept implementation minimal and consistent with the existing optimized API approach

## Checklist

* Verified only the targeted calendar query logic was modified
* Ran 'npm run lint'