### PR TITLE
🐛 fix(city): restore owner live glow boost

### DIFF
--- a/src/components/InstancedBuildings.tsx
+++ b/src/components/InstancedBuildings.tsx
@@ -467,7 +467,7 @@ export default memo(function InstancedBuildings({
     for (let i = 0; i < count; i++) {
       const login = buildings[i].login.toLowerCase();
       arr[i] = liveByLogin?.has(login)
-        ? login === "Ixotic27"
+        ? login === "ixotic27"
           ? 1.5
           : 1.0
         : 0.0;


### PR DESCRIPTION
## What does this PR do?

Fixes the live building highlight boost for the project owner. `login` is normalized to lowercase before the comparison, so comparing it to `"Ixotic27"` could never match. This PR changes the comparison to `"ixotic27"`, allowing the intended 1.5x live glow branch to run.

## Related issue

Fixes #143

## Screenshots

Visual capture depends on live presence data for `Ixotic27`, which is not deterministic in local dev. Deterministic logic check:

```txt
Before: "Ixotic27".toLowerCase() === "Ixotic27" -> false
After:  "Ixotic27".toLowerCase() === "ixotic27" -> true
```

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

## Validation

- `npm run build` -> passed after `npm run setup` generated local public env config
- `git diff --check` -> passed
- `npx eslint src/components/InstancedBuildings.tsx` -> blocked by existing unrelated lint errors already present in this file (`react-hooks/immutability` and `no-explicit-any`), not introduced by this PR
- `npm run lint` -> blocked by existing repo-wide lint errors outside this change
