### PR TITLE
fix(ads): block suspicious TLD links with paths

### DIFF
--- a/src/lib/__tests__/ad-moderation.test.ts
+++ b/src/lib/__tests__/ad-moderation.test.ts
@@ -24,6 +24,8 @@ describe('ad-moderation utilities (pure)', () => {
   it('isSuspiciousLink detects suspicious TLDs with paths and query strings', () => {
     expect(isSuspiciousLink('https://promo.xyz/path')).toBe(true);
     expect(isSuspiciousLink('https://promo.top/?campaign=1')).toBe(true);
+    expect(isSuspiciousLink('promo.xyz/path')).toBe(true);
+    expect(isSuspiciousLink('www.promo.top')).toBe(true);
     expect(isSuspiciousLink('https://safe.example.com/path')).toBe(false);
   });
 });

--- a/src/lib/__tests__/ad-moderation.test.ts
+++ b/src/lib/__tests__/ad-moderation.test.ts
@@ -20,5 +20,10 @@ describe('ad-moderation utilities (pure)', () => {
   it('isSuspiciousLink detects IP-based URLs', () => {
     expect(isSuspiciousLink('http://192.168.0.1/account/secure')).toBe(true);
   });
-});
 
+  it('isSuspiciousLink detects suspicious TLDs with paths and query strings', () => {
+    expect(isSuspiciousLink('https://promo.xyz/path')).toBe(true);
+    expect(isSuspiciousLink('https://promo.top/?campaign=1')).toBe(true);
+    expect(isSuspiciousLink('https://safe.example.com/path')).toBe(false);
+  });
+});

--- a/src/lib/ad-moderation.ts
+++ b/src/lib/ad-moderation.ts
@@ -57,12 +57,24 @@ const SUSPICIOUS_LINK_PATTERNS = [
   /account[.-](?:verify|secure|update|recovery)/i,
   /github[.-](?:verify|secure|auth|login)(?!\.com)/i,
   // Known scam TLDs
-  /\.(?:xyz|top|buzz|click|link|gq|ml|tk|cf|ga)$/i,
   // IP-based URLs
   /https?:\/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/,
   // Excessive subdomains (common in phishing)
   /https?:\/\/(?:[^/]*\.){4,}/,
 ];
+
+const SUSPICIOUS_TLDS = new Set([
+  "xyz",
+  "top",
+  "buzz",
+  "click",
+  "link",
+  "gq",
+  "ml",
+  "tk",
+  "cf",
+  "ga",
+]);
 
 export function containsBlockedContent(
   text: string,
@@ -85,6 +97,14 @@ export function containsBlockedContent(
 }
 
 export function isSuspiciousLink(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    const tld = hostname.split(".").pop();
+    if (tld && SUSPICIOUS_TLDS.has(tld)) return true;
+  } catch {
+    // Keep malformed values on the existing pattern-only path.
+  }
+
   for (const pattern of SUSPICIOUS_LINK_PATTERNS) {
     if (pattern.test(url)) return true;
   }

--- a/src/lib/ad-moderation.ts
+++ b/src/lib/ad-moderation.ts
@@ -56,7 +56,6 @@ const SUSPICIOUS_LINK_PATTERNS = [
   /login[.-]confirm/i,
   /account[.-](?:verify|secure|update|recovery)/i,
   /github[.-](?:verify|secure|auth|login)(?!\.com)/i,
-  // Known scam TLDs
   // IP-based URLs
   /https?:\/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/,
   // Excessive subdomains (common in phishing)
@@ -75,6 +74,22 @@ const SUSPICIOUS_TLDS = new Set([
   "cf",
   "ga",
 ]);
+
+function extractHostname(url: string): string | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  for (const candidate of [trimmedUrl, `https://${trimmedUrl}`]) {
+    try {
+      const hostname = new URL(candidate).hostname.toLowerCase();
+      if (hostname) return hostname;
+    } catch {
+      // Try the next candidate before falling back to regex checks.
+    }
+  }
+
+  return null;
+}
 
 export function containsBlockedContent(
   text: string,
@@ -97,13 +112,9 @@ export function containsBlockedContent(
 }
 
 export function isSuspiciousLink(url: string): boolean {
-  try {
-    const hostname = new URL(url).hostname.toLowerCase();
-    const tld = hostname.split(".").pop();
-    if (tld && SUSPICIOUS_TLDS.has(tld)) return true;
-  } catch {
-    // Keep malformed values on the existing pattern-only path.
-  }
+  const hostname = extractHostname(url);
+  const tld = hostname?.split(".").pop();
+  if (tld && SUSPICIOUS_TLDS.has(tld)) return true;
 
   for (const pattern of SUSPICIOUS_LINK_PATTERNS) {
     if (pattern.test(url)) return true;


### PR DESCRIPTION
## What does this PR do?
Fixes Sky Ads link moderation so scam-prone TLDs are detected even when the URL includes a path or query string. Previously the suspicious TLD regex only matched when the TLD was at the very end of the entire URL, so `https://promo.xyz/path` and `https://promo.top/?campaign=1` could pass moderation.

## Related issue
Fixes #134

## How
The URL hostname is parsed with the platform `URL` API, the final hostname label is checked against the existing suspicious TLD list, and malformed URLs continue through the existing regex-based checks. This keeps the moderation behavior focused and avoids changing the broader blocked-content rules.

## Testing
- `npm test -- --run src/lib/__tests__/ad-moderation.test.ts` - passed locally
- `npx eslint src/lib/ad-moderation.ts src/lib/__tests__/ad-moderation.test.ts` - passed locally
- `npx tsc --noEmit --pretty false --incremental false` - passed locally
- `npm run setup && npm run build` - passed locally
- GitHub Actions `Lint · Build` - passed
- GitHub Actions `Production Build` - passed
- GitHub Actions template, issue-link, branch hygiene, security, and auto-label checks - passed
- Vercel - blocked by maintainer/team authorization requirement

## Risks / Notes
This intentionally checks only the parsed hostname TLD, not arbitrary path text, so a safe domain containing `.xyz` in a path is not blocked. A local full `npm run lint` reports pre-existing repository-wide lint issues outside this diff, while the changed files pass targeted ESLint and the repository CI lint/build job passes.

## Screenshots
Not applicable; this is moderation logic only.

## Checklist
- [x] `npm run lint` passes in CI; targeted local ESLint for this PR also passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
