### PR TITLE
Fixes #217: isOwnBuilding validation incorrectly falls back to GitHub

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1075,7 +1075,8 @@ function HomeContent() {
   // Extra guard: check if selected building is own by comparing linked account
   const isOwnBuilding =
     !!selectedBuilding &&
-    selectedBuilding.login.toLowerCase() === selfLogin;
+    !!linkedLeetCodeUsername &&
+    selectedBuilding.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase();
 
   // Fly timer — ticks every second while flying and not paused
   useEffect(() => {
@@ -1241,7 +1242,7 @@ function HomeContent() {
   // Kudos handler
   const handleGiveKudos = useCallback(async () => {
     if (!selectedBuilding || kudosSending || kudosSent || !session) return;
-    if (selectedBuilding.login.toLowerCase() === selfLogin) return;
+    if (isOwnBuilding) return;
     setKudosSending(true);
     setKudosError(null);
     try {
@@ -1277,7 +1278,7 @@ function HomeContent() {
     } finally {
       setKudosSending(false);
     }
-  }, [selectedBuilding, kudosSending, kudosSent, session, selfLogin]);
+  }, [selectedBuilding, kudosSending, kudosSent, session, isOwnBuilding]);
 
   // Gift: open modal with available items
   const handleOpenGift = useCallback(async () => {
@@ -5059,7 +5060,7 @@ function HomeContent() {
                 )}
 
                 {/* Own building: copy invite link */}
-                {identityResolved && selectedBuilding.login.toLowerCase() === selfLogin && (
+                {identityResolved && isOwnBuilding && (
                   <div className="mx-4 mb-3">
                     <button
                       onClick={() => {
@@ -5094,7 +5095,7 @@ function HomeContent() {
 
                 {/* Actions */}
                 <div className="flex gap-2 p-4 pt-0 pb-5 sm:pb-4">
-                  {selectedBuilding.login.toLowerCase() === selfLogin ? (
+                  {isOwnBuilding ? (
                     <>
                       <Link
                         href={`/shop/${selfLogin}?tab=loadout`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1241,6 +1241,7 @@ function HomeContent() {
 
   // Kudos handler
   const handleGiveKudos = useCallback(async () => {
+    if (!identityResolved) return;
     if (!selectedBuilding || kudosSending || kudosSent || !session) return;
     if (isOwnBuilding) return;
     setKudosSending(true);
@@ -1278,11 +1279,11 @@ function HomeContent() {
     } finally {
       setKudosSending(false);
     }
-  }, [selectedBuilding, kudosSending, kudosSent, session, isOwnBuilding]);
+  }, [selectedBuilding, kudosSending, kudosSent, session, isOwnBuilding, identityResolved]);
 
   // Gift: open modal with available items
   const handleOpenGift = useCallback(async () => {
-    if (!selectedBuilding || !session) return;
+    if (!identityResolved || !selectedBuilding || !session) return;
     setGiftModalOpen(true);
     setGiftItems(null);
     try {
@@ -1300,7 +1301,7 @@ function HomeContent() {
     } catch {
       /* ignore */
     }
-  }, [selectedBuilding, session]);
+  }, [selectedBuilding, session, identityResolved]);
 
   // Gift: checkout for receiver
   const handleGiftCheckout = useCallback(
@@ -5094,49 +5095,51 @@ function HomeContent() {
                 )}
 
                 {/* Actions */}
-                <div className="flex gap-2 p-4 pt-0 pb-5 sm:pb-4">
-                  {isOwnBuilding ? (
-                    <>
-                      <Link
-                        href={`/shop/${selfLogin}?tab=loadout`}
-                        className="btn-press flex-1 py-2 text-center text-[10px] text-bg"
-                        style={{
-                          backgroundColor: theme.accent,
-                          boxShadow: `2px 2px 0 0 ${theme.shadow}`,
-                        }}
-                      >
-                        Loadout
-                      </Link>
-                      <Link
-                        href={`/dev/${selfLogin}`}
-                        className="btn-press flex-1 border-[2px] border-border py-2 text-center text-[10px] text-cream transition-colors hover:border-border-light"
-                      >
-                        Profile
-                      </Link>
-                    </>
-                  ) : (
-                    <>
-                      <Link
-                        href={`/dev/${selectedBuilding.login}`}
-                        className="btn-press flex-1 py-2 text-center text-[10px] text-bg"
-                        style={{
-                          backgroundColor: theme.accent,
-                          boxShadow: `2px 2px 0 0 ${theme.shadow}`,
-                        }}
-                      >
-                        View Profile
-                      </Link>
-                      <a
-                        href={`https://leetcode.com/u/${selectedBuilding.login}/`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn-press flex-1 border-[2px] border-border py-2 text-center text-[10px] text-cream transition-colors hover:border-border-light"
-                      >
-                        LeetCode
-                      </a>
-                    </>
-                  )}
-                </div>
+                {identityResolved && (
+                  <div className="flex gap-2 p-4 pt-0 pb-5 sm:pb-4">
+                    {isOwnBuilding ? (
+                      <>
+                        <Link
+                          href={`/shop/${selfLogin}?tab=loadout`}
+                          className="btn-press flex-1 py-2 text-center text-[10px] text-bg"
+                          style={{
+                            backgroundColor: theme.accent,
+                            boxShadow: `2px 2px 0 0 ${theme.shadow}`,
+                          }}
+                        >
+                          Loadout
+                        </Link>
+                        <Link
+                          href={`/dev/${selfLogin}`}
+                          className="btn-press flex-1 border-[2px] border-border py-2 text-center text-[10px] text-cream transition-colors hover:border-border-light"
+                        >
+                          Profile
+                        </Link>
+                      </>
+                    ) : (
+                      <>
+                        <Link
+                          href={`/dev/${selectedBuilding.login}`}
+                          className="btn-press flex-1 py-2 text-center text-[10px] text-bg"
+                          style={{
+                            backgroundColor: theme.accent,
+                            boxShadow: `2px 2px 0 0 ${theme.shadow}`,
+                          }}
+                        >
+                          View Profile
+                        </Link>
+                        <a
+                          href={`https://leetcode.com/u/${selectedBuilding.login}/`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn-press flex-1 border-[2px] border-border py-2 text-center text-[10px] text-cream transition-colors hover:border-border-light"
+                        >
+                          LeetCode
+                        </a>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </>


### PR DESCRIPTION
## What does this PR do?

Fixes a logic bug where the `isOwnBuilding` validation incorrectly falls back to the user's GitHub `authLogin` if their `linkedLeetCodeUsername` is not explicitly set. 

This PR updates `isOwnBuilding` in `src/app/page.tsx` to strictly require `linkedLeetCodeUsername` and ensure it matches the selected building's login. It also replaces direct usages of `selfLogin` comparisons across action buttons (Kudos, Compare, Copy Invite Link) with `isOwnBuilding` to ensure consistent logic and prevent unauthorized actions.

## Related issue

Fixes #217

## Screenshots

N/A - Logic fix only (prevents unauthorized actions on buildings).

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
