### PR TITLE
fix: grant 15 points to developers.points on daily claim 

### DIFF
--- a/supabase/migrations/045_fix_complete_all_dailies_points.sql
+++ b/supabase/migrations/045_fix_complete_all_dailies_points.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION complete_all_dailies(p_developer_id bigint)
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE
+  v_today       date := current_date;
+  v_last_date   date;
+  v_old_streak  int;
+  v_new_streak  int;
+  v_total       int;
+  v_points      int;
+BEGIN
+  SELECT last_dailies_date, dailies_streak, dailies_completed, points
+  INTO v_last_date, v_old_streak, v_total, v_points
+  FROM developers
+  WHERE id = p_developer_id
+  FOR UPDATE;
+
+  IF v_last_date = v_today THEN
+    RETURN jsonb_build_object('already_completed', true, 'streak', v_old_streak, 'total', v_total);
+  END IF;
+
+  IF v_last_date = v_today - 1 THEN
+    v_new_streak := v_old_streak + 1;
+  ELSE
+    v_new_streak := 1;
+  END IF;
+
+  v_total := v_total + 1;
+  v_points := COALESCE(v_points, 0) + 15;
+
+  UPDATE developers
+  SET dailies_completed = v_total,
+      dailies_streak = v_new_streak,
+      last_dailies_date = v_today,
+      points = v_points
+  WHERE id = p_developer_id;
+
+  RETURN jsonb_build_object(
+    'already_completed', false,
+    'streak', v_new_streak,
+    'total', v_total,
+    'points_granted', 15
+  );
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where completing all three daily missions granted 15 points in the API response and optimistically updated the UI, but never actually wrote those points to the database. Any user who completed their dailies would see an incremented balance that silently reset on the next page load.

The `complete_all_dailies` Postgres function in `026_dailies.sql` only updated `dailies_completed`, `dailies_streak`, and `last_dailies_date` — the `points` column was never touched.

## Fix

Added a new migration `045_fix_complete_all_dailies_points.sql` that redefines `complete_all_dailies` to atomically increment `developers.points` by 15 alongside the existing streak update:

```sql
-- Before
UPDATE developers
SET dailies_completed = v_total,
    dailies_streak = v_new_streak,
    last_dailies_date = v_today
WHERE id = p_developer_id;

-- After
v_points := COALESCE(v_points, 0) + 15;

UPDATE developers
SET dailies_completed = v_total,
    dailies_streak = v_new_streak,
    last_dailies_date = v_today,
    points = v_points
WHERE id = p_developer_id;
```

No application code changes were needed — `src/app/api/dailies/claim/route.ts` already calls the RPC correctly.

## Visual Proof

This is a database-level bug fix with no UI changes to screenshot.

**Root cause:** The `complete_all_dailies` function in `026_dailies.sql` 
was missing `points = v_points` in its UPDATE statement.

**Proof via code diff — before (`026_dailies.sql`):**
```sql
UPDATE developers
SET dailies_completed = v_total,
    dailies_streak = v_new_streak,
    last_dailies_date = v_today
WHERE id = p_developer_id;
-- ❌ points column never updated
```

**After (`045_fix_complete_all_dailies_points.sql`):**
```sql
v_points := COALESCE(v_points, 0) + 15;

UPDATE developers
SET dailies_completed = v_total,
    dailies_streak = v_new_streak,
    last_dailies_date = v_today,
    points = v_points          -- ✅ points now written atomically
WHERE id = p_developer_id;
```

## Files changed
- `supabase/migrations/045_fix_complete_all_dailies_points.sql` — new migration redefining `complete_all_dailies` with the points write

## Related issue
Fixes #205

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above