### PR TITLE
fix: use includes() for multi-defense detection in raid preview — stealth cloak bypass

### DIFF
--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -118,10 +118,10 @@ export async function POST(request: Request) {
   const defenderScoutedDefense = hasSatellite 
     ? (activeDefenses.length > 0 ? activeDefenses.join(", ") : null)
     : (activeDefenses.length > 0 ? activeDefenses[0] : null);
-  const isStealthCloak = defenderScoutedDefense === "stealth_cloak";
-  const isEmpShield = defenderScoutedDefense === "emp_shield";
-  const isAntiMissile = defenderScoutedDefense === "anti_missile_system";
-  const isAntiTank = defenderScoutedDefense === "anti_tank_mines";
+  const isStealthCloak = defenderScoutedDefense?.includes("stealth_cloak") ?? false;
+  const isEmpShield = defenderScoutedDefense?.includes("emp_shield") ?? false;
+  const isAntiMissile = defenderScoutedDefense?.includes("anti_missile_system") ?? false;
+  const isAntiTank = defenderScoutedDefense?.includes("anti_tank_mines") ?? false;
 
   // Calculate scores
   const attack = calculateAttackScore({


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `POST /api/raid/preview` where the stealth cloak's protection was bypassed when the defender had multiple active defenses and the attacker had a scouting satellite.

When `hasSatellite = true`, all active defenses are joined into a single string: `"stealth_cloak, anti_missile_system"`. The strict equality checks (`=== "stealth_cloak"`) then evaluated to `false`, so:

- `isStealthCloak` was never set
- Defender's `weeklyContributions`, `appStreak`, and `weeklyKudosReceived` were passed in full to `calculateDefenseScore`
- `defender_avatar` and `defender_building_height` were revealed in the response

This completely bypassed the stealth cloak's core protection, leaking defender stats and identity to the attacker. The same bug affected `isEmpShield`, `isAntiMissile`, and `isAntiTank` for the same reason.

**Fix:**

Replaced all four strict equality checks with `.includes()`:

```typescript
// Before
const isStealthCloak = defenderScoutedDefense === "stealth_cloak";
const isEmpShield    = defenderScoutedDefense === "emp_shield";
const isAntiMissile  = defenderScoutedDefense === "anti_missile_system";
const isAntiTank     = defenderScoutedDefense === "anti_tank_mines";

// After
const isStealthCloak = defenderScoutedDefense?.includes("stealth_cloak") ?? false;
const isEmpShield    = defenderScoutedDefense?.includes("emp_shield") ?? false;
const isAntiMissile  = defenderScoutedDefense?.includes("anti_missile_system") ?? false;
const isAntiTank     = defenderScoutedDefense?.includes("anti_tank_mines") ?? false;
```

Works correctly for both paths:
- **No satellite** — `defenderScoutedDefense` is `activeDefenses[0]`, a single item string — `.includes()` matches exactly as before
- **With satellite** — joined string like `"stealth_cloak, anti_missile_system"` — `.includes()` correctly detects each item

**Files changed:**
- `src/app/api/raid/preview/route.ts` — 4 lines changed

## Related issue

Fixes #145

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above