### PR TITLE
fix: persist building customizations through Edge cache window (#105)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,6 +82,8 @@ import {
   trackDisabledButtonClicked,
 } from "@/lib/himetrica";
 
+import { applyLocalStorageOverrides } from "@/lib/cityOverrides";
+
 const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
   ssr: false,
 });
@@ -1559,24 +1561,9 @@ function HomeContent() {
     }
 
     if (allDevs.length === 0) return null;
-
-    // Apply loadout override from localStorage (saved in shop, TTL 10 min)
-    try {
-      const raw = localStorage.getItem("leetcodecity:loadout_override");
-      if (raw) {
-        const { developerId, loadout, ts } = JSON.parse(raw);
-        if (Date.now() - ts < 10 * 60 * 1000) {
-          const idx = allDevs.findIndex(
-            (d: Record<string, unknown>) => d.id === developerId,
-          );
-          if (idx !== -1) {
-            allDevs[idx] = { ...allDevs[idx], loadout };
-          }
-        } else {
-          localStorage.removeItem("leetcodecity:loadout_override");
-        }
-      }
-    } catch {}
+ 
+    // Apply localStorage overrides (style, color, billboard, loadout) — TTL 20 min
+    applyLocalStorageOverrides(allDevs);
 
     rawDevsRef.current = allDevs;
     setStats(cityStats);
@@ -1712,23 +1699,8 @@ function HomeContent() {
           return;
         }
 
-        // Apply loadout override from localStorage (saved in shop, TTL 10 min)
-        try {
-          const raw = localStorage.getItem("leetcodecity:loadout_override");
-          if (raw) {
-            const { developerId, loadout, ts } = JSON.parse(raw);
-            if (Date.now() - ts < 10 * 60 * 1000) {
-              const idx = allDevs.findIndex(
-                (d: Record<string, unknown>) => d.id === developerId,
-              );
-              if (idx !== -1) {
-                allDevs[idx] = { ...allDevs[idx], loadout };
-              }
-            } else {
-              localStorage.removeItem("leetcodecity:loadout_override");
-            }
-          }
-        } catch {}
+        // Apply localStorage overrides (style, color, billboard, loadout) — TTL 20 min
+        applyLocalStorageOverrides(allDevs);
 
         // Generate layout
         setLoadStage("generating");
@@ -1787,7 +1759,7 @@ function HomeContent() {
     }
 
     loadCity();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // esliloadCitynt-disable-next-line react-hooks/exhaustive-deps
   }, [loadStage]);
 
   // City reload on tab return removed — navigating back from shop already

--- a/src/components/ShopClient.tsx
+++ b/src/components/ShopClient.tsx
@@ -853,6 +853,15 @@ export default function ShopClient({
         setBStyle(oldStyle); // Revert on failure
         const data = await res.json().catch(() => ({}));
         setError(`Failed to save style: ${data.error || res.statusText}`);
+      } else {
+        try {
+          localStorage.setItem(
+            "leetcodecity:style_override",
+            JSON.stringify({ developerId, value: newStyle, ts: Date.now() })
+          )
+        } catch (e) {
+            console.warn("[ShopClient] localStorage write failed:", e);
+        }
       }
     } catch (e: any) {
       setBStyle(oldStyle);
@@ -920,6 +929,23 @@ export default function ShopClient({
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         setError(`Failed to save ${itemId}: ${data.error || res.statusText}`);
+      } else {
+        try{
+          if (itemId === "custom_color" && payload.color) {
+            localStorage.setItem(
+              "leetcodecity:color_override",
+              JSON.stringify({ developerId, value: payload.color, ts: Date.now() })
+            );
+          }
+          if (itemId === "billboard" && payload.images) {
+            localStorage.setItem(
+              "leetcodecity:billboard_override",
+              JSON.stringify({ developerId, value: payload.images, ts: Date.now() })
+            )
+          }
+        } catch (err) {
+            console.warn("[ShopClient] localStorage write failed:", err);
+        }
       }
     } catch (err: any) {
       setError(`Network error: ${err.message}`);

--- a/src/lib/cityOverrides.ts
+++ b/src/lib/cityOverrides.ts
@@ -1,0 +1,53 @@
+const TTL = 20 * 60 * 1000; // 20 minutes, must outlast Edge cache (s-maxage=300 + SWR=600)
+
+export function applyLocalStorageOverrides(allDevs: any[]): void {
+  try {
+    const rawLoadout = localStorage.getItem("leetcodecity:loadout_override");
+    if (rawLoadout) {
+      const { developerId, loadout, ts } = JSON.parse(rawLoadout);
+      if (Date.now() - ts < TTL) {
+        const idx = allDevs.findIndex((d) => d.id === developerId);
+        if (idx !== -1) allDevs[idx] = { ...allDevs[idx], loadout };
+      } else {
+        localStorage.removeItem("leetcodecity:loadout_override");
+      }
+    }
+
+    const rawStyle = localStorage.getItem("leetcodecity:style_override");
+    if (rawStyle) {
+      const { developerId, value, ts } = JSON.parse(rawStyle);
+      if (Date.now() - ts < TTL) {
+        const idx = allDevs.findIndex((d) => d.id === developerId);
+        if (idx !== -1)
+          allDevs[idx] = { ...allDevs[idx], building_style: value };
+      } else {
+        localStorage.removeItem("leetcodecity:style_override");
+      }
+    }
+
+    const rawColor = localStorage.getItem("leetcodecity:color_override");
+    if (rawColor) {
+      const { developerId, value, ts } = JSON.parse(rawColor);
+      if (Date.now() - ts < TTL) {
+        const idx = allDevs.findIndex((d) => d.id === developerId);
+        if (idx !== -1) allDevs[idx] = { ...allDevs[idx], custom_color: value };
+      } else {
+        localStorage.removeItem("leetcodecity:color_override");
+      }
+    }
+
+    const rawBillboard = localStorage.getItem(
+      "leetcodecity:billboard_override",
+    );
+    if (rawBillboard) {
+      const { developerId, value, ts } = JSON.parse(rawBillboard);
+      if (Date.now() - ts < TTL) {
+        const idx = allDevs.findIndex((d) => d.id === developerId);
+        if (idx !== -1)
+          allDevs[idx] = { ...allDevs[idx], billboard_images: value };
+      } else {
+        localStorage.removeItem("leetcodecity:billboard_override");
+      }
+    }
+  } catch {}
+}


### PR DESCRIPTION
**PR Description:**

## What does this PR do?

Fixes a bug where building customizations (style, color, billboard images, loadout) would revert to their previous state on page reload, even after being saved successfully to the database.

The root cause was a two-part mismatch:

1. `/api/city` is Edge-cached with `s-maxage=300, stale-while-revalidate=600`, meaning stale data could be served for up to 15 minutes after a change.
2. The localStorage override mechanism either didn't exist for some customization types (`building_style`, `custom_color`, `billboard_images`), or had a TTL of only 10 minutes — shorter than the 15-minute Edge cache window — meaning overrides expired before the cache refreshed.

**Changes made:**

- **`ShopClient.tsx`:** Added localStorage writes in `handleToggleStyle`, `handleSaveCustomization` (for `custom_color` and `billboard`), and related handlers to persist `leetcodecity:style_override`, `leetcodecity:color_override`, and `leetcodecity:billboard_override` alongside the existing `loadout_override`.
- **`cityOverrides.ts`:** Increased the TTL constant from 10 minutes to 20 minutes (`20 * 60 * 1000`) so all overrides outlast the maximum Edge cache staleness window (`300 + 600 = 900s ≈ 15 min`).
- **`page.tsx`:** Updated `applyLocalStorageOverrides` calls in both city load paths (initial load and `reloadCity`) to apply the new override keys (`style_override`, `color_override`, `billboard_override`) to the dev array before layout generation.

## Related issue

Fixes #105

## Screenshots

N/A — no visual regression; the fix restores the *correct* visual state rather than changing it.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally (requires being logged in with a claimed building)
- [x] No secrets or `.env` values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.