### PR TITLE
fix: enforce dynamic rendering and disable caching for presence API route

### DIFF
--- a/src/app/api/presence/route.ts
+++ b/src/app/api/presence/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   const sb = getSupabaseAdmin();
   const cutoff = new Date(Date.now() - 5 * 60_000).toISOString();
@@ -47,7 +49,7 @@ export async function GET() {
     { count: developers.length, developers },
     {
       headers: {
-        "Cache-Control": "s-maxage=10, stale-while-revalidate=20",
+        "Cache-Control": "no-store",
       },
     },
   );


### PR DESCRIPTION
## What does this PR do?

Fixes a stale presence bug caused by Next.js statically caching the `GET /api/presence` route at build time. Because the handler had no dynamic inputs (no `cookies()`, `headers()`, etc.), Next.js froze the `Date.now()` call used for the 5-minute heartbeat cutoff, meaning the response never reflected live session data after the initial build.

Two changes fix this:
- Added `export const dynamic = "force-dynamic"` to force per-request evaluation of the route.
- Replaced the `Cache-Control` header value `s-maxage=10, stale-while-revalidate=20` with `no-store` to prevent CDNs and browsers from serving stale presence data.

## Related issue

Fixes #104

## Screenshots

N/A no visual changes. Verified by signing in, triggering IDE heartbeats via VS Code, and confirming the website correctly reflects coding presence on page reload.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.