### PR TITLE
Fix checkout rate limiter cleanup #76

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -4,14 +4,13 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 import { createCheckoutSession } from "@/lib/stripe";
 import { createPixQrCode } from "@/lib/abacatepay";
 import { createCryptoInvoice } from "@/lib/nowpayments";
+import { rateLimit } from "@/lib/rate-limit";
 
 // Defense-in-depth: per-user rate limit IN ADDITION to the IP-based
 // middleware rate limit.  This one is keyed by Supabase user ID so it
 // catches authenticated abuse even when requests come from different IPs.
 // Note: in-memory – resets on deploy / cold-start.  Acceptable because
 // the middleware already provides the primary protection layer.
-const lastCheckout = new Map<string, number>();
-
 /**
  * @param {import('next/server').NextRequest} request
  */
@@ -27,12 +26,10 @@ export async function POST(request: Request) {
   }
 
   // Rate limit: 1 checkout per 10 seconds per user
-  const now = Date.now();
-  const last = lastCheckout.get(user.id);
-  if (last && now - last < 10_000) {
+  const { ok } = rateLimit(`checkout:${user.id}`, 1, 10_000);
+  if (!ok) {
     return NextResponse.json({ error: "Too fast. Wait a few seconds." }, { status: 429 });
   }
-  lastCheckout.set(user.id, now);
 
   const sb = getSupabaseAdmin();
 
@@ -309,9 +306,9 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Failed to create purchase" }, { status: 500 });
       }
 
-      const { invoiceUrl, invoiceId } = await createCryptoInvoice(item_id, dev.id, githubLogin);
+      const { invoiceUrl } = await createCryptoInvoice(item_id, dev.id, githubLogin);
 
-      // Save invoice ID as provider_tx_id so webhook can find this purchase
+      // Save lookup key as provider_tx_id so webhook can find this purchase
       await sb
         .from("purchases")
         .update({ provider_tx_id: `${dev.id}:${item_id}` })


### PR DESCRIPTION
## What does this PR do?

Fixes the checkout route rate limiter memory leak by replacing the route-local unbounded `lastCheckout` Map with the existing cleanup-aware shared `rateLimit` helper. The checkout limit remains unchanged: 1 checkout request per user every 10 seconds.

Also removes an unused `invoiceId` destructure in the same route.

## Related issue

Fixes #76

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.