### PR TITLE
feat: implement rate limiting for buy-with-points endpoint

### DIFF
--- a/src/app/api/shop/buy-with-points/route.ts
+++ b/src/app/api/shop/buy-with-points/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { rateLimit } from "@/lib/rate-limit";
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -13,6 +14,11 @@ export async function POST(request: Request) {
 
     if (!user) {
         return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { ok } = rateLimit(`buy-points:${user.id}`, 1, 5_000);
+    if (!ok) {
+        return NextResponse.json({ error: "Too fast" }, { status: 429 });
     }
 
     const { item_id } = await request.json();


### PR DESCRIPTION
## What does this PR do?

Adds rate limiting to the `POST /api/shop/buy-with-points` endpoint, consistent with the pattern used in other state-mutating endpoints (e.g. `/api/checkout`).

Without this, a user could spam the endpoint and:
- Generate many concurrent requests before the optimistic lock on the points balance kicks in
- Waste server resources on auth checks and DB queries for each failed attempt
- Flood the `activity_feed` table with `item_purchased` events

**Changes:**
- Import `rateLimit` from `@/lib/rate-limit`
- Add `rateLimit(`buy-points:${user.id}`, 1, 5_000)` check immediately after the auth guard, returning `429 Too fast` if exceeded

## Related issue

Fixes #227

## Screenshots

N/A — no visual changes.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x]  ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)