### PR TITLE
fix(queue): guard flush() against concurrent invocations

### DIFF
--- a/packages/vscode-extension/src/api/queue.ts
+++ b/packages/vscode-extension/src/api/queue.ts
@@ -3,9 +3,10 @@ import { sendHeartbeats } from "./client";
 import { FLUSH_INTERVAL_MS, MAX_BATCH_SIZE, QUEUE_STORAGE_KEY } from "../constants";
 import type { RawHeartbeat } from "../privacy/sanitizer";
 
-const queue: RawHeartbeat[] = [];
+let queue: RawHeartbeat[] = [];
 let flushTimer: ReturnType<typeof setInterval> | undefined;
 let globalState: vscode.Memento;
+let isFlushing = false;
 
 export function initQueue(context: vscode.ExtensionContext) {
   globalState = context.globalState;
@@ -24,7 +25,8 @@ export function enqueue(heartbeat: RawHeartbeat) {
   queue.push(heartbeat);
   persist();
   // Flush immediately when first heartbeat arrives (instant feedback)
-  if (wasEmpty) {
+  // Skip if a flush is already in-flight — interval will pick it up
+  if (wasEmpty && !isFlushing) {
     flush();
   }
 }
@@ -46,17 +48,26 @@ function startFlushing() {
 }
 
 async function flush() {
-  if (queue.length === 0) return;
+  // Guard against concurrent flush invocations.
+  // Without this, setInterval and enqueue() can both call flush() simultaneously.
+  // Across the await boundary, a failed batch could be unshifted back into the queue
+  // while another flush already persisted a state without it — causing permanent loss.
+  if (isFlushing || queue.length === 0) return;
 
+  isFlushing = true;
   const batch = queue.splice(0, MAX_BATCH_SIZE);
-  const ok = await sendHeartbeats(batch);
 
-  if (!ok) {
-    // Put failed batch back at front
-    queue.unshift(...batch);
+  try {
+    const ok = await sendHeartbeats(batch);
+
+    if (!ok) {
+      // Put failed batch back at front so it retries on the next flush
+      queue.unshift(...batch);
+    }
+  } finally {
+    isFlushing = false;
+    persist();
   }
-
-  persist();
 }
 
 function persist() {


### PR DESCRIPTION
## What does this PR do?

Fixes a heartbeat loss bug in the VS Code extension caused by concurrent `flush()` invocations.

`flush()` was `async` with no in-flight guard. Two independent callers could invoke it simultaneously:
- `setInterval(flush, FLUSH_INTERVAL_MS)` every 30 seconds
- `enqueue()` calling `flush()` immediately when the queue goes from empty to non-empty

Across the `await` boundary: Flush A splices a batch and starts `await sendHeartbeats()`. While awaiting, Flush B runs, splices new items, succeeds, and calls `persist()` — writing a queue state without Flush A's batch. Flush A then fails, unshifts its batch back into memory, but the persisted state no longer includes it. If VS Code closes before the next interval tick, those heartbeats are permanently lost.

**Fix:**
- Added `let isFlushing = false` guard
- `flush()` returns early if already in-flight
- `persist()` moved into `finally` block so storage always reflects   correct in-memory state after the await settles
- `enqueue()` skips immediate flush if one is already in-flight

1 file changed: `packages/vscode-extension/src/api/queue.ts`

## Related issue

Fixes #116

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above