### PR TITLE
fix(streak): use schema-backed freeze count column

### DIFF
--- a/src/app/api/cron/streak-reminder/route.ts
+++ b/src/app/api/cron/streak-reminder/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
     // Find developers with streak >= 3 who haven't checked in today
     const { data: devs } = await sb
       .from("developers")
-      .select("id, github_login, app_streak, streak_freeze_count, last_checkin_date")
+      .select("id, github_login, app_streak, streak_freezes_available, last_checkin_date")
       .eq("claimed", true)
       .not("email", "is", null)
       .gte("app_streak", 3)
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
           continue;
         }
 
-        const hasFreezeAvailable = (dev.streak_freeze_count ?? 0) > 0;
+        const hasFreezeAvailable = (dev.streak_freezes_available ?? 0) > 0;
 
         sendStreakReminderNotification(
           dev.id,

--- a/src/app/api/dailies/claim/route.ts
+++ b/src/app/api/dailies/claim/route.ts
@@ -87,11 +87,11 @@ export async function POST() {
   if (claimResult.total % 7 === 0) {
     const { data: devFreeze } = await admin
       .from("developers")
-      .select("streak_freeze_count")
+      .select("streak_freezes_available")
       .eq("id", dev.id)
       .single();
 
-    if ((devFreeze?.streak_freeze_count ?? 0) < 2) {
+    if ((devFreeze?.streak_freezes_available ?? 0) < 2) {
       await admin.rpc("grant_streak_freeze", { p_developer_id: dev.id });
       await admin.from("streak_freeze_log").insert({
         developer_id: dev.id,


### PR DESCRIPTION
## What does this PR do?

Fixes the streak-freeze schema mismatch in the dailies claim route and streak reminder cron route. Both routes were reading `streak_freeze_count`, but the migrations and existing RPCs define/use `streak_freezes_available`.

## Related issue

Fixes #132

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

## How was this tested?

- `npx eslint src/app/api/cron/streak-reminder/route.ts src/app/api/dailies/claim/route.ts`
- `npm run build`
- `npm test -- --run`

Note: full `npm run lint` still fails on pre-existing repo-wide lint errors outside this PR, mostly scripts/admin/3D component rules. The changed files pass targeted ESLint.

## Screenshots / Demo

Not applicable; backend route/schema-name fix only.

## Checklist

- [x] My code follows the project style
- [x] I ran relevant tests and build checks
- [x] I linked the related issue
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.