### PR TITLE
fix(raid): avoid mutating weekly date calculation

### DIFF
--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -169,6 +169,7 @@ export async function POST(request: Request) {
     }
 
     // Check weekly cooldown
+    // Raid limits use UTC ISO weeks to stay aligned with persisted UTC timestamps.
     const isoWeekStart = getIsoWeekStart();
 
     const { count: weeklyPairCount } = await admin
@@ -238,11 +239,12 @@ export async function POST(request: Request) {
       .eq("developer_id", attacker.id)
       .eq("item_id", consumable_item_id)
       .single();
+    const resetWeekStr = consumable?.last_reset_week
+      ? getUtcDateString(consumable.last_reset_week)
+      : null;
       
     if (consumable && consumable.quantity > 0) {
       // Check weekly uses
-      const resetWeekStr = getUtcDateString(consumable.last_reset_week);
-      
       let currentUses = consumable.weekly_uses;
       if (currentWeekStr !== resetWeekStr) {
         currentUses = 0; // It's a new week
@@ -267,7 +269,7 @@ export async function POST(request: Request) {
         if (
           !consumable ||
           consumable.weekly_uses < 3 ||
-          getUtcDateString(consumable.last_reset_week) !== currentWeekStr
+          resetWeekStr !== currentWeekStr
         ) {
           attackerConsumableItemId = consumable_item_id;
         }

--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -17,6 +17,30 @@ import {
   XP_LOSE_DEFENDER,
 } from "@/lib/raid";
 import { ITEM_UNLOCK_LEVELS } from "@/lib/zones";
+import {
+  getIsoWeekStart,
+  getIsoWeekStartDateString,
+  getUtcDateString,
+} from "@/lib/week";
+
+type RaidDeveloper = {
+  id: number;
+  claimed: boolean;
+  github_login: string;
+  avatar_url?: string | null;
+  contributions?: number | null;
+  public_repos?: number | null;
+  total_stars?: number | null;
+  kudos_count?: number | null;
+  app_streak?: number | null;
+  raid_xp?: number | null;
+  xp_level?: number | null;
+  current_week_contributions?: number | null;
+  current_week_kudos_given?: number | null;
+  current_week_kudos_received?: number | null;
+  last_raided_at?: string | null;
+  active_defenses?: unknown;
+};
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -62,7 +86,7 @@ export async function POST(request: Request) {
 
   // Fetch attacker + defender in parallel
   const raidColumns = "id, claimed, github_login, avatar_url, contributions, public_repos, total_stars, kudos_count, app_streak, raid_xp, xp_level, current_week_contributions, current_week_kudos_given, current_week_kudos_received, last_raided_at, active_defenses";
-  let [attackerRes, defenderRes] = await Promise.all([
+  const [initialAttackerRes, defenderRes] = await Promise.all([
     admin
       .from("developers")
       .select(raidColumns)
@@ -76,11 +100,10 @@ export async function POST(request: Request) {
       .limit(1)
       .maybeSingle(),
   ]);
+  let attackerRes = initialAttackerRes;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let attacker = attackerRes.data as Record<string, any> | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const defender = defenderRes.data as Record<string, any> | null;
+  let attacker = attackerRes.data as RaidDeveloper | null;
+  const defender = defenderRes.data as RaidDeveloper | null;
 
   // Auto-claim logic if building exists but not claimed by user yet
   if (!attacker && githubLogin) {
@@ -108,7 +131,7 @@ export async function POST(request: Request) {
         .eq("claimed_by", user.id)
         .limit(1)
         .maybeSingle();
-      attacker = attackerRes.data as Record<string, any> | null;
+      attacker = attackerRes.data as RaidDeveloper | null;
     }
   }
 
@@ -146,11 +169,7 @@ export async function POST(request: Request) {
     }
 
     // Check weekly cooldown
-    const now = new Date();
-    const isoWeekStart = new Date(now);
-    const dayOfWeek = now.getDay();
-    isoWeekStart.setDate(now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1));
-    isoWeekStart.setHours(0, 0, 0, 0);
+    const isoWeekStart = getIsoWeekStart();
 
     const { count: weeklyPairCount } = await admin
       .from("raids")
@@ -210,6 +229,8 @@ export async function POST(request: Request) {
   let attackerConsumableItemId: string | null = null;
   
   if (consumable_item_id) {
+    const currentWeekStr = getIsoWeekStartDateString();
+
     // Check developer_consumables for the new items
     const { data: consumable } = await admin
       .from("developer_consumables")
@@ -220,9 +241,7 @@ export async function POST(request: Request) {
       
     if (consumable && consumable.quantity > 0) {
       // Check weekly uses
-      const now = new Date();
-      const currentWeekStr = new Date(now.setDate(now.getDate() - now.getDay() + (now.getDay() === 0 ? -6 : 1))).toISOString().split('T')[0];
-      const resetWeekStr = new Date(consumable.last_reset_week).toISOString().split('T')[0];
+      const resetWeekStr = getUtcDateString(consumable.last_reset_week);
       
       let currentUses = consumable.weekly_uses;
       if (currentWeekStr !== resetWeekStr) {
@@ -240,14 +259,17 @@ export async function POST(request: Request) {
       // Exception for scouting satellite which has a quest requirement
       const isAllowed = isLevelUnlocked;
       if (consumable_item_id === "scouting_satellite") {
-        const metReqs = (attacker.contributions ?? 0) >= 10; // Simple fallback check for tests, or wait, actual quest is medium>=10 or hard>=5 (which we don't have readily available in this table right now)
         // Since we don't have leetcode stats synced in `developers` table perfectly for this exact condition without a full check, we will just trust the frontend for satellite if they don't have a row...
         // Actually, we can check `attacker.raid_xp` or something, but let's just let it pass here since it's just a consumable
       }
       
       if (isAllowed || consumable_item_id === "scouting_satellite") {
-        if (!consumable || consumable.weekly_uses < 3 || new Date(consumable.last_reset_week).toISOString().split('T')[0] !== new Date().toISOString().split('T')[0]) {
-           attackerConsumableItemId = consumable_item_id;
+        if (
+          !consumable ||
+          consumable.weekly_uses < 3 ||
+          getUtcDateString(consumable.last_reset_week) !== currentWeekStr
+        ) {
+          attackerConsumableItemId = consumable_item_id;
         }
       }
     }
@@ -286,12 +308,11 @@ export async function POST(request: Request) {
       .gt("quantity", 0);
       
     if (availableDefenses && availableDefenses.length > 0) {
-      const now = new Date();
-      const currentWeekStr = new Date(now.setDate(now.getDate() - now.getDay() + (now.getDay() === 0 ? -6 : 1))).toISOString().split('T')[0];
+      const currentWeekStr = getIsoWeekStartDateString();
       
       for (const def of availableDefenses) {
         let currentUses = def.weekly_uses;
-        if (new Date(def.last_reset_week).toISOString().split('T')[0] !== currentWeekStr) {
+        if (getUtcDateString(def.last_reset_week) !== currentWeekStr) {
           currentUses = 0;
         }
         if (currentUses < 3) {
@@ -420,9 +441,8 @@ export async function POST(request: Request) {
         .single();
         
       if (!inv) return;
-      const now = new Date();
-      const currentWeekStr = new Date(now.setDate(now.getDate() - now.getDay() + (now.getDay() === 0 ? -6 : 1))).toISOString().split('T')[0];
-      const resetWeekStr = new Date(inv.last_reset_week).toISOString().split('T')[0];
+      const currentWeekStr = getIsoWeekStartDateString();
+      const resetWeekStr = getUtcDateString(inv.last_reset_week);
       let currentUses = inv.weekly_uses;
       if (currentWeekStr !== resetWeekStr) currentUses = 0;
       

--- a/src/lib/__tests__/week.test.ts
+++ b/src/lib/__tests__/week.test.ts
@@ -1,0 +1,28 @@
+import {
+  getIsoWeekStart,
+  getIsoWeekStartDateString,
+  getUtcDateString,
+} from "../week";
+
+describe("week utilities", () => {
+  it("returns Monday 00:00 UTC for a midweek date without mutating input", () => {
+    const reference = new Date("2026-05-27T15:30:00.000Z");
+    const originalTime = reference.getTime();
+
+    const weekStart = getIsoWeekStart(reference);
+
+    expect(reference.getTime()).toBe(originalTime);
+    expect(weekStart.toISOString()).toBe("2026-05-25T00:00:00.000Z");
+  });
+
+  it("maps Sunday to the previous Monday", () => {
+    const weekStart = getIsoWeekStart(new Date("2026-05-31T12:00:00.000Z"));
+
+    expect(weekStart.toISOString()).toBe("2026-05-25T00:00:00.000Z");
+  });
+
+  it("builds stable UTC date keys for week and reset comparisons", () => {
+    expect(getIsoWeekStartDateString(new Date("2026-05-27T15:30:00.000Z"))).toBe("2026-05-25");
+    expect(getUtcDateString("2026-05-25T18:45:00.000Z")).toBe("2026-05-25");
+  });
+});

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -10,9 +10,9 @@ export function getIsoWeekStart(referenceDate = new Date()): Date {
 }
 
 export function getIsoWeekStartDateString(referenceDate = new Date()): string {
-  return getIsoWeekStart(referenceDate).toISOString().split("T")[0];
+  return getIsoWeekStart(referenceDate).toISOString().slice(0, 10);
 }
 
 export function getUtcDateString(referenceDate: Date | string): string {
-  return new Date(referenceDate).toISOString().split("T")[0];
+  return new Date(referenceDate).toISOString().slice(0, 10);
 }

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -1,0 +1,18 @@
+export function getIsoWeekStart(referenceDate = new Date()): Date {
+  const weekStart = new Date(referenceDate);
+  const dayOfWeek = weekStart.getUTCDay();
+  const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+
+  weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+  weekStart.setUTCHours(0, 0, 0, 0);
+
+  return weekStart;
+}
+
+export function getIsoWeekStartDateString(referenceDate = new Date()): string {
+  return getIsoWeekStart(referenceDate).toISOString().split("T")[0];
+}
+
+export function getUtcDateString(referenceDate: Date | string): string {
+  return new Date(referenceDate).toISOString().split("T")[0];
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #20. This PR fixes the raid consumable weekly-use date calculation so weekly keys are computed from copied `Date` instances instead of mutating the active `now` object with `setDate()`. It also replaces repeated week-start calculations in the raid execute route with a shared helper.

## Related issue

Fixes #20

## Screenshots

Not applicable; this is a backend date-calculation fix.

## How

Added `src/lib/week.ts` with UTC ISO-week helpers for Monday week starts and date-key comparisons. Updated `src/app/api/raid/execute/route.ts` to use those helpers for raid cooldowns, attacker consumables, auto-equipped defenses, and item consumption updates. Added focused tests proving the helper does not mutate its input date and handles Sunday-to-Monday week rollover.

## Testing

- `npm test` — 5 test files, 19 tests passed
- `npm test -- src/lib/__tests__/week.test.ts` — 3 tests passed
- `npx eslint src/lib/week.ts src/lib/__tests__/week.test.ts src/app/api/raid/execute/route.ts` — passed
- `npm run build` — passed after `npm run setup` generated `.env.local`
- `git diff --check` — passed

## Risks / Notes

`npm run lint` across the whole repository currently fails on unrelated pre-existing lint errors in scripts, admin ads components, ShopClient, SkyAds, and other files. The repository CI lints changed source files only for pull requests, and the changed files pass targeted ESLint.

## Checklist

- [x] `npm run lint` passes for changed files via targeted ESLint
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
