### PR TITLE
Fixed error message from misleading "Leetcode" to proper "Github" based Login error response.

### DIFF
--- a/src/app/api/claim/route.ts
+++ b/src/app/api/claim/route.ts
@@ -20,7 +20,7 @@ export async function POST() {
 
   if (!githubLogin) {
     return NextResponse.json(
-      { error: "No LeetCode username in profile" },
+      { error: "GitHub profile information could not be retrieved. Please log in again." },
       { status: 400 }
     );
   }


### PR DESCRIPTION
## What does this PR do?

Changed the misleading error message of "Leetcode usename not found" to github based Login error response.  
New error message (If github username not found):  
#### "GitHub profile information could not be retrieved. Please log in again."

## Related issue

Fixes: #17 

## Checklist

- [X] `npm run lint` passes
- [X] Tested locally
- [X] No secrets or .env values committed
- [X] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
