### PR TITLE
fix(checkin): make streak reward grant atomic

### DIFF
--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -50,8 +50,22 @@ async function grantStreakReward(
       ? unowned[Math.floor(Math.random() * unowned.length)]
       : tier.pool[Math.floor(Math.random() * tier.pool.length)]; // fallback: grant anyway
 
+    // Record the reward first — upsert guards against concurrent duplicate grants.
+    // If another request already inserted this milestone, do nothing and skip.
+    const { data: rewardInserted } = await sb
+      .from("streak_rewards")
+      .upsert(
+        { developer_id: developerId, milestone: tier.milestone, item_id: itemId },
+        { onConflict: "developer_id,milestone", ignoreDuplicates: true }
+      )
+      .select("id")
+      .maybeSingle();
+
+    // Only grant the item if we actually inserted the reward row (not a duplicate)
+    if (!rewardInserted) continue;
+
     // Grant the item
-    await sb.from("purchases").insert({
+    await sb.from("purchases").upsert({
       developer_id: developerId,
       item_id: itemId,
       provider: "free",
@@ -59,14 +73,7 @@ async function grantStreakReward(
       amount_cents: 0,
       currency: "usd",
       status: "completed",
-    });
-
-    // Record the reward
-    await sb.from("streak_rewards").insert({
-      developer_id: developerId,
-      milestone: tier.milestone,
-      item_id: itemId,
-    });
+    }, { onConflict: "provider_tx_id", ignoreDuplicates: true });
 
     return {
       milestone: tier.milestone,


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in `grantStreakReward` inside `src/app/api/checkin/route.ts` where two concurrent POST requests to
`/api/checkin` could both pass the `maybeSingle()` existence check before either had committed a `streak_rewards` row — resulting in a user receiving a duplicate item or the milestone record never being written.

**Changes:**
- `streak_rewards` insert replaced with `upsert` on `onConflict: "developer_id,milestone"` with `ignoreDuplicates: true`
- Added a guard: only proceed to grant the purchase if the upsert actually inserted a new row
- `purchases` insert replaced with `upsert` on `provider_tx_id` as a secondary safety net

Only 1 file changed: `src/app/api/checkin/route.ts`

## Related issue

Fixes #114

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above