### PR TITLE
fix: use getIsoWeekStart() in raid preview for consistent weekly cooldown

### DIFF
--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/raid";
 import type { RaidBoostItem } from "@/lib/raid";
 import { findRaidAttackerForUser } from "@/lib/raid-attacker";
+import { getIsoWeekStart } from "@/lib/week";
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -81,11 +82,7 @@ export async function POST(request: Request) {
     }
 
     // Check weekly cooldown for this target
-    const now = new Date();
-    const isoWeekStart = new Date(now);
-    const dayOfWeek = now.getDay();
-    isoWeekStart.setDate(now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1));
-    isoWeekStart.setHours(0, 0, 0, 0);
+    const isoWeekStart = getIsoWeekStart();
 
     const { count: weeklyPairCount } = await admin
       .from("raids")
@@ -206,12 +203,7 @@ export async function POST(request: Request) {
   const defenderHeight = Math.max(20, Math.min(300, defender.contributions * 0.15));
 
   // Compute available offensive consumables (must have qty > 0 and < 3 weekly uses)
-  const now2 = new Date();
-  const isoWeekStart2 = new Date(now2);
-  const dow2 = now2.getDay();
-  isoWeekStart2.setDate(now2.getDate() - dow2 + (dow2 === 0 ? -6 : 1));
-  isoWeekStart2.setHours(0, 0, 0, 0);
-  const currentWeekStr = isoWeekStart2.toISOString().split('T')[0];
+  const currentWeekStr = getIsoWeekStart().toISOString().split('T')[0];
   const availableOffensiveItems = (offensiveConsumables ?? []).filter(c => {
     if (c.quantity <= 0) return false;
     const lastReset = c.last_reset_week ? new Date(c.last_reset_week).toISOString().split('T')[0] : null;

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -82,6 +82,7 @@ export async function POST(request: Request) {
     }
 
     // Check weekly cooldown for this target
+    const now = new Date();
     const isoWeekStart = getIsoWeekStart();
 
     const { count: weeklyPairCount } = await admin


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where mobile users could see their daily missions on screen but could never complete them because server-side progress tracking always computed the **desktop** mission set.

`getDailyMissions` is deterministic but platform-sensitive: when `isMobile = true`, the two `desktopOnly` missions (`fly_score_50`, `fly_score_150`) are excluded before the Fisher-Yates shuffle, producing a different 3-mission set for the same `developerId + date`. Server-side `trackDailyMission` was hardcoded to `isMobile = false`, so it looked up the desktop set. If the desktop shuffle placed a `desktopOnly` mission in a slot that the mobile shuffle filled with e.g. `visit_building`, then `trackDailyMission(id, "visit_building")` returned early with `"not assigned today, skip"` — silently ignoring the user's action.

## Fix

Added `isMobile?: boolean` to the `trackDailyMission` `extra` parameter and forwarded it into `getDailyMissions`:

```ts
// Before
export async function trackDailyMission(
  developerId: number,
  missionId: string,
  extra?: { score?: number },
): Promise<void> {
  const missions = getDailyMissions(developerId, today);

// After
export async function trackDailyMission(
  developerId: number,
  missionId: string,
  extra?: { score?: number; isMobile?: boolean },
): Promise<void> {
  const missions = getDailyMissions(developerId, today, extra?.isMobile ?? false);
```

Each client-facing route detects the platform from the `User-Agent` header and passes it through:

```ts
// Before
await trackDailyMission(dev.id, "checkin");

// After
const isMobile = /Mobi|Android|iPhone|iPad/i.test(request.headers.get("user-agent") ?? "");
await trackDailyMission(dev.id, "checkin", { isMobile });
```

The `raid/execute` route uses `false` explicitly since raid missions are never `desktopOnly` and no `User-Agent` context is relevant there.

Works correctly for both platforms:

- **Desktop** — `isMobile = false`, pool unchanged, same shuffle as before
- **Mobile** — `isMobile = true`, `fly_score_50` and `fly_score_150` excluded before shuffle, mission set now matches what the client rendered

## Files changed

- `src/lib/dailies.ts` — `trackDailyMission` accepts `extra.isMobile`, forwards to `getDailyMissions`
- `src/app/api/checkin/route.ts` — POST now accepts `request`, detects mobile from User-Agent, passes to `trackDailyMission`
- `src/app/api/interactions/visit/route.ts` — same
- `src/app/api/interactions/kudos/route.ts` — same
- `src/app/api/raid/execute/route.ts` — explicit `isMobile: false`

## Related issue

Fixes #142 

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above