### PR TITLE
fix: use LeetCode API for weekly contributions in check-in route

### DIFF
--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -8,6 +8,7 @@ import { touchLastActive } from "@/lib/notification-helpers";
 import { sendStreakMilestoneNotification } from "@/lib/notification-senders/streak";
 import { sendStreakBrokenNotification } from "@/lib/notification-senders/streak-broken";
 import { trackDailyMission } from "@/lib/dailies";
+import { fetchLeetCodeWeeklySubmissions } from "@/lib/leetcode";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 // A12: Streak reward milestones — {milestone: days, pool: item_ids to pick from}
@@ -79,55 +80,8 @@ async function grantStreakReward(
 
 // Lightweight LeetCode fetch: only current week contributions
 async function fetchWeeklyContributions(login: string): Promise<number | null> {
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) return null;
-
-  try {
-    const res = await fetch("https://api.github.com/graphql", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: `query($login: String!) {
-          user(login: $login) {
-            contributionsCollection {
-              contributionCalendar {
-                weeks { contributionDays { contributionCount, date } }
-              }
-            }
-          }
-        }`,
-        variables: { login },
-      }),
-    });
-
-    if (!res.ok) return null;
-    const json = await res.json();
-    const weeks = json?.data?.user?.contributionsCollection?.contributionCalendar?.weeks;
-    if (!weeks) return null;
-
-    const now = new Date();
-    const isoWeekStart = new Date(now);
-    const dayOfWeek = now.getDay();
-    isoWeekStart.setDate(now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1));
-    isoWeekStart.setHours(0, 0, 0, 0);
-
-    let total = 0;
-    for (const week of weeks) {
-      for (const day of week.contributionDays ?? []) {
-        if (new Date(day.date) >= isoWeekStart) {
-          total += day.contributionCount;
-        }
-      }
-    }
-    return total;
-  } catch (err) {
-    console.warn("[app/api/checkin/route.ts] error:", err);
-    return null;
-  }
-}  
+  return fetchLeetCodeWeeklySubmissions(login);
+}
 
 export async function POST() {
   const supabase = await createServerSupabase();

--- a/src/app/api/cron/lc-refresh/route.ts
+++ b/src/app/api/cron/lc-refresh/route.ts
@@ -89,6 +89,39 @@ async function upsertFullProfile(
   const totalSolved = getAC("All");
   const totalSub = getTot("All");
   const activeDays = user.userCalendar?.totalActiveDays ?? 0;
+
+  // Calculate weekly contributions (last 7 days)
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const sevenDaysAgoDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgoYear = sevenDaysAgoDate.getFullYear();
+
+  const yearsToCheck = [currentYear];
+  if (sevenDaysAgoYear !== currentYear) {
+    yearsToCheck.push(sevenDaysAgoYear);
+  }
+
+  let weeklyContributions = 0;
+  now.setHours(0, 0, 0, 0);
+  const sevenDaysAgoTs = Math.floor(now.getTime() / 1000) - 7 * 24 * 60 * 60;
+
+  for (const year of yearsToCheck) {
+    const calendarStr = user[`y${year}`]?.submissionCalendar;
+    if (calendarStr) {
+      try {
+        const calendar = JSON.parse(calendarStr);
+        for (const [timestampStr, count] of Object.entries(calendar)) {
+          const timestamp = parseInt(timestampStr, 10);
+          if (timestamp >= sevenDaysAgoTs) {
+            weeklyContributions += count as number;
+          }
+        }
+      } catch (err) {
+        console.warn(`[lc-refresh] Error parsing calendar for year ${year}:`, err);
+      }
+    }
+  }
+
   const lcRank = user.profile?.ranking ?? 999999;
   const litPercentage = Math.min(0.92, Math.max(0.15, activeDays / 365));
   const realName = user.profile?.realName?.trim() || user.username;
@@ -117,6 +150,7 @@ async function upsertFullProfile(
       contributions_total: Math.round(litPercentage * 1000),
       total_stars: user.profile?.reputation ?? 0,
       public_repos: Math.max(0, 500000 - lcRank),
+      current_week_contributions: weeklyContributions,
       rank: lcRank,
       lc_global_rank: lcRank,
       fetched_at: new Date().toISOString(),

--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -64,3 +64,63 @@ export function parseMaxStreak(matchedUser: any, currentYear: number): number {
     if (currentStreak > maxStreak) maxStreak = currentStreak;
     return maxStreak;
 }
+
+export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<number | null> {
+    try {
+        const now = new Date();
+        const currentYear = now.getFullYear();
+        const sevenDaysAgoDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const sevenDaysAgoYear = sevenDaysAgoDate.getFullYear();
+
+        const yearsToFetch = [currentYear];
+        if (sevenDaysAgoYear !== currentYear) {
+            yearsToFetch.push(sevenDaysAgoYear);
+        }
+
+        let totalWeeklyCount = 0;
+
+        for (const year of yearsToFetch) {
+            const res = await fetch("https://leetcode.com/graphql", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "User-Agent": "Mozilla/5.0",
+                    "Referer": "https://leetcode.com/"
+                },
+                body: JSON.stringify({
+                    query: `
+              query getUserCalendar($username: String!, $year: Int) {
+                matchedUser(username: $username) {
+                  userCalendar(year: $year) {
+                    submissionCalendar
+                  }
+                }
+              }
+            `,
+                    variables: { username, year }
+                })
+            });
+
+            if (!res.ok) continue;
+            const data = await res.json();
+            const calendarStr = data?.data?.matchedUser?.userCalendar?.submissionCalendar;
+            if (!calendarStr) continue;
+
+            const calendar = JSON.parse(calendarStr);
+            now.setHours(0, 0, 0, 0);
+            const sevenDaysAgoTs = Math.floor(now.getTime() / 1000) - 7 * 24 * 60 * 60;
+
+            for (const [timestampStr, count] of Object.entries(calendar)) {
+                const timestamp = parseInt(timestampStr, 10);
+                if (timestamp >= sevenDaysAgoTs) {
+                    totalWeeklyCount += count as number;
+                }
+            }
+        }
+
+        return totalWeeklyCount;
+    } catch (err) {
+        console.error("[lib/leetcode.ts] error fetching weekly submissions:", err);
+        return 0;
+    }
+}


### PR DESCRIPTION
Closes #22
    
## What does this PR do?
    
This PR fixes the bug where the check-in route was incorrectly attempting to fetch weekly contribution data from GitHub using LeetCode usernames. Since LeetCode usernames are not valid GitHub logins, this resulting in silent failures and 0 scores for Battle/Raid features.
    
## Key changes:

- Created `fetchLeetCodeWeeklySubmissions` helper in `src/lib/leetcode.ts` to fetch a sliding 7-day of submissions from LeetCode GraphQL.
- Updated `src/app/api/checkin/route.ts` to use the new LeetCode helper.
- Updated `src/app/api/cron/lc-refresh/route.ts` to refresh weekly contributions hourly for all users.
- Implemented year-rollover logic to ensure accurate counts during the January transition.

## Related issue

Fixes #22

## Checklist

- [x] `npm run lint` passes (monitored existing issues, no new regressions)
- [x] Tested locally (verified with live LeetCode data via script)
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.