### PR TITLE
fix(raid): clamp raid history pagination

### DIFF
--- a/src/app/api/raid/history/route.ts
+++ b/src/app/api/raid/history/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { parseRaidHistoryPagination } from "@/lib/raid-history";
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -7,8 +8,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const developerId = searchParams.get("developer_id");
-  const limit = Math.min(50, parseInt(searchParams.get("limit") ?? "20", 10));
-  const offset = Math.max(0, parseInt(searchParams.get("offset") ?? "0", 10));
+  const { limit, offset } = parseRaidHistoryPagination(searchParams);
 
   if (!developerId) {
     return NextResponse.json({ error: "Missing developer_id" }, { status: 400 });

--- a/src/lib/__tests__/raid-history.test.ts
+++ b/src/lib/__tests__/raid-history.test.ts
@@ -1,0 +1,31 @@
+import {
+  RAID_HISTORY_DEFAULT_LIMIT,
+  RAID_HISTORY_MAX_LIMIT,
+  parseRaidHistoryPagination,
+} from "../raid-history";
+
+describe("parseRaidHistoryPagination", () => {
+  it("uses default pagination when query params are missing", () => {
+    const result = parseRaidHistoryPagination(new URLSearchParams());
+
+    expect(result).toEqual({ limit: RAID_HISTORY_DEFAULT_LIMIT, offset: 0 });
+  });
+
+  it("defaults invalid limit values instead of returning NaN", () => {
+    const result = parseRaidHistoryPagination(new URLSearchParams("limit=abc&offset=abc"));
+
+    expect(result).toEqual({ limit: RAID_HISTORY_DEFAULT_LIMIT, offset: 0 });
+  });
+
+  it("clamps negative limit and offset values to safe lower bounds", () => {
+    const result = parseRaidHistoryPagination(new URLSearchParams("limit=-5&offset=-10"));
+
+    expect(result).toEqual({ limit: 1, offset: 0 });
+  });
+
+  it("clamps large limits to the maximum supported page size", () => {
+    const result = parseRaidHistoryPagination(new URLSearchParams("limit=500&offset=12"));
+
+    expect(result).toEqual({ limit: RAID_HISTORY_MAX_LIMIT, offset: 12 });
+  });
+});

--- a/src/lib/raid-history.ts
+++ b/src/lib/raid-history.ts
@@ -1,0 +1,17 @@
+export const RAID_HISTORY_DEFAULT_LIMIT = 20;
+export const RAID_HISTORY_MAX_LIMIT = 50;
+
+export function parseRaidHistoryPagination(searchParams: URLSearchParams) {
+  const rawLimit = Number.parseInt(
+    searchParams.get("limit") ?? String(RAID_HISTORY_DEFAULT_LIMIT),
+    10,
+  );
+  const rawOffset = Number.parseInt(searchParams.get("offset") ?? "0", 10);
+
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(RAID_HISTORY_MAX_LIMIT, Math.max(1, rawLimit))
+    : RAID_HISTORY_DEFAULT_LIMIT;
+  const offset = Number.isFinite(rawOffset) ? Math.max(0, rawOffset) : 0;
+
+  return { limit, offset };
+}


### PR DESCRIPTION
## What does this PR do?

Clamps `/api/raid/history` pagination query params before they reach Supabase range calculation or the fallback array slice. This prevents invalid values like `limit=abc` or `limit=-5` from becoming `NaN`/negative bounds and returning an unstable page response.

## Related issue

Fixes #190

## Screenshots

N/A - API-only bug fix.

## Checklist

- [ ] `npm run lint` passes
- [x] `npx eslint src/app/api/raid/history/route.ts src/lib/raid-history.ts src/lib/__tests__/raid-history.test.ts`
- [x] `npx vitest run src/lib/__tests__/raid-history.test.ts`
- [x] `git diff --check`
- [x] `set -a; source .env.example; set +a; npm run build`
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

## How

Added a small `parseRaidHistoryPagination` helper for the raid history API defaults and bounds, then reused it in the route handler. The helper keeps the existing default page size of 20, caps the max page size at 50, floors invalid/negative offsets to 0, and ensures limits stay within a safe 1..50 range.

## Testing

Focused parser coverage verifies missing params, invalid values, negative values, and oversized limits. The production build was run with `.env.example` loaded so Supabase URL configuration is present.

## Risks / Notes

Full `npm run lint` is currently blocked by pre-existing unrelated lint errors outside this change set. The changed files pass targeted ESLint, the focused tests pass, and the production build passes with `.env.example` loaded. The linked issue is still awaiting maintainer triage/assignment, so the repository automation closed this PR until issue #190 is approved.
