### PR TITLE
fix: fail closed on raid limit/peace shield checks — remove silent exception swallow

### DIFF
--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -105,42 +105,50 @@ export async function POST(request: Request) {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
 
-  try {
-    const { count: raidsToday } = await admin
-      .from("raids")
-      .select("id", { count: "exact", head: true })
-      .eq("attacker_id", attacker.id)
-      .gte("created_at", todayStart.toISOString());
+  // Daily cap check
+  const { count: raidsToday, error: dailyCheckError } = await admin
+    .from("raids")
+    .select("id", { count: "exact", head: true })
+    .eq("attacker_id", attacker.id)
+    .gte("created_at", todayStart.toISOString());
 
-    if ((raidsToday ?? 0) >= MAX_RAIDS_PER_DAY) {
-      return NextResponse.json({ error: "Daily raid limit reached" }, { status: 429 });
+  if (dailyCheckError) {
+    // Only tolerate missing-table errors (schema not yet migrated); fail closed on all others
+    if (!dailyCheckError.message?.includes("42P01")) {
+      console.error("[raid/execute] daily cap check failed:", dailyCheckError.message);
+      return NextResponse.json({ error: "Raid temporarily unavailable" }, { status: 500 });
     }
-
-    // Check 2-hour peace shield on defender
-    if (defender.last_raided_at) {
-      const shieldExpires = new Date(new Date(defender.last_raided_at).getTime() + 2 * 60 * 60 * 1000);
-      if (new Date() < shieldExpires) {
-        return NextResponse.json({ error: "Target has an active Peace Shield" }, { status: 429 });
-      }
-    }
-
-    // Check weekly cooldown
-    // Raid limits use UTC ISO weeks to stay aligned with persisted UTC timestamps.
-    const isoWeekStart = getIsoWeekStart();
-
-    const { count: weeklyPairCount } = await admin
-      .from("raids")
-      .select("id", { count: "exact", head: true })
-      .eq("attacker_id", attacker.id)
-      .eq("defender_id", defender.id)
-      .gte("created_at", isoWeekStart.toISOString());
-
-    if ((weeklyPairCount ?? 0) > 0) {
-      return NextResponse.json({ error: "Already raided this target this week" }, { status: 429 });
-    }
-  } catch (err) {
-    console.warn("[app/api/raid/execute/route.ts] non-critical error:", err);
+  } else if ((raidsToday ?? 0) >= MAX_RAIDS_PER_DAY) {
+    return NextResponse.json({ error: "Daily raid limit reached" }, { status: 429 });
   }
+
+  // 2-hour peace shield check
+  if (defender.last_raided_at) {
+    const shieldExpires = new Date(new Date(defender.last_raided_at).getTime() + 2 * 60 * 60 * 1000);
+    if (new Date() < shieldExpires) {
+      return NextResponse.json({ error: "Target has an active Peace Shield" }, { status: 429 });
+    }
+  }
+
+  // Weekly per-pair cooldown check
+  const isoWeekStart = getIsoWeekStart();
+
+  const { count: weeklyPairCount, error: weeklyCheckError } = await admin
+    .from("raids")
+    .select("id", { count: "exact", head: true })
+    .eq("attacker_id", attacker.id)
+    .eq("defender_id", defender.id)
+    .gte("created_at", isoWeekStart.toISOString());
+
+  if (weeklyCheckError) {
+    if (!weeklyCheckError.message?.includes("42P01")) {
+      console.error("[raid/execute] weekly cooldown check failed:", weeklyCheckError.message);
+      return NextResponse.json({ error: "Raid temporarily unavailable" }, { status: 500 });
+    }
+  } else if ((weeklyPairCount ?? 0) > 0) {
+    return NextResponse.json({ error: "Already raided this target this week" }, { status: 429 });
+  }
+  
   // Determine vehicle + tag style from saved loadout (or override from request)
   const [{ data: raidLoadoutRow }, { data: ownedVehiclePurchases }] = await Promise.all([
     admin


### PR DESCRIPTION
## What does this PR do?

Fixes a critical security bug where all three raid enforcement checks — daily cap, 2-hour peace shield, and weekly per-pair cooldown — were wrapped in a single `try/catch` that silently swallowed any database error and allowed the raid to proceed unconditionally.

The original code:
```typescript
try {
  // daily cap check
  // peace shield check
  // weekly cooldown check
} catch (err) {
  console.warn("non-critical error:", err);
}
// raid proceeds regardless
```

Any DB error (timeout, connection pool exhaustion, missing table) bypassed all three limits simultaneously while still granting XP and inserting the raid row via `execute_raid`.

**Fix:**

Replaced the single swallowing try/catch with individual inline error checks on each query. Each check now **fails closed** — returning HTTP 500 on any unexpected DB error rather than silently proceeding.

The only tolerated error is Postgres code `42P01` (table does not exist), which preserves the original intent of allowing the route to work before the `raids` table migration has run. All other errors surface as 500s.

The peace shield check is pure in-memory (no DB call) and needed no change.

**Files changed:**
- `src/app/api/raid/execute/route.ts` — replaced try/catch with inline per-check error handling, fail-closed on unexpected DB errors

## Related issue

Fixes #164

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above