### PR TITLE
fix(shader): prevent stale building uniforms

### DIFF
--- a/src/components/InstancedBuildings.tsx
+++ b/src/components/InstancedBuildings.tsx
@@ -220,7 +220,6 @@ export default memo(function InstancedBuildings({
   }, [buildings]);
 
   const geo = useMemo(() => new THREE.BoxGeometry(1, 1, 1), []);
-
   const material = useMemo(() => {
     return new THREE.ShaderMaterial({
       uniforms: {
@@ -232,22 +231,22 @@ export default memo(function InstancedBuildings({
         uFogFar: { value: 3500 },
         uFocusedId: { value: -1.0 },
         uFocusedIdB: { value: -1.0 },
-        uDimOpacity: { value: 0.6 },
-        uDimEmissive: { value: 0.5 },
-        uCityEnergy: { value: 0.15 },
-        uTimeOfDay: { value: 1.0 }, // New uniform added
+        uDimOpacity: { value: dimOpacity },
+        uDimEmissive: { value: dimEmissive },
+        uCityEnergy: { value: cityEnergy },
+        uTimeOfDay: { value: 1.0 },
       },
       vertexShader,
       fragmentShader,
     });
-  }, []);
-
-  useEffect(() => {
-    material.uniforms.uAtlas.value = atlasTexture;
-    material.uniforms.uRoofColor.value.set(colors.roof);
-    material.uniforms.uFaceColor.value.set(colors.face);
-    material.needsUpdate = true;
-  }, [material, atlasTexture, colors.roof, colors.face]);
+  }, [
+    atlasTexture,
+    colors.roof,
+    colors.face,
+    dimOpacity,
+    dimEmissive,
+    cityEnergy,
+  ]);
 
   const { uvFrontData, uvSideData, riseData, tintData, lcData } =
     useMemo(() => {


### PR DESCRIPTION
## What does this PR do?

This PR fixes a potential stale uniform issue in `src/components/InstancedBuildings.tsx`.

Previously, the building `ShaderMaterial` was memoized with an empty dependency array:

```tsx
const material = useMemo(() => {
  return new THREE.ShaderMaterial({...});
}, []);
```

Because the material was only created once, uniforms initialized from dynamic values such as:

* `atlasTexture`
* `colors.roof`
* `colors.face`
* `dimOpacity`
* `dimEmissive`
* `cityEnergy`

could become stale when those values changed (for example during theme changes or visual state updates).

### Changes Made

* Added all dynamic shader inputs to the `useMemo` dependency array.
* Removed the manual uniform synchronization effect.
* Ensured the material is recreated whenever its initialization values change.
* Prevented outdated texture and color values from being retained by the shader.

This keeps the shader uniforms in sync with the latest theme and rendering state while simplifying the update logic.

## Related issue

Fixes #156

## Checklist

* [x] Audited shader uniforms for potential staleness
* [x] Added proper dependencies to the `useMemo` hook
* [x] Removed redundant manual uniform synchronization logic
* [x] Verified the application loads successfully after the change
* [x] Ensured no new runtime errors were introduced
* [ ] Added screenshots (to be attached if required by maintainers)
* [ ] Tested theme switching visually (environment limitation)
