### PR TITLE
fix: persist loadout cosmetics on city reload and fresh page load 

### DIFF
--- a/src/app/api/loadout/route.ts
+++ b/src/app/api/loadout/route.ts
@@ -24,9 +24,10 @@ export async function GET(request: Request) {
     .eq("item_id", "loadout")
     .maybeSingle();
 
-  return NextResponse.json({
-    loadout: data?.config ?? null,
-  });
+  return NextResponse.json(
+    { loadout: data?.config ?? null },
+    { headers: { "Cache-Control": "no-store" } }
+  );
 }
 
 /**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2095,6 +2095,13 @@ function HomeContent() {
     }
   }, [giftedParam, userParam, buildings, reloadCity]);
 
+  // Reload city immediately when loadout is saved from the shop
+  useEffect(() => {
+    const handler = () => reloadCity(true);
+    window.addEventListener("leetcodecity:loadout-saved", handler);
+    return () => window.removeEventListener("leetcodecity:loadout-saved", handler);
+  }, [reloadCity]);
+
   const searchUser = useCallback(async () => {
     const trimmed = username.trim().toLowerCase();
     if (!trimmed) return;

--- a/src/components/Building3D.tsx
+++ b/src/components/Building3D.tsx
@@ -476,10 +476,10 @@ export const BuildingItemEffects = memo(function BuildingItemEffects({ building,
 
   // Without a loadout, only render flag (free claim item). All other items require explicit equip.
   const hasLoadout = loadout && (loadout.crown || loadout.roof || loadout.aura || loadout.faces);
-  const crownItem = hasLoadout ? loadout.crown : (items.includes("flag") ? "flag" : null);
-  const roofItem = hasLoadout ? loadout.roof : null;
-  const auraItem = hasLoadout ? loadout.aura : null;
-  const facesItem = hasLoadout ? loadout.faces : null;
+  const crownItem = hasLoadout && crownItems.includes(loadout.crown!) ? loadout.crown : (items.includes("flag") ? "flag" : null);
+  const roofItem = hasLoadout && roofItems.includes(loadout.roof!) ? loadout.roof : null;
+  const auraItem = hasLoadout && auraItems.includes(loadout.aura!) ? loadout.aura : null;
+  const facesItem = hasLoadout && facesItems.includes(loadout.faces!) ? loadout.faces : null;
 
   const shouldRenderZone = (itemId: string) => {
     if (!items.includes(itemId)) return false;

--- a/src/components/ShopClient.tsx
+++ b/src/components/ShopClient.tsx
@@ -910,6 +910,7 @@ export default function ShopClient({
             JSON.stringify({ developerId, loadout: payload, ts: Date.now() }),
           );
         } catch (err) { console.warn("[components/ShopClient.tsx] non-critical error:", err); } 
+        window.dispatchEvent(new CustomEvent("leetcodecity:loadout-saved"));
       } else {
         setError("Failed to save. Try again.");
       }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where building cosmetics (crown, roof, aura, faces) equipped via the shop were saved to the database correctly but not reflected in the city rendering on page reload or fresh tab open.

### Root Cause Analysis

After investigating the codebase, the persistence gap had two distinct layers:

**Layer 1 — In-memory city cache not busted after save (`ShopClient.tsx` → `page.tsx`)**

After `POST /api/loadout` succeeds, `handleSaveLoadout` in `ShopClient.tsx` wrote a localStorage override (`leetcodecity:loadout_override`) but never signaled the city map to refresh. The module-level `CityCache` in `src/lib/cityCache.ts` has a 5-minute TTL and survives client-side navigation. So when the user navigated back to the city map after saving, `getCityCache()` returned the stale pre-save snapshot and `reloadCity` was never called — the equipped cosmetics were invisible until the cache expired naturally.

**Layer 2 — Edge cache serving stale loadout on fresh page loads (`GET /api/loadout`)**

On a hard reload or first visit from another device, the `GET /api/loadout` response had no `Cache-Control` header, leaving it eligible for Vercel's Edge cache. If the Edge-cached response pre-dated the DB write, and the localStorage override was absent (private browsing, different device, TTL expired), the saved loadout from `developer_customizations` was simply not applied — the stale cached response won.

**Layer 3 — No guard for invalid/deprecated item IDs in rendering (`Building3D.tsx`)**

`BuildingItemEffects` read `loadout.crown`, `loadout.roof` etc. and passed them directly into rendering logic without checking whether the item ID still exists in `ZONE_ITEMS`. A deprecated or renamed item ID would attempt to render and fail silently, leaving the slot blank with no fallback.

### Fix

**`src/components/ShopClient.tsx`**
After the localStorage write succeeds, dispatch a custom window event `leetcodecity:loadout-saved`. This decouples the shop component from the city map — the shop doesn't need to know about `reloadCity` or city state directly.

**`src/app/page.tsx`**
Added a `useEffect` that listens for `leetcodecity:loadout-saved` and calls `reloadCity(true)`. Passing `true` calls `clearCityCache()` before re-fetching, ensuring the fresh DB value is applied immediately in the same tab without waiting for the 5-minute TTL.

**`src/app/api/loadout/route.ts`**
Added `Cache-Control: no-store` to the GET response. Loadout data is auth-gated and per-user — it should never be served from an Edge cache shared across requests. This ensures fresh page loads always get the latest value from the database.

**`src/components/Building3D.tsx`**
Each loadout slot (`crownItem`, `roofItem`, `auraItem`, `facesItem`) is now validated against the corresponding `ZONE_ITEMS` array (already available in scope as `crownItems`, `roofItems`, `auraItems`, `facesItems`) before being used. If the item ID is not in the allowlist, the slot falls back to `null` (or `"flag"` for crown, which is the free default). No new imports required.

**Files changed:**
- `src/components/ShopClient.tsx` — dispatch `leetcodecity:loadout-saved` after successful save (1 line added)
- `src/app/page.tsx` — new `useEffect` listening for `leetcodecity:loadout-saved`, calls `reloadCity(true)` (5 lines added)
- `src/app/api/loadout/route.ts` — `Cache-Control: no-store` header on GET response (2 lines changed)
- `src/components/Building3D.tsx` — ZONE_ITEMS allowlist validation on all 4 loadout slots (4 lines changed)

## Related issue

Fixes #157

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above