### PR TITLE
fix(xp): prevent baseline XP for empty profiles

### DIFF
--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -3,7 +3,6 @@ import {
   xpDeltaForLevel,
   levelFromXp,
   tierFromLevel,
-  rankFromLevel,
   levelProgress,
   calculateLeetcodeXp,
   xpForAchievementTier,
@@ -106,6 +105,18 @@ describe("calculateLeetcodeXp", () => {
         easy_solved: 0,
         medium_solved: 0,
         hard_solved: 0,
+        contest_rating: 0,
+        lc_streak: 0,
+      })
+    ).toBe(0);
+  });
+
+  it("does not award solved XP for invalid negative solved counts", () => {
+    expect(
+      calculateLeetcodeXp({
+        easy_solved: -1,
+        medium_solved: -2,
+        hard_solved: -3,
         contest_rating: 0,
         lc_streak: 0,
       })

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -144,11 +144,15 @@ export function calculateLeetcodeXp(dev: {
   contest_rating: number;
   lc_streak: number;
 }): number {
+  const easySolved = Math.max(dev.easy_solved, 0);
+  const mediumSolved = Math.max(dev.medium_solved, 0);
+  const hardSolved = Math.max(dev.hard_solved, 0);
+
   // Fairly distribute Base XP using logarithmic scaling
   const solvedXp =
-    Math.floor(Math.log2(Math.max(dev.easy_solved, 1) + 1) * 3) +
-    Math.floor(Math.log2(Math.max(dev.medium_solved, 1) + 1) * 6) +
-    Math.floor(Math.log2(Math.max(dev.hard_solved, 1) + 1) * 12);
+    Math.floor(Math.log2(easySolved + 1) * 3) +
+    Math.floor(Math.log2(mediumSolved + 1) * 6) +
+    Math.floor(Math.log2(hardSolved + 1) * 12);
   
   // High contest ratings exponentially scale better, but bounded realistically
   const ratingXp = dev.contest_rating > 1400 


### PR DESCRIPTION
## What does this PR do?

Fixes the LeetCode XP formula so profiles with zero solved Easy/Medium/Hard counts no longer receive free baseline XP. The solved-count inputs are clamped at zero before the logarithmic score is calculated, preserving normal scaling for valid solved counts while fixing the all-zero regression that currently breaks `npm test -- --run`.

## Related issue

Fixes #186

## Screenshots

Not applicable; this is a calculation and test-suite fix.

## Checklist

- [x] `npm test -- --run` passes
- [x] `npm run lint -- src/lib/xp.ts src/lib/__tests__/xp.test.ts` passes for changed files
- [x] `npm run build` passes
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

## Notes

Full repo-wide `npm run lint` still fails on existing unrelated lint errors across scripts/admin/3D files. This PR changes only `src/lib/xp.ts` and `src/lib/__tests__/xp.test.ts`; the changed files lint clean.