### PR TITLE
fix: remove duplicate takeoff audio trigger

### DIFF
--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -230,12 +230,7 @@ export function useRaidSequence(): [RaidState, RaidActions] {
           };
         });
 
-        // Start audio
-        preloadRaidAudio();
-        playRaidSound("takeoff");
-
-        // Auto-advance intro -> flight
-        timerRef.current = setTimeout(() => setPhase("flight"), 4500);
+        
       } catch (err) {
         console.warn("[lib/useRaidSequence.ts] error:", err);
         setState((prev) => ({


### PR DESCRIPTION
## What does this PR do?

Removes duplicate raid audio and timer initialization from `executeRaid()`.

The intro phase handler already manages:
- audio preloading
- takeoff audio playback
- intro-to-flight timer transitions

Removing the duplicate logic prevents the takeoff sound from playing twice and avoids duplicate timer initialization.

## Related issue

Fixes #19

## Screenshots

N/A (no UI changes)

## Checklist

- [x] `npm run lint` executed (repository contains pre-existing lint errors/warnings unrelated to this change)
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] I have starred this repository