### PR TITLE
🐛 fix(loadout): validate developer id

### DIFF
--- a/src/app/api/loadout/developer-id.test.ts
+++ b/src/app/api/loadout/developer-id.test.ts
@@ -1,0 +1,14 @@
+import { parseDeveloperId } from "./developer-id";
+
+describe("parseDeveloperId", () => {
+  it("returns null for non-numeric developer IDs", () => {
+    expect(parseDeveloperId("abc")).toBeNull();
+    expect(parseDeveloperId("123abc")).toBeNull();
+    expect(parseDeveloperId("-5")).toBeNull();
+    expect(parseDeveloperId("0")).toBeNull();
+  });
+
+  it("returns parsed numeric developer IDs", () => {
+    expect(parseDeveloperId("42")).toBe(42);
+  });
+});

--- a/src/app/api/loadout/developer-id.ts
+++ b/src/app/api/loadout/developer-id.ts
@@ -1,0 +1,12 @@
+export function parseDeveloperId(rawDeveloperId: string): number | null {
+  if (!/^\d+$/.test(rawDeveloperId)) {
+    return null;
+  }
+
+  const developerId = Number.parseInt(rawDeveloperId, 10);
+  if (!Number.isSafeInteger(developerId) || developerId < 1) {
+    return null;
+  }
+
+  return developerId;
+}

--- a/src/app/api/loadout/route.ts
+++ b/src/app/api/loadout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { ZONE_ITEMS } from "@/lib/zones";
+import { parseDeveloperId } from "./developer-id";
 
 export const dynamic = "force-dynamic";
 
@@ -16,11 +17,16 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Missing developer_id" }, { status: 400 });
   }
 
+  const developerId = parseDeveloperId(devId);
+  if (developerId === null) {
+    return NextResponse.json({ error: "Invalid developer_id" }, { status: 400 });
+  }
+
   const admin = getSupabaseAdmin();
   const { data } = await admin
     .from("developer_customizations")
     .select("config")
-    .eq("developer_id", parseInt(devId, 10))
+    .eq("developer_id", developerId)
     .eq("item_id", "loadout")
     .maybeSingle();
 


### PR DESCRIPTION
## What does this PR do?

Validates the `developer_id` query parameter before the loadout endpoint queries Supabase.

- Returns `400` for non-numeric IDs like `developer_id=abc`
- Rejects partial numeric junk like `123abc`, negative IDs, and `0`
- Passes only a validated positive numeric developer ID to the `.eq("developer_id", ...)` filter
- Adds focused Vitest coverage for the parser

## Related issue

Fixes #229

## Screenshots

Not applicable. This is an API validation fix with regression tests.

## Checklist

- [x] `npm run lint -- src/app/api/loadout/route.ts src/app/api/loadout/developer-id.ts src/app/api/loadout/developer-id.test.ts` passes
- [x] `npm test -- src/app/api/loadout/developer-id.test.ts` passes
- [x] `npm run build` passes
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)