### PR TITLE
fix(rate-limit): clamp remaining value Fixes #103

### DIFF
--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,19 @@
+import { rateLimit } from "../rate-limit";
+
+describe("rateLimit", () => {
+  it("never reports a negative remaining value", () => {
+    const result = rateLimit("rate-limit-clamp-test", 0, 60_000);
+
+    expect(result.remaining).toBe(0);
+  });
+
+  it("reports zero remaining after consuming the final allowed request", () => {
+    const result = rateLimit("rate-limit-final-request-test", 1, 60_000);
+
+    expect(result).toEqual({
+      ok: true,
+      remaining: 0,
+      reset: expect.any(Number),
+    });
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -45,7 +45,7 @@ export function rateLimit(
   // First request in this window (or window expired)
   if (!entry || now > entry.resetAt) {
     store.set(key, { count: 1, resetAt: now + windowMs });
-    return { ok: true, remaining: limit - 1, reset: now + windowMs };
+    return { ok: true, remaining: Math.max(0, limit - 1), reset: now + windowMs };
   }
 
   // Window still active – check quota
@@ -54,5 +54,5 @@ export function rateLimit(
   }
 
   entry.count++;
-  return { ok: true, remaining: limit - entry.count, reset: entry.resetAt };
+  return { ok: true, remaining: Math.max(0, limit - entry.count), reset: entry.resetAt };
 }


### PR DESCRIPTION
## What does this PR do?

Clamps the rate-limit `remaining` calculation so it never returns a negative value. This keeps the returned rate-limit metrics aligned with expected HTTP rate-limit behavior, even when request counts reach or exceed the configured limit.

Also adds regression tests for the non-negative remaining value behavior.

## Related issue

Fixes #103

## Screenshots

Not applicable. This is a backend utility fix with no visual changes.

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.