### PR TITLE
fix(raid): resolve linked attacker claims

### DIFF
--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -22,6 +22,7 @@ import {
   getIsoWeekStartDateString,
   getUtcDateString,
 } from "@/lib/week";
+import { findRaidAttackerForUser } from "@/lib/raid-attacker";
 
 type RaidDeveloper = {
   id: number;
@@ -78,21 +79,10 @@ export async function POST(request: Request) {
 
   const admin = getSupabaseAdmin();
 
-  const githubLogin = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
-
   // Fetch attacker + defender in parallel
   const raidColumns = "id, claimed, github_login, avatar_url, contributions, public_repos, total_stars, kudos_count, app_streak, raid_xp, xp_level, current_week_contributions, current_week_kudos_given, current_week_kudos_received, last_raided_at, active_defenses";
-  const [initialAttackerRes, defenderRes] = await Promise.all([
-    admin
-      .from("developers")
-      .select(raidColumns)
-      .eq("claimed_by", user.id)
-      .limit(1)
-      .maybeSingle(),
+  const [attacker, defenderRes] = await Promise.all([
+    findRaidAttackerForUser(admin, user, raidColumns),
     admin
       .from("developers")
       .select(raidColumns)
@@ -100,41 +90,7 @@ export async function POST(request: Request) {
       .limit(1)
       .maybeSingle(),
   ]);
-  let attackerRes = initialAttackerRes;
-
-  let attacker = attackerRes.data as RaidDeveloper | null;
   const defender = defenderRes.data as RaidDeveloper | null;
-
-  // Auto-claim logic if building exists but not claimed by user yet
-  if (!attacker && githubLogin) {
-    const { data: unclaimedBuilding } = await admin
-      .from("developers")
-      .select("id, claimed_by")
-      .eq("github_login", githubLogin)
-      .limit(1)
-      .maybeSingle();
-
-    if (unclaimedBuilding) {
-      await admin
-        .from("developers")
-        .update({
-          claimed: true,
-          claimed_by: user.id,
-          claimed_at: new Date().toISOString(),
-          fetch_priority: 1,
-        })
-        .eq("id", unclaimedBuilding.id);
-      
-      attackerRes = await admin
-        .from("developers")
-        .select(raidColumns)
-        .eq("claimed_by", user.id)
-        .limit(1)
-        .maybeSingle();
-      attacker = attackerRes.data as RaidDeveloper | null;
-    }
-  }
-
   if (!attacker || !attacker.claimed) {
     return NextResponse.json({ error: "Must claim building first" }, { status: 403 });
   }

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -9,6 +9,7 @@ import {
   MAX_RAIDS_PER_DAY,
 } from "@/lib/raid";
 import type { RaidBoostItem } from "@/lib/raid";
+import { findRaidAttackerForUser } from "@/lib/raid-attacker";
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -34,52 +35,10 @@ export async function POST(request: Request) {
   }
 
   const admin = getSupabaseAdmin();
-
-  const githubLogin = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
+  const attackerColumns = "id, claimed, app_streak, github_login, avatar_url, current_week_contributions, current_week_kudos_given, owned_items";
 
   // Fetch attacker
-  let attackerRes = await admin
-    .from("developers")
-    .select("id, claimed, app_streak, github_login, avatar_url, current_week_contributions, current_week_kudos_given, owned_items")
-    .eq("claimed_by", user.id)
-    .limit(1)
-    .maybeSingle();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let attacker = attackerRes.data as Record<string, any> | null;
-
-  // Auto-claim logic if building exists but not claimed by user yet
-  if (!attacker && githubLogin) {
-    const { data: unclaimedBuilding } = await admin
-      .from("developers")
-      .select("id, claimed_by")
-      .eq("github_login", githubLogin)
-      .limit(1)
-      .maybeSingle();
-
-    if (unclaimedBuilding) {
-      await admin
-        .from("developers")
-        .update({
-          claimed: true,
-          claimed_by: user.id,
-          claimed_at: new Date().toISOString(),
-          fetch_priority: 1,
-        })
-        .eq("id", unclaimedBuilding.id);
-      
-      attackerRes = await admin
-        .from("developers")
-        .select("id, claimed, app_streak, github_login, avatar_url, current_week_contributions, current_week_kudos_given, owned_items")
-        .eq("claimed_by", user.id)
-        .limit(1)
-        .maybeSingle();
-      attacker = attackerRes.data as Record<string, any> | null;
-    }
-  }
+  const attacker = await findRaidAttackerForUser(admin, user, attackerColumns);
 
   if (!attacker || !attacker.claimed) {
     return NextResponse.json({ error: "Must claim building first" }, { status: 403 });

--- a/src/lib/__tests__/raid-attacker.test.ts
+++ b/src/lib/__tests__/raid-attacker.test.ts
@@ -1,0 +1,130 @@
+import { findRaidAttackerForUser, getAuthLoginCandidates } from "../raid-attacker";
+
+type DeveloperRow = {
+  id: number;
+  claimed?: boolean | null;
+  claimed_by?: string | null;
+  github_login?: string | null;
+  lc_username?: string | null;
+  lc_github?: string | null;
+};
+
+function makeAdmin(rows: DeveloperRow[]) {
+  return {
+    from(table: string) {
+      expect(table).toBe("developers");
+
+      return {
+        select() {
+          const filters: ((row: DeveloperRow) => boolean)[] = [];
+          const query = {
+            eq(column: keyof DeveloperRow, value: string | number | boolean) {
+              filters.push((row) => row[column] === value);
+              return query;
+            },
+            limit() {
+              return query;
+            },
+            async maybeSingle() {
+              return { data: rows.find((row) => filters.every((filter) => filter(row))) ?? null };
+            },
+          };
+
+          return query;
+        },
+        update(values: Partial<DeveloperRow>) {
+          return {
+            async eq(column: keyof DeveloperRow, value: string | number) {
+              const row = rows.find((candidate) => candidate[column] === value);
+              if (row) Object.assign(row, values);
+              return { error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("raid attacker lookup", () => {
+  it("deduplicates GitHub login candidates from metadata and identities", () => {
+    const candidates = getAuthLoginCandidates({
+      id: "user-1",
+      user_metadata: {
+        user_name: "SaurabhhhCodes",
+        preferred_username: "@saurabhhhcodes",
+      },
+      identities: [
+        {
+          identity_data: {
+            user_name: "https://github.com/saurabhhhcodes",
+          },
+        },
+      ],
+    });
+
+    expect(candidates).toEqual(["saurabhhhcodes"]);
+  });
+
+  it("repairs a linked row that belongs to the current session but has claimed=false", async () => {
+    const rows: DeveloperRow[] = [
+      {
+        id: 7,
+        claimed: false,
+        claimed_by: "user-1",
+        github_login: "leetcode_user",
+      },
+    ];
+
+    const attacker = await findRaidAttackerForUser(makeAdmin(rows) as never, {
+      id: "user-1",
+      user_metadata: {},
+      identities: [],
+    }, "id, claimed, claimed_by, github_login");
+
+    expect(attacker?.claimed).toBe(true);
+    expect(rows[0]).toMatchObject({ claimed: true, claimed_by: "user-1", fetch_priority: 1 });
+  });
+
+  it("restores a stale LeetCode claim when the profile links to the signed-in GitHub account", async () => {
+    const rows: DeveloperRow[] = [
+      {
+        id: 12,
+        claimed: true,
+        claimed_by: "old-session-id",
+        github_login: "leetcode_handle",
+        lc_username: "leetcode_handle",
+        lc_github: "https://github.com/saurabhhhcodes",
+      },
+    ];
+
+    const attacker = await findRaidAttackerForUser(makeAdmin(rows) as never, {
+      id: "new-session-id",
+      user_metadata: { user_name: "saurabhhhcodes" },
+      identities: [],
+    }, "id, claimed, claimed_by, github_login, lc_github");
+
+    expect(attacker?.id).toBe(12);
+    expect(rows[0]).toMatchObject({ claimed: true, claimed_by: "new-session-id" });
+  });
+
+  it("does not take over a row claimed by another user from a plain username match", async () => {
+    const rows: DeveloperRow[] = [
+      {
+        id: 14,
+        claimed: true,
+        claimed_by: "other-user",
+        github_login: "saurabhhhcodes",
+      },
+    ];
+
+    const attacker = await findRaidAttackerForUser(makeAdmin(rows) as never, {
+      id: "user-1",
+      user_metadata: { user_name: "saurabhhhcodes" },
+      identities: [],
+    }, "id, claimed, claimed_by, github_login");
+
+    expect(attacker).toBeNull();
+    expect(rows[0].claimed_by).toBe("other-user");
+  });
+});

--- a/src/lib/raid-attacker.ts
+++ b/src/lib/raid-attacker.ts
@@ -1,0 +1,174 @@
+import type { User } from "@supabase/supabase-js";
+
+type AuthUser = Pick<User, "id" | "user_metadata" | "identities">;
+// Supabase route handlers select different developer column sets for preview and execute.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DeveloperRow = Record<string, any> & {
+  id: number;
+  claimed?: boolean | null;
+  claimed_by?: string | null;
+};
+type DeveloperResult = PromiseLike<{ data: DeveloperRow | null }>;
+type DeveloperQuery = {
+  eq(column: string, value: string | number | boolean): DeveloperQuery;
+  limit(count: number): DeveloperQuery;
+  maybeSingle(): DeveloperResult;
+};
+type DeveloperUpdate = {
+  eq(column: string, value: string | number): PromiseLike<{ error?: unknown }>;
+};
+type DeveloperTable = {
+  select(columns: string): DeveloperQuery;
+  update(values: Record<string, unknown>): DeveloperUpdate;
+};
+type DeveloperAdmin = {
+  from(table: "developers"): DeveloperTable;
+};
+
+const LOGIN_METADATA_KEYS = [
+  "user_name",
+  "preferred_username",
+  "login",
+  "name",
+  "full_name",
+] as const;
+
+function getGitHubProfileVariants(login: string): string[] {
+  return [
+    `https://github.com/${login}`,
+    `https://github.com/${login}/`,
+    `http://github.com/${login}`,
+    `http://github.com/${login}/`,
+    `github.com/${login}`,
+    `github.com/${login}/`,
+  ];
+}
+
+function normalizeLogin(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  const githubMatch = trimmed.match(/github\.com\/([^/?#]+)/);
+  const login = githubMatch?.[1] ?? trimmed.replace(/^@/, "");
+
+  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(login) ? login : null;
+}
+
+function mergeSelectColumns(columns: string): string {
+  const required = ["id", "claimed", "claimed_by"];
+  const seen = new Set<string>();
+  const merged = [...required, ...columns.split(",").map((column) => column.trim())]
+    .filter(Boolean)
+    .filter((column) => {
+      if (seen.has(column)) return false;
+      seen.add(column);
+      return true;
+    });
+
+  return merged.join(", ");
+}
+
+export function getAuthLoginCandidates(user: AuthUser): string[] {
+  const candidates = new Set<string>();
+
+  for (const key of LOGIN_METADATA_KEYS) {
+    const login = normalizeLogin(user.user_metadata?.[key]);
+    if (login) candidates.add(login);
+  }
+
+  for (const identity of user.identities ?? []) {
+    for (const key of LOGIN_METADATA_KEYS) {
+      const login = normalizeLogin(identity.identity_data?.[key]);
+      if (login) candidates.add(login);
+    }
+  }
+
+  return [...candidates];
+}
+
+async function selectDeveloper(
+  admin: DeveloperAdmin,
+  columns: string,
+  matcher: (query: DeveloperQuery) => DeveloperResult,
+): Promise<DeveloperRow | null> {
+  const query = admin.from("developers").select(columns);
+  const { data } = await matcher(query);
+  return data;
+}
+
+async function markClaimedForUser(
+  admin: DeveloperAdmin,
+  developerId: number,
+  userId: string,
+): Promise<void> {
+  await admin
+    .from("developers")
+    .update({
+      claimed: true,
+      claimed_by: userId,
+      claimed_at: new Date().toISOString(),
+      fetch_priority: 1,
+    })
+    .eq("id", developerId);
+}
+
+async function prepareAttacker(
+  admin: DeveloperAdmin,
+  row: DeveloperRow | null,
+  userId: string,
+  canRebindStaleClaim: boolean,
+): Promise<DeveloperRow | null> {
+  if (!row) return null;
+
+  if (row.claimed && row.claimed_by === userId) return row;
+
+  const hasNoOwner = !row.claimed_by;
+  const belongsToCurrentSession = row.claimed_by === userId;
+  if (!hasNoOwner && !belongsToCurrentSession && !canRebindStaleClaim) {
+    return null;
+  }
+
+  await markClaimedForUser(admin, row.id, userId);
+  return { ...row, claimed: true, claimed_by: userId };
+}
+
+export async function findRaidAttackerForUser(
+  admin: unknown,
+  user: AuthUser,
+  columns: string,
+): Promise<DeveloperRow | null> {
+  const developerAdmin = admin as DeveloperAdmin;
+  const selectColumns = mergeSelectColumns(columns);
+
+  const claimedBySession = await selectDeveloper(developerAdmin, selectColumns, (query) =>
+    query.eq("claimed_by", user.id).limit(1).maybeSingle(),
+  );
+  const directAttacker = await prepareAttacker(developerAdmin, claimedBySession, user.id, true);
+  if (directAttacker) return directAttacker;
+
+  for (const login of getAuthLoginCandidates(user)) {
+    const loginMatchedDeveloper = await selectDeveloper(developerAdmin, selectColumns, (query) =>
+      query.eq("github_login", login).limit(1).maybeSingle(),
+    );
+    const loginAttacker = await prepareAttacker(developerAdmin, loginMatchedDeveloper, user.id, false);
+    if (loginAttacker) return loginAttacker;
+
+    const lcUsernameMatchedDeveloper = await selectDeveloper(developerAdmin, selectColumns, (query) =>
+      query.eq("lc_username", login).limit(1).maybeSingle(),
+    );
+    const lcUsernameAttacker = await prepareAttacker(developerAdmin, lcUsernameMatchedDeveloper, user.id, false);
+    if (lcUsernameAttacker) return lcUsernameAttacker;
+
+    for (const profileUrl of getGitHubProfileVariants(login)) {
+      const profileLinkedDeveloper = await selectDeveloper(developerAdmin, selectColumns, (query) =>
+        query.eq("lc_github", profileUrl).limit(1).maybeSingle(),
+      );
+      const profileLinkedAttacker = await prepareAttacker(developerAdmin, profileLinkedDeveloper, user.id, true);
+      if (profileLinkedAttacker) return profileLinkedAttacker;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the raid preview/execute attacker lookup so linked users are recognized consistently after LeetCode verification instead of getting `Must claim building first`.

- moves the duplicated attacker lookup into a shared helper
- keeps the direct `claimed_by = user.id` path as the first lookup
- repairs rows that belong to the current session but still have `claimed=false`
- supports stale-session recovery only when the linked LeetCode profile has an exact GitHub profile URL for the signed-in GitHub account
- avoids taking over a row that is already claimed by another user from only a plain username match
- uses the same helper from both preview and execute routes

## Related issue

Fixes #13

## Screenshots

Not applicable; API/auth lookup fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.

## Local validation

- `npm run setup:check`
- `npm run test -- src/lib/__tests__/raid-attacker.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/lib/raid-attacker.ts src/lib/__tests__/raid-attacker.test.ts src/app/api/raid/preview/route.ts src/app/api/raid/execute/route.ts`
- `npm run build`

Note: lint exits successfully with an existing warning in `src/app/api/raid/execute/route.ts` for `metReqs`, unrelated to this change.
