### PR TITLE
fix(dailies): pass isMobile context to claim route

### DIFF
--- a/src/app/api/dailies/claim/route.ts
+++ b/src/app/api/dailies/claim/route.ts
@@ -5,7 +5,7 @@ import { rateLimit } from "@/lib/rate-limit";
 import { getDailyMissions, getTodayStr } from "@/lib/dailies";
 import { checkAchievements } from "@/lib/achievements";
 
-export async function POST() {
+export async function POST(request: Request) {
   const supabase = await createServerSupabase();
   const {
     data: { user },
@@ -41,8 +41,18 @@ export async function POST() {
     return NextResponse.json({ error: "Already claimed today" }, { status: 400 });
   }
 
+  // Read isMobile from request body so the server uses the same mission
+  // set the client was assigned (mobile excludes desktopOnly missions)
+  let isMobile = false;
+  try {
+    const body = await request.json();
+    isMobile = body?.mobile === true;
+  } catch {
+    // no body or invalid json — default to desktop
+  }
+
   // Verify all 3 missions are completed
-  const missions = getDailyMissions(dev.id, today);
+  const missions = getDailyMissions(dev.id, today, isMobile);
   const { data: progressRows } = await admin
     .from("daily_mission_progress")
     .select("mission_id, completed")

--- a/src/app/api/dailies/route.ts
+++ b/src/app/api/dailies/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getDailyMissions, getTodayStr, trackDailyMission } from "@/lib/dailies";
 
-export async function GET() {
+export async function GET(request: Request) {
   const supabase = await createServerSupabase();
   const {
     data: { user },
@@ -34,7 +34,9 @@ export async function GET() {
     await trackDailyMission(dev.id, "checkin");
   }
 
-  const missions = getDailyMissions(dev.id, today);
+  const { searchParams } = new URL(request.url);
+  const isMobile = searchParams.get("mobile") === "1";
+  const missions = getDailyMissions(dev.id, today, isMobile);
 
   // Fetch today's progress
   const { data: progressRows } = await admin


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where mobile users were permanently blocked from claiming their daily missions reward.

`getDailyMissions` is seeded deterministically per `date + developerId`. With `isMobile=true`, `desktopOnly` missions (`fly_score_50`, `fly_score_150`) are excluded from the shuffle pool — producing a **different 3-mission set** than `isMobile=false`.

Neither `/api/dailies` (GET) nor `/api/dailies/claim` (POST) were forwarding the mobile context. Both called `getDailyMissions(dev.id, today)` with the default `isMobile=false`. On any day where the desktop seed picked a `fly_score_*` mission, mobile users who completed their actual 3 missions would fail the `allDone` check and receive HTTP 400 for the entire day.

**Changes:**
- `src/app/api/dailies/route.ts` — accepts `?mobile=1` query param, forwards to `getDailyMissions`
- `src/app/api/dailies/claim/route.ts` — accepts `{ mobile: true }` in request body, forwards to `getDailyMissions`

2 files changed.

## Related issue

Fixes #115

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above