### PR TITLE
[Improvement] Replace eslint-disable comments and any types with proper typing #28

### DIFF
--- a/src/app/api/city/route.ts
+++ b/src/app/api/city/route.ts
@@ -4,6 +4,28 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 /**
  * @param {import('next/server').NextRequest} request
  */
+
+type DeveloperRow = {
+  id: number;
+
+  kudos_count?: number | null;
+  visit_count?: number | null;
+
+  app_streak?: number | null;
+  raid_xp?: number | null;
+
+  current_week_contributions?: number | null;
+  current_week_kudos_given?: number | null;
+  current_week_kudos_received?: number | null;
+
+  rabbit_completed?: boolean | null;
+
+  xp_total?: number | null;
+  xp_level?: number | null;
+
+  [key: string]: unknown;
+};
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const from = Math.max(0, parseInt(searchParams.get("from") ?? "0", 10));
@@ -27,9 +49,8 @@ export async function GET(request: Request) {
     sb.from("city_stats").select("*").eq("id", 1).single(),
   ]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const devs = (devsResult.data ?? []) as Record<string, any>[];
-  const devIds = devs.map((d: Record<string, any>) => d.id);
+  const devs = (devsResult.data ?? []) as DeveloperRow[];
+  const devIds = devs.map((d) => d.id);
 
   if (devIds.length === 0) {
     return NextResponse.json(
@@ -118,8 +139,9 @@ export async function GET(request: Request) {
   // Build a quick style map
   const styleMap: Record<number, string> = {};
   for (const row of customizationsResult.data ?? []) {
-    if (row.item_id === "building_style" && typeof (row.config as any)?.style === "string") {
-      styleMap[row.developer_id] = (row.config as any).style;
+    const config = row.config as Record<string, unknown>;
+    if (row.item_id === "building_style" && typeof config.style === "string") {
+      styleMap[row.developer_id] = config.style;
     }
   }
 

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -23,6 +23,9 @@ type RaidDefender = {
   current_week_kudos_received?: number | null;
   last_raided_at?: string | null;
   active_defenses?: unknown;
+  public_repos?: number | null;
+  total_stars?: number | null;
+  kudos_count?: number | null;
 };
 
 /**
@@ -234,7 +237,10 @@ export async function POST(request: Request) {
   }
 
   // Estimate building height from contributions
-  const defenderHeight = Math.max(20, Math.min(300, defender.contributions * 0.15));
+  const defenderHeight = Math.max(
+    20,
+    Math.min(300, (defender.contributions ?? 0) * 0.15)
+  );
 
   // Compute available offensive consumables (must have qty > 0 and < 3 weekly uses)
   const currentWeekStr = getIsoWeekStart().toISOString().split('T')[0];
@@ -264,7 +270,7 @@ export async function POST(request: Request) {
     defense_score: defense.total,
     attack_breakdown: attack.breakdown,
     defense_breakdown: defense.breakdown,
-    attacker_login: attacker.github_login,
+    attacker_login: attacker.github_login ?? "",
     defender_login: defender.github_login,
     attacker_avatar: attacker.avatar_url ?? null,
     defender_avatar: isStealthCloak ? null : defender.avatar_url ?? null,

--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -12,6 +12,19 @@ import type { RaidBoostItem } from "@/lib/raid";
 import { findRaidAttackerForUser } from "@/lib/raid-attacker";
 import { getIsoWeekStart } from "@/lib/week";
 
+type RaidDefender = {
+  id: number;
+  claimed: boolean;
+  app_streak?: number | null;
+  avatar_url?: string | null;
+  github_login: string;
+  contributions?: number | null;
+  current_week_contributions?: number | null;
+  current_week_kudos_received?: number | null;
+  last_raided_at?: string | null;
+  active_defenses?: unknown;
+};
+
 /**
  * @param {import('next/server').NextRequest} request
  */
@@ -71,8 +84,8 @@ export async function POST(request: Request) {
     .select("id, claimed, app_streak, avatar_url, github_login, contributions, current_week_contributions, current_week_kudos_received, last_raided_at, active_defenses")
     .eq("github_login", target_login.toLowerCase())
     .single();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const defender = defenderRes.data as Record<string, any> | null;
+
+  const defender = defenderRes.data as RaidDefender | null;
 
   if (!defender) {
     return NextResponse.json({ error: "Target not found" }, { status: 404 });
@@ -131,9 +144,9 @@ export async function POST(request: Request) {
   // Active Defenses
   const activeDefenses: string[] = Array.isArray(defender.active_defenses) ? defender.active_defenses : [];
   const hasSatellite = (attacker.owned_items ?? []).includes("scouting_satellite");
-  
+
   // If attacker has Tactical Satellite, reveal all defenses. Otherwise just the first one.
-  const defenderScoutedDefense = hasSatellite 
+  const defenderScoutedDefense = hasSatellite
     ? (activeDefenses.length > 0 ? activeDefenses.join(", ") : null)
     : (activeDefenses.length > 0 ? activeDefenses[0] : null);
   const isStealthCloak = defenderScoutedDefense?.includes("stealth_cloak") ?? false;

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -4,6 +4,60 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 import { fetchLeetCodeAboutMe, parseMaxStreak } from "@/lib/leetcode";
 import { calculateLeetcodeXp } from "@/lib/xp";
 
+type TagProblem = {
+    tagName: string;
+    problemsSolved: number;
+};
+
+type LeetCodeUserStats = {
+    username?: string;
+    maxStreak?: number;
+    badges?: {
+        id: string;
+        name: string;
+        icon: string;
+        displayName: string;
+    }[];
+    profile?: {
+        realName?: string;
+        userAvatar?: string;
+        aboutMe?: string;
+        ranking?: number;
+        reputation?: number;
+        countryName?: string;
+        school?: string;
+        company?: string;
+        websites?: string[];
+        linkedinUrl?: string;
+        twitterUrl?: string;
+        githubUrl?: string;
+    };
+    submitStats?: {
+        acSubmissionNum?: { difficulty: string; count: number }[];
+        totalSubmissionNum?: { difficulty: string; count: number }[];
+    };
+    tagProblemCounts?: {
+        advanced?: TagProblem[];
+        intermediate?: TagProblem[];
+        fundamental?: TagProblem[];
+    };
+};
+
+type ContestStats = {
+    rating?: number;
+    globalRanking?: number;
+    attendedContestsCount?: number;
+    topPercentage?: number;
+    badge?: {
+        name?: string;
+    };
+};
+
+type StreakStats = {
+    streak?: number;
+    totalActiveDays?: number;
+};
+
 /**
  * @param {import('next/server').NextRequest} req
  */
@@ -51,9 +105,9 @@ export async function POST(req: Request) {
         }
 
         // Fetch full LC stats: easy/medium/hard, contest rating, streak
-        let lcUserStats: any = null;
-        let lcContestStats = null;
-        let lcStreakStats = null;
+        let lcUserStats: LeetCodeUserStats | null = null;
+        let lcContestStats: ContestStats | null = null;
+        let lcStreakStats: StreakStats | null = null;
         try {
             const currentYear = new Date().getFullYear();
             let aliases = "";
@@ -167,9 +221,9 @@ export async function POST(req: Request) {
             ...(tagCounts?.intermediate ?? []),
             ...(tagCounts?.fundamental ?? []),
         ]
-            .sort((a: any, b: any) => b.problemsSolved - a.problemsSolved)
+            .sort((a: TagProblem, b: TagProblem) => b.problemsSolved - a.problemsSolved)
             .slice(0, 20)
-            .map((t: any) => ({ name: t.tagName, solved: t.problemsSolved }));
+            .map((t: TagProblem) => ({ name: t.tagName, solved: t.problemsSolved }));
 
         // litPercentage = how lit the building windows are
         // For LC: active_days / 365 (capped at 1.0), same mechanic as LeetCode City uses commit frequency
@@ -267,7 +321,9 @@ export async function POST(req: Request) {
 
         return NextResponse.json({ success: true, leetcode_username: leetcode_username.toLowerCase() });
 
-    } catch (err: any) {
-        return NextResponse.json({ error: err.message }, { status: 500 });
+    } catch (err: unknown) {
+        const message =
+            err instanceof Error ? err.message : "Internal server error";
+        return NextResponse.json({ error: message }, { status: 500 });
     }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
   generateCityLayout,
   DISTRICT_NAMES,
   DISTRICT_COLORS,
+  type DeveloperRecord,
   type CityBuilding,
   type CityPlaza,
   type CityDecoration,
@@ -84,7 +85,19 @@ import {
 } from "@/lib/himetrica";
 
 import { applyLocalStorageOverrides } from "@/lib/cityOverrides";
-import { CityDeveloper } from "./types/city";
+
+type CityDeveloperRecord = DeveloperRecord & {
+  loadout?: unknown;
+  custom_color?: string | null;
+  owned_items?: string[];
+  billboard_images?: string[];
+  building_style?: string | null;
+};
+interface CityStats {
+  total_developers: number;
+  total_contributions: number;
+  total_stars?: number;
+}
 
 const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
   ssr: false,
@@ -219,6 +232,7 @@ const DEV_CLASSES = [
   "404 Brain Not Found",
   "Sudo Make Me A Sandwich",
 ];
+
 function getDevClass(login: string) {
   let h = 0;
   for (let i = 0; i < login.length; i++)
@@ -227,18 +241,6 @@ function getDevClass(login: string) {
     ((h % DEV_CLASSES.length) + DEV_CLASSES.length) % DEV_CLASSES.length
   ];
 }
-
-interface CityStats {
-  total_developers: number;
-  total_contributions: number;
-  total_stars?: number;
-}
-
-type CityDeveloper = {
-  id: number;
-  github_login: string;
-  [key: string]: unknown;
-};
 
 // Milestones that trigger 24h celebration effects
 const CELEBRATION_MILESTONES = [
@@ -542,7 +544,7 @@ function HomeContent() {
   const failedUsernamesRef = useRef<Map<string, string>>(new Map()); // username -> error code
   const [buildings, setBuildings] = useState<CityBuilding[]>([]);
   // Keep raw dev records so we can inject new devs and regenerate layout locally
-  const rawDevsRef = useRef<CityDeveloper[]>([]);
+  const rawDevsRef = useRef<CityDeveloperRecord[]>([]);
   const [plazas, setPlazas] = useState<CityPlaza[]>([]);
   const [decorations, setDecorations] = useState<CityDecoration[]>([]);
   const [river, setRiver] = useState<CityRiver | null>(null);
@@ -1571,8 +1573,11 @@ function HomeContent() {
     if (bustCache) clearCityCache();
     const cacheBust = bustCache ? `?_t=${Date.now()}` : "";
 
-    let allDevs: CityDeveloper[] = [];
-    let cityStats: CityStats | null = null;
+    let allDevs: CityDeveloperRecord[] = [];
+    let cityStats: CityStats = {
+      total_developers: 0,
+      total_contributions: 0,
+    };
 
     // Try pre-computed snapshot first (disabled — snapshot bucket doesn't exist yet for LC city)
     // try {
@@ -1700,8 +1705,11 @@ function HomeContent() {
         setLoadProgress(10);
 
 
-        let allDevs: CityDeveloper[] = [];
-        let cityStats: CityStats | null = null;
+        let allDevs: CityDeveloperRecord[] = [];
+        let cityStats: CityStats = {
+          total_developers: 0,
+          total_contributions: 0,
+        };
 
         // Try pre-computed snapshot first (disabled — snapshot bucket doesn't exist yet for LC city)
         // try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,6 +84,7 @@ import {
 } from "@/lib/himetrica";
 
 import { applyLocalStorageOverrides } from "@/lib/cityOverrides";
+import { CityDeveloper } from "./types/city";
 
 const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
   ssr: false,
@@ -232,6 +233,12 @@ interface CityStats {
   total_contributions: number;
   total_stars?: number;
 }
+
+type CityDeveloper = {
+  id: number;
+  github_login: string;
+  [key: string]: unknown;
+};
 
 // Milestones that trigger 24h celebration effects
 const CELEBRATION_MILESTONES = [
@@ -535,8 +542,7 @@ function HomeContent() {
   const failedUsernamesRef = useRef<Map<string, string>>(new Map()); // username -> error code
   const [buildings, setBuildings] = useState<CityBuilding[]>([]);
   // Keep raw dev records so we can inject new devs and regenerate layout locally
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawDevsRef = useRef<any[]>([]);
+  const rawDevsRef = useRef<CityDeveloper[]>([]);
   const [plazas, setPlazas] = useState<CityPlaza[]>([]);
   const [decorations, setDecorations] = useState<CityDecoration[]>([]);
   const [river, setRiver] = useState<CityRiver | null>(null);
@@ -551,13 +557,13 @@ function HomeContent() {
   const [feedback, setFeedback] = useState<{
     type: "loading" | "error";
     code?:
-      | "not-found"
-      | "org"
-      | "no-activity"
-      | "rate-limit"
-      | "github-rate-limit"
-      | "network"
-      | "generic";
+    | "not-found"
+    | "org"
+    | "no-activity"
+    | "rate-limit"
+    | "github-rate-limit"
+    | "network"
+    | "generic";
     username?: string;
     raw?: string;
   } | null>(null);
@@ -577,7 +583,7 @@ function HomeContent() {
     setWeatherMode(next);
     try {
       localStorage.setItem("leetcodecity_weather_mode", next);
-    } catch {}
+    } catch { }
   };
 
   useEffect(() => {
@@ -592,13 +598,13 @@ function HomeContent() {
       if (savedCycle === "0") {
         setDayNightCycleActive(false);
       }
-    } catch {}
+    } catch { }
     try {
       const savedWeather = localStorage.getItem("leetcodecity_weather_mode");
       if (savedWeather === "sunny" || savedWeather === "rainy" || savedWeather === "windy" || savedWeather === "stormy" || savedWeather === "snowy") {
         setWeatherMode(savedWeather as any);
       }
-    } catch {}
+    } catch { }
   }, []);
 
   const [hud, setHud] = useState({ speed: 0, altitude: 0 });
@@ -675,10 +681,10 @@ function HomeContent() {
             try {
               if (d.hasKey) localStorage.setItem("leetcodecity_has_vscode_key", "1");
               else localStorage.removeItem("leetcodecity_has_vscode_key");
-            } catch {}
+            } catch { }
           }
         })
-        .catch(() => {});
+        .catch(() => { });
     }
   }, [codingPanelOpen, hasVsCodeKey]);
   const [session, setSession] = useState<Session | null>(null);
@@ -804,7 +810,7 @@ function HomeContent() {
         .then((d) => {
           if (d?.stargazers_count != null) setGithubStars(d.stargazers_count);
         })
-        .catch(() => {});
+        .catch(() => { });
     };
     const fetchDiscord = () => {
       fetch("https://discord.com/api/v9/invites/tTq4wjfG?with_counts=true")
@@ -813,7 +819,7 @@ function HomeContent() {
           if (d?.approximate_member_count != null)
             setDiscordMembers(d.approximate_member_count);
         })
-        .catch(() => {});
+        .catch(() => { });
     };
     fetchStars();
     fetchDiscord();
@@ -850,13 +856,13 @@ function HomeContent() {
         prev.map((b) =>
           b.login === defenderLogin
             ? {
-                ...b,
-                active_raid_tag: {
-                  attacker_login: attackerLogin,
-                  tag_style: tagStyle,
-                  expires_at: new Date(Date.now() + 7 * 86400000).toISOString(),
-                },
-              }
+              ...b,
+              active_raid_tag: {
+                attacker_login: attackerLogin,
+                tag_style: tagStyle,
+                expires_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+              },
+            }
             : b,
         ),
       );
@@ -870,7 +876,7 @@ function HomeContent() {
       .then((data) => {
         if (Array.isArray(data) && data.length > 0) setSkyAds(data);
       })
-      .catch(() => {});
+      .catch(() => { });
   }, []);
 
   // Derived — second focused building for dual-focus camera
@@ -978,7 +984,7 @@ function HomeContent() {
                 // Small delay so the UI has settled after login redirect
                 setTimeout(() => setShowLinkModal(true), 800);
               }
-            } catch {}
+            } catch { }
           }
         }
       },
@@ -991,7 +997,7 @@ function HomeContent() {
   useEffect(() => {
     if (!session || !linkedLeetCodeUsername) return;
     const ping = () =>
-      fetch("/api/lc-pulse", { method: "POST" }).catch(() => {});
+      fetch("/api/lc-pulse", { method: "POST" }).catch(() => { });
     ping(); // fire immediately on account link / page load
     const id = setInterval(ping, 5 * 60 * 1000); // every 5 minutes
     return () => clearInterval(id);
@@ -1109,7 +1115,7 @@ function HomeContent() {
       .then((data) => {
         if (data?.vehicle) setFlyVehicle(data.vehicle);
       })
-      .catch(() => {});
+      .catch(() => { });
   }, [sessionUserId]);
 
   // Load theme from DB when logged in (overrides localStorage)
@@ -1130,7 +1136,7 @@ function HomeContent() {
           localStorage.setItem("leetcodecity_theme", String(data.city_theme));
         }
       })
-      .catch(() => {});
+      .catch(() => { });
   }, [sessionUserId]);
 
   // Cycle theme: save to localStorage + sync to DB if logged in
@@ -1143,7 +1149,7 @@ function HomeContent() {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ city_theme: next }),
-        }).catch(() => {});
+        }).catch(() => { });
       }
       return next;
     });
@@ -1495,7 +1501,7 @@ function HomeContent() {
         if (best >= 5 && serverProgress < 5 && localProgress >= 5) {
           setRabbitCompletion(true);
         }
-      } catch {}
+      } catch { }
     })();
   }, [session]);
 
@@ -1565,10 +1571,8 @@ function HomeContent() {
     if (bustCache) clearCityCache();
     const cacheBust = bustCache ? `?_t=${Date.now()}` : "";
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let allDevs: any[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let cityStats: any = null;
+    let allDevs: CityDeveloper[] = [];
+    let cityStats: CityStats | null = null;
 
     // Try pre-computed snapshot first (disabled — snapshot bucket doesn't exist yet for LC city)
     // try {
@@ -1617,7 +1621,7 @@ function HomeContent() {
     }
 
     if (allDevs.length === 0) return null;
- 
+
     // Apply localStorage overrides (style, color, billboard, loadout) — TTL 20 min
     applyLocalStorageOverrides(allDevs);
 
@@ -1695,10 +1699,9 @@ function HomeContent() {
         setLoadStage("fetching");
         setLoadProgress(10);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let allDevs: any[] = [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let cityStats: any = null;
+
+        let allDevs: CityDeveloper[] = [];
+        let cityStats: CityStats | null = null;
 
         // Try pre-computed snapshot first (disabled — snapshot bucket doesn't exist yet for LC city)
         // try {
@@ -1888,7 +1891,7 @@ function HomeContent() {
           currentPB,
           parseInt(localStorage.getItem("leetcodecity_fly_pb") || "0", 10) || 0,
         );
-      } catch {}
+      } catch { }
       // Only show "New PB!" if there WAS a previous best to beat (not on first-ever flight)
       const isNewPB = currentPB > 0 && finalScore > currentPB;
       // Update personal best
@@ -1897,7 +1900,7 @@ function HomeContent() {
         flyPersonalBestRef.current = finalScore;
         try {
           localStorage.setItem("leetcodecity_fly_pb", String(finalScore));
-        } catch {}
+        } catch { }
       }
       // Update fly history (streak, days played, per-seed scores)
       if (finalScore > 0) {
@@ -1912,11 +1915,11 @@ function HomeContent() {
           const hist = raw
             ? JSON.parse(raw)
             : {
-                seeds: {},
-                currentStreak: 0,
-                longestStreak: 0,
-                lastPlayedSeed: "",
-              };
+              seeds: {},
+              currentStreak: 0,
+              longestStreak: 0,
+              lastPlayedSeed: "",
+            };
           const prev = hist.seeds[currentSeed];
           hist.seeds[currentSeed] = {
             bestScore: Math.max(prev?.bestScore ?? 0, finalScore),
@@ -1946,7 +1949,7 @@ function HomeContent() {
             "leetcodecity_fly_history",
             JSON.stringify(hist),
           );
-        } catch {}
+        } catch { }
       }
       // Exit fly immediately (don't block on API)
       setFlyMode(false);
@@ -1997,7 +2000,7 @@ function HomeContent() {
                 );
               }
             })
-            .catch(() => {});
+            .catch(() => { });
         }
       }
     },
@@ -2441,8 +2444,8 @@ function HomeContent() {
   // Determine if the logged-in user has their synced building
   const myBuilding = linkedLeetCodeUsername
     ? buildings.find(
-        (b) => b.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase(),
-      )
+      (b) => b.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase(),
+    )
     : null;
 
   const needsToLink = !!session && !linkedLeetCodeUsername;
@@ -2536,7 +2539,7 @@ function HomeContent() {
       .then((data) => {
         if (Array.isArray(data)) setMilestoneCelebrations(data);
       })
-      .catch(() => {});
+      .catch(() => { });
   }, []);
 
   // Record milestone when crossed
@@ -2567,7 +2570,7 @@ function HomeContent() {
           ]);
         }
       })
-      .catch(() => {});
+      .catch(() => { });
   }, [stats.total_developers, milestoneCelebrations]);
 
   // Feature 1: Daily Challenge Nudge — show after load if user has history but hasn't played today
@@ -2591,7 +2594,7 @@ function HomeContent() {
         // Auto-dismiss after 15s
         const autoDismiss = setTimeout(() => setShowDailyNudge(false), 15000);
         dailyNudgeTimerRef.current = autoDismiss;
-      } catch {}
+      } catch { }
     }, 2000);
     return () => clearTimeout(dailyNudgeTimerRef.current);
   }, [loadStage, isMobile, session, flyMode, introMode]);
@@ -2615,7 +2618,7 @@ function HomeContent() {
         setShowFlyHint(false);
         try {
           localStorage.setItem("leetcodecity_fly_hint_seen", "1");
-        } catch {}
+        } catch { }
       }, 10000);
       flyHintTimerRef.current = autoDismiss;
     }, 5000);
@@ -2761,7 +2764,7 @@ function HomeContent() {
         }}
         introMode={introMode}
         onIntroEnd={endIntro}
-        onFocusInfo={() => {}}
+        onFocusInfo={() => { }}
         ghostPreviewLogin={ghostPreviewLogin}
         liveByLogin={liveByLogin}
         cityEnergy={cityEnergy}
@@ -3205,7 +3208,7 @@ function HomeContent() {
                 setShowFlyControls(false);
                 try {
                   localStorage.setItem("leetcodecity_fly_controls_seen", "1");
-                } catch {}
+                } catch { }
                 // Resume the paused flight by dispatching Space keydown
                 window.dispatchEvent(
                   new KeyboardEvent("keydown", {
@@ -3291,15 +3294,14 @@ function HomeContent() {
                   const next = !prev;
                   try {
                     localStorage.setItem("leetcodecity_daynight_cycle", next ? "1" : "0");
-                  } catch {}
+                  } catch { }
                   return next;
                 });
               }}
-              className={`btn-press flex items-center gap-1.5 border-[3px] px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors ${
-                dayNightCycleActive
-                  ? "border-amber-500/80 bg-amber-500/10 text-amber-400 hover:border-amber-400"
-                  : "border-border bg-bg/70 text-cream hover:border-border-light"
-              }`}
+              className={`btn-press flex items-center gap-1.5 border-[3px] px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors ${dayNightCycleActive
+                ? "border-amber-500/80 bg-amber-500/10 text-amber-400 hover:border-amber-400"
+                : "border-border bg-bg/70 text-cream hover:border-border-light"
+                }`}
             >
               <span style={{ color: theme.accent }}>&#9654;</span>
               <span>{dayNightCycleActive ? "CYCLE ON" : "CYCLE OFF"}</span>
@@ -3708,7 +3710,7 @@ function HomeContent() {
                                     if (data.key) {
                                       setVsCodeKey(data.key);
                                       setHasVsCodeKey(true);
-                                      try { localStorage.setItem("leetcodecity_has_vscode_key", "1"); } catch {}
+                                      try { localStorage.setItem("leetcodecity_has_vscode_key", "1"); } catch { }
                                       navigator.clipboard.writeText(data.key);
                                       setVsCodeKeyCopied(true);
                                       setTimeout(
@@ -3797,117 +3799,117 @@ function HomeContent() {
             <div className="hidden sm:flex sm:justify-center w-full">
               {MILESTONE_MODE === "stars"
                 ? // ── LeetCode Stars mode ──
-                  (() => {
-                    const MILESTONES = [100, 250, 500, 1000, 2000, 5000];
-                    const current = githubStars;
-                    const target = MILESTONES.find((m) => current < m) || 10000;
-                    const pct = Math.min(100, (current / target) * 100);
-                    const isDone = current >= target;
+                (() => {
+                  const MILESTONES = [100, 250, 500, 1000, 2000, 5000];
+                  const current = githubStars;
+                  const target = MILESTONES.find((m) => current < m) || 10000;
+                  const pct = Math.min(100, (current / target) * 100);
+                  const isDone = current >= target;
 
-                    return (
-                      <div className="pointer-events-auto mt-4 w-full max-w-[320px] rounded border border-border bg-bg/80 p-3 pt-2 shadow-xl backdrop-blur-md">
-                        <div className="mb-1.5 flex items-center justify-between text-[8px] uppercase tracking-widest text-cream">
-                          <span>
-                            {isDone
-                              ? "GOAL REACHED"
-                              : `ROAD TO ${target} STARS`}
+                  return (
+                    <div className="pointer-events-auto mt-4 w-full max-w-[320px] rounded border border-border bg-bg/80 p-3 pt-2 shadow-xl backdrop-blur-md">
+                      <div className="mb-1.5 flex items-center justify-between text-[8px] uppercase tracking-widest text-cream">
+                        <span>
+                          {isDone
+                            ? "GOAL REACHED"
+                            : `ROAD TO ${target} STARS`}
+                        </span>
+                        <span style={{ color: theme.accent }}>
+                          {Math.max(0, target - current).toLocaleString()} TO
+                          GO
+                        </span>
+                      </div>
+                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg shadow-inner">
+                        <div
+                          className="h-full rounded-full transition-all duration-1000 ease-out"
+                          style={{
+                            width: `${pct}%`,
+                            backgroundColor: theme.accent,
+                            boxShadow: `0 0 10px ${theme.accent}`,
+                          }}
+                        />
+                      </div>
+                      <div className="mt-2 flex items-center justify-between text-[8px] text-dim uppercase tracking-wider">
+                        <span>
+                          {current.toLocaleString()} /{" "}
+                          {target.toLocaleString()}
+                        </span>
+                        <a
+                          href="https://github.com/Ixotic27/The-Leetcode-City"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[#ffa116] hover:underline"
+                        >
+                          Source code
+                        </a>
+                        {" | "}
+                        <a
+                          href="https://github.com/srizzon/git-city"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[#ffa116] hover:underline"
+                        >
+                          Original Repo
+                        </a>
+                      </div>
+                    </div>
+                  );
+                })()
+                : // ── Total Developers mode ──
+                (() => {
+                  const MILESTONES = [10000, 20000, 50000, 100000];
+                  const count = stats.total_developers;
+                  if (count <= 0) return null;
+
+                  const target = MILESTONES.find((m) => count < m);
+                  if (!target) return null;
+                  const prev =
+                    MILESTONES[MILESTONES.indexOf(target) - 1] ?? 0;
+                  const progress = ((count - prev) / (target - prev)) * 100;
+                  const remaining = target - count;
+                  const label =
+                    target >= 1000
+                      ? `${target / 1000}K`
+                      : target.toLocaleString();
+                  return (
+                    <div className="w-full max-w-sm">
+                      <div className="border-[2px] border-border bg-bg/80 px-4 py-3 backdrop-blur-sm">
+                        <div className="mb-2 flex items-baseline justify-between">
+                          <span
+                            className="text-[9px] tracking-wider"
+                            style={{ color: theme.accent }}
+                          >
+                            ROAD TO {label}
                           </span>
-                          <span style={{ color: theme.accent }}>
-                            {Math.max(0, target - current).toLocaleString()} TO
-                            GO
+                          <span className="text-[9px] text-cream/60">
+                            {remaining.toLocaleString()} to go
                           </span>
                         </div>
-                        <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg shadow-inner">
+                        <div className="relative h-2.5 w-full overflow-hidden border-[2px] border-border bg-bg">
                           <div
-                            className="h-full rounded-full transition-all duration-1000 ease-out"
+                            className="absolute inset-y-0 left-0 transition-all duration-1000"
                             style={{
-                              width: `${pct}%`,
+                              width: `${progress}%`,
                               backgroundColor: theme.accent,
-                              boxShadow: `0 0 10px ${theme.accent}`,
+                              boxShadow: `0 0 8px ${theme.accent}60`,
                             }}
                           />
                         </div>
-                        <div className="mt-2 flex items-center justify-between text-[8px] text-dim uppercase tracking-wider">
-                          <span>
-                            {current.toLocaleString()} /{" "}
-                            {target.toLocaleString()}
+                        <div className="mt-2 flex items-baseline justify-between">
+                          <span className="text-[10px] text-cream">
+                            {count.toLocaleString()}{" "}
+                            <span className="text-cream/40">
+                              / {target.toLocaleString()}
+                            </span>
                           </span>
-                          <a
-                            href="https://github.com/Ixotic27/The-Leetcode-City"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-[#ffa116] hover:underline"
-                          >
-                            Source code
-                          </a>
-                          {" | "}
-                          <a
-                            href="https://github.com/srizzon/git-city"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-[#ffa116] hover:underline"
-                          >
-                            Original Repo
-                          </a>
+                          <span className="text-[8px] text-cream/40 normal-case">
+                            Something unlocks at {label}...
+                          </span>
                         </div>
                       </div>
-                    );
-                  })()
-                : // ── Total Developers mode ──
-                  (() => {
-                    const MILESTONES = [10000, 20000, 50000, 100000];
-                    const count = stats.total_developers;
-                    if (count <= 0) return null;
-
-                    const target = MILESTONES.find((m) => count < m);
-                    if (!target) return null;
-                    const prev =
-                      MILESTONES[MILESTONES.indexOf(target) - 1] ?? 0;
-                    const progress = ((count - prev) / (target - prev)) * 100;
-                    const remaining = target - count;
-                    const label =
-                      target >= 1000
-                        ? `${target / 1000}K`
-                        : target.toLocaleString();
-                    return (
-                      <div className="w-full max-w-sm">
-                        <div className="border-[2px] border-border bg-bg/80 px-4 py-3 backdrop-blur-sm">
-                          <div className="mb-2 flex items-baseline justify-between">
-                            <span
-                              className="text-[9px] tracking-wider"
-                              style={{ color: theme.accent }}
-                            >
-                              ROAD TO {label}
-                            </span>
-                            <span className="text-[9px] text-cream/60">
-                              {remaining.toLocaleString()} to go
-                            </span>
-                          </div>
-                          <div className="relative h-2.5 w-full overflow-hidden border-[2px] border-border bg-bg">
-                            <div
-                              className="absolute inset-y-0 left-0 transition-all duration-1000"
-                              style={{
-                                width: `${progress}%`,
-                                backgroundColor: theme.accent,
-                                boxShadow: `0 0 8px ${theme.accent}60`,
-                              }}
-                            />
-                          </div>
-                          <div className="mt-2 flex items-baseline justify-between">
-                            <span className="text-[10px] text-cream">
-                              {count.toLocaleString()}{" "}
-                              <span className="text-cream/40">
-                                / {target.toLocaleString()}
-                              </span>
-                            </span>
-                            <span className="text-[8px] text-cream/40 normal-case">
-                              Something unlocks at {label}...
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })()}
+                    </div>
+                  );
+                })()}
             </div>
 
             {/* Search / Welcome CTA takeover */}
@@ -4050,7 +4052,7 @@ function HomeContent() {
                           setFlyPersonalBest(
                             parseInt(
                               localStorage.getItem("leetcodecity_fly_pb") ||
-                                "0",
+                              "0",
                               10,
                             ) || 0,
                           );
@@ -4105,7 +4107,7 @@ function HomeContent() {
                                   "leetcodecity_fly_hint_seen",
                                   "1",
                                 );
-                              } catch {}
+                              } catch { }
                             }}
                             className="mt-2 px-3 py-1 text-[9px] text-bg"
                             style={{ backgroundColor: theme.accent }}
@@ -4254,8 +4256,8 @@ function HomeContent() {
                           className="flex items-center gap-1.5 border-[3px] border-border bg-bg/80 px-3 py-1.5 text-[10px] text-cream normal-case backdrop-blur-sm transition-colors hover:border-border-light"
                           style={
                             streakData &&
-                            streakData.streak > 0 &&
-                            streakData.checked_in
+                              streakData.streak > 0 &&
+                              streakData.checked_in
                               ? { animation: "streak-pulse 1.5s ease-in-out 2" }
                               : undefined
                           }
@@ -4383,8 +4385,8 @@ function HomeContent() {
                       className="btn-press flex items-center gap-1.5 border-[2px] border-border px-3 py-1.5 text-[10px] normal-case transition-colors active:bg-white/5"
                       style={
                         streakData &&
-                        streakData.streak > 0 &&
-                        streakData.checked_in
+                          streakData.streak > 0 &&
+                          streakData.checked_in
                           ? { animation: "streak-pulse 1.5s ease-in-out 2" }
                           : undefined
                       }
@@ -4771,13 +4773,13 @@ function HomeContent() {
                     { label: "Solved", value: solved.toLocaleString() },
                     ...(easySolved || medSolved || hardSolved
                       ? [
-                          { label: "Easy", value: easySolved.toLocaleString() },
-                          {
-                            label: "Medium",
-                            value: medSolved.toLocaleString(),
-                          },
-                          { label: "Hard", value: hardSolved.toLocaleString() },
-                        ]
+                        { label: "Easy", value: easySolved.toLocaleString() },
+                        {
+                          label: "Medium",
+                          value: medSolved.toLocaleString(),
+                        },
+                        { label: "Hard", value: hardSolved.toLocaleString() },
+                      ]
                       : []),
                     {
                       label: "Streak",
@@ -5208,12 +5210,12 @@ function HomeContent() {
             key: keyof CityBuilding;
             invert?: boolean;
           }[] = [
-            { label: "City Rank", key: "rank", invert: true },
-            { label: "Solved", key: "contributions" },
-            { label: "Reputation", key: "total_stars" },
-            { label: "LC Rank", key: "public_repos", invert: true },
-            { label: "Kudos", key: "kudos_count" },
-          ];
+              { label: "City Rank", key: "rank", invert: true },
+              { label: "Solved", key: "contributions" },
+              { label: "Reputation", key: "total_stars" },
+              { label: "LC Rank", key: "public_repos", invert: true },
+              { label: "Kudos", key: "kudos_count" },
+            ];
           let totalAWins = 0;
           let totalBWins = 0;
           const cmpRows = compareStatDefs.map((s) => {

--- a/src/app/types/city.ts
+++ b/src/app/types/city.ts
@@ -1,0 +1,10 @@
+export interface CityDeveloper {
+    id: number;
+    github_login: string;
+    [key: string]: unknown;
+}
+
+export interface CityStats {
+    total_developers: number;
+    total_contributions: number;
+}

--- a/src/lib/raid-attacker.ts
+++ b/src/lib/raid-attacker.ts
@@ -8,8 +8,13 @@ type DeveloperRow = {
   claimed?: boolean | null;
   claimed_by?: string | null;
 
-  github_login?: string | null;
+  github_login: string;
   avatar_url?: string | null;
+
+  contributions?: number | null;
+  public_repos?: number | null;
+  total_stars?: number | null;
+  kudos_count?: number | null;
 
   app_streak?: number | null;
   raid_xp?: number | null;
@@ -21,6 +26,7 @@ type DeveloperRow = {
 
   owned_items?: string[];
 };
+
 type DeveloperResult = PromiseLike<{ data: DeveloperRow | null }>;
 type DeveloperQuery = {
   eq(column: string, value: string | number | boolean): DeveloperQuery;

--- a/src/lib/raid-attacker.ts
+++ b/src/lib/raid-attacker.ts
@@ -2,11 +2,24 @@ import type { User } from "@supabase/supabase-js";
 
 type AuthUser = Pick<User, "id" | "user_metadata" | "identities">;
 // Supabase route handlers select different developer column sets for preview and execute.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DeveloperRow = Record<string, any> & {
+
+type DeveloperRow = {
   id: number;
   claimed?: boolean | null;
   claimed_by?: string | null;
+
+  github_login?: string | null;
+  avatar_url?: string | null;
+
+  app_streak?: number | null;
+  raid_xp?: number | null;
+  xp_level?: number | null;
+
+  current_week_contributions?: number | null;
+  current_week_kudos_given?: number | null;
+  current_week_kudos_received?: number | null;
+
+  owned_items?: string[];
 };
 type DeveloperResult = PromiseLike<{ data: DeveloperRow | null }>;
 type DeveloperQuery = {


### PR DESCRIPTION
## What does this PR do?

Improves TypeScript type safety by replacing unsafe `any` and `Record<string, any>` usages with explicit interfaces and typed structures across the city API, LeetCode verification flow, and frontend city data handling.

### Changes made

* Replaced `Record<string, any>` assertions in `src/app/api/city/route.ts` with typed developer row definitions.
* Added typed interfaces for LeetCode profile and tag statistics in `src/app/api/verify-leetcode/route.ts`.
* Replaced `any` callback parameters and error handling with safer typed alternatives.
* Replaced `any[]` collections and `any` state placeholders in `src/app/page.tsx` with typed city developer and city stats structures.
* Removed unnecessary `@typescript-eslint/no-explicit-any` suppression comments in the affected files.

## Related issue

Fixes #28 

## Checklist

* [x] `npm run lint` passes for modified code
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
