### PR TITLE
fix: remove hardcoded username check from bungalow building style

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -685,7 +685,7 @@ export function generateCityLayout(devs: DeveloperRecord[]): {
         litPercentage = 0.2 + composite * 0.7;
 
         // BUNGALOW OVERRIDE
-        if (dev.github_login.toLowerCase() === "ishant_27" && dev.building_style === "bungalow") {
+        if (dev.building_style === "bungalow") {
           w = 80;
           d = 60;
           height = 25;


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `src/lib/github.ts` where the bungalow building style dimensions were gated behind a hardcoded username check, making the style non-functional for every user except `ishant_27`.

Any user who purchased or selected the bungalow style from the shop received normal tower dimensions because the override block never executed for them.

## Fix

Removed the `dev.github_login.toLowerCase() === "ishant_27"` condition so bungalow dimensions apply to any developer with `building_style === "bungalow"`:

```ts
// Before
if (dev.github_login.toLowerCase() === "ishant_27" && dev.building_style === "bungalow") {
  w = 80;
  d = 60;
  height = 25;
}

// After
if (dev.building_style === "bungalow") {
  w = 80;
  d = 60;
  height = 25;
}
```

## Files changed

- `src/lib/github.ts` — 1 line changed

## Related issue

Fixes #26

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above