### PR TITLE
(feature): Implemented dynamic snowy winter system - with icicle geometry and ice particle.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -322,7 +321,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -334,7 +332,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1822,7 +1819,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2280,7 +2276,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.2.tgz",
       "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.2",
         "@supabase/functions-js": "2.106.2",
@@ -2711,7 +2706,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2727,7 +2721,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2762,7 +2755,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2834,7 +2826,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3556,7 +3547,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3976,7 +3966,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4723,7 +4712,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4909,7 +4897,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6888,7 +6875,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -7308,7 +7294,6 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
       "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
       "license": "Zlib",
-      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.184.0"
       }
@@ -7387,7 +7372,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7397,7 +7381,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8286,8 +8269,7 @@
       "version": "0.183.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.0.tgz",
       "integrity": "sha512-G6SH2jfefIVa2YI4JL2VbgQhrrbp1A8dRc7lr3PW827kdVyaX2RgH6M5FmjmdVFLgSHppyg3OYOZdTfWElle+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8379,7 +8361,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8491,7 +8472,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8639,7 +8619,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8811,7 +8790,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9448,7 +9426,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+type WeatherMode = "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+
+function codeToMode(code: number): WeatherMode {
+  if (code >= 200 && code <= 299) return "stormy";
+  if ((code >= 300 && code <= 399) || (code >= 500 && code <= 531)) return "rainy";
+  if (code >= 600 && code <= 622) return "snowy";
+  if (code >= 700 && code <= 781) return "windy";
+  if (code === 800) return "sunny";
+  // 801–804: light to heavy cloud cover
+  if (code >= 801 && code <= 802) return "sunny";
+  if (code >= 803 && code <= 804) return "windy";
+  return "sunny";
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const apiKey = process.env.OPENWEATHERMAP_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json({ weatherMode: "sunny" as WeatherMode });
+  }
+
+  try {
+    let url: string;
+    const lat = searchParams.get("lat");
+    const lon = searchParams.get("lon");
+    const city = searchParams.get("city");
+
+    if (lat && lon) {
+      url = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${apiKey}`;
+    } else if (city) {
+      url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}`;
+    } else {
+      return NextResponse.json({ weatherMode: "sunny" as WeatherMode });
+    }
+
+    const res = await fetch(url, { next: { revalidate: 1800 } });
+    if (!res.ok) {
+      return NextResponse.json({ weatherMode: "sunny" as WeatherMode });
+    }
+
+    const data = await res.json();
+    const weatherCode: number = data?.weather?.[0]?.id ?? 800;
+    const description: string = data?.weather?.[0]?.description ?? "";
+    const cityName: string = data?.name ?? "";
+
+    return NextResponse.json({
+      weatherMode: codeToMode(weatherCode),
+      weatherCode,
+      description,
+      cityName,
+    });
+  } catch {
+    return NextResponse.json({ weatherMode: "sunny" as WeatherMode });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,7 @@ import {
 import LoadingScreen, { type LoadingStage } from "@/components/LoadingScreen";
 import MiniMap from "@/components/MiniMap";
 import CityAnalyticsDashboard from "@/components/CityAnalyticsDashboard";
+import { useWeather } from "@/lib/useWeather";
 import { getCityCache, setCityCache, clearCityCache } from "@/lib/cityCache";
 import {
   DEFAULT_SKY_ADS,
@@ -578,16 +579,12 @@ function HomeContent() {
   const [themeIndex, setThemeIndex] = useState(0);
   const [isCodexOpen, setIsCodexOpen] = useState(false);
   const [dayNightCycleActive, setDayNightCycleActive] = useState(true);
-  const [weatherMode, setWeatherMode] = useState<"sunny" | "rainy" | "windy" | "stormy" | "snowy">("sunny");
+  const { weatherMode, setWeatherMode, cityName, isLoading: weatherLoading, searchByCity } = useWeather();
 
   const cycleWeather = () => {
     const modes: ("sunny" | "rainy" | "windy" | "stormy" | "snowy")[] = ["sunny", "rainy", "windy", "stormy", "snowy"];
     const idx = modes.indexOf(weatherMode);
-    const next = modes[(idx + 1) % modes.length];
-    setWeatherMode(next);
-    try {
-      localStorage.setItem("leetcodecity_weather_mode", next);
-    } catch { }
+    setWeatherMode(modes[(idx + 1) % modes.length]);
   };
 
   useEffect(() => {
@@ -601,12 +598,6 @@ function HomeContent() {
       const savedCycle = localStorage.getItem("leetcodecity_daynight_cycle");
       if (savedCycle === "0") {
         setDayNightCycleActive(false);
-      }
-    } catch { }
-    try {
-      const savedWeather = localStorage.getItem("leetcodecity_weather_mode");
-      if (savedWeather === "sunny" || savedWeather === "rainy" || savedWeather === "windy" || savedWeather === "stormy" || savedWeather === "snowy") {
-        setWeatherMode(savedWeather as any);
       }
     } catch { }
   }, []);
@@ -5817,6 +5808,9 @@ function HomeContent() {
             setDayNightCycleActive={setDayNightCycleActive}
             weatherMode={weatherMode}
             cycleWeather={cycleWeather}
+            cityName={cityName}
+            searchByCity={searchByCity}
+            weatherLoading={weatherLoading}
           />
         </div>
       )}

--- a/src/components/ActionToolbar.tsx
+++ b/src/components/ActionToolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 
 interface ActionToolbarProps {
   cycleTheme: () => void;
@@ -14,6 +14,9 @@ interface ActionToolbarProps {
   setDayNightCycleActive: React.Dispatch<React.SetStateAction<boolean>>;
   weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
   cycleWeather?: () => void;
+  cityName?: string | null;
+  searchByCity?: (city: string) => void;
+  weatherLoading?: boolean;
 }
 
 const ActionToolbar: React.FC<ActionToolbarProps> = ({
@@ -27,7 +30,23 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
   setDayNightCycleActive,
   weatherMode = "sunny",
   cycleWeather = () => {},
+  cityName,
+  searchByCity,
+  weatherLoading = false,
 }) => {
+  const [cityInputOpen, setCityInputOpen] = useState(false);
+  const [cityDraft, setCityDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleCitySubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (cityDraft.trim() && searchByCity) {
+      searchByCity(cityDraft.trim());
+      setCityDraft("");
+      setCityInputOpen(false);
+    }
+  };
+
   return (
     <div className="flex items-center gap-2">
       {/* Theme Cycle Button */}
@@ -39,7 +58,7 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
         <span className="text-cream">{theme.name}</span>
         <span className="text-dim">{themeIndex + 1}/{themesLength}</span>
       </button>
- 
+
       {/* Day/Night Cycle Button */}
       <button
         onClick={() => {
@@ -60,15 +79,51 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
         <span style={{ color: theme.accent }}>&#9654;</span>
         <span>{dayNightCycleActive ? "CYCLE ON" : "CYCLE OFF"}</span>
       </button>
- 
-      {/* Weather Selector Button */}
-      <button
-        onClick={cycleWeather}
-        className="btn-press flex items-center gap-1.5 border-[3px] border-border bg-bg/70 px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors hover:border-border-light text-cream"
-      >
-        <span style={{ color: theme.accent }}>&#9654;</span>
-        <span>WEATHER: {weatherMode.toUpperCase()}</span>
-      </button>
+
+      {/* Weather Controls */}
+      <div className="flex items-center gap-1">
+        {/* Weather cycle button — click to cycle mode */}
+        <button
+          onClick={cycleWeather}
+          className="btn-press flex items-center gap-1.5 border-[3px] border-border bg-bg/70 px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors hover:border-border-light text-cream"
+        >
+          <span style={{ color: theme.accent }}>&#9654;</span>
+          <span>
+            {weatherLoading ? "..." : weatherMode.toUpperCase()}
+            {cityName && !weatherLoading && (
+              <span className="text-dim ml-1 normal-case">({cityName})</span>
+            )}
+          </span>
+        </button>
+
+        {/* City search toggle */}
+        {searchByCity && (
+          <button
+            onClick={() => {
+              setCityInputOpen((v) => !v);
+              if (!cityInputOpen) setTimeout(() => inputRef.current?.focus(), 50);
+            }}
+            title="Search by city"
+            className="btn-press flex items-center border-[3px] border-border bg-bg/70 px-1.5 py-1 text-[10px] backdrop-blur-sm transition-colors hover:border-border-light text-dim"
+          >
+            &#9906;
+          </button>
+        )}
+
+        {/* Inline city search input */}
+        {cityInputOpen && searchByCity && (
+          <form onSubmit={handleCitySubmit} className="flex items-center">
+            <input
+              ref={inputRef}
+              value={cityDraft}
+              onChange={(e) => setCityDraft(e.target.value)}
+              onKeyDown={(e) => e.key === "Escape" && setCityInputOpen(false)}
+              placeholder="City name..."
+              className="border-[3px] border-border bg-bg/90 px-2 py-1 text-[10px] text-cream outline-none placeholder:text-dim backdrop-blur-sm w-28"
+            />
+          </form>
+        )}
+      </div>
 
       {/* Audio/Radio Slot if mounted */}
       {isMounted && <div id="gc-radio-slot" />}

--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -1625,6 +1625,11 @@ export default function AtmosphereCycleManager({
       const fog = scene.fog as THREE.Fog | null;
       if (fog) {
         fog.color.set(lightningIntensity > 0 ? "#e2f0ff" : fogColorToUse);
+        // Tighten fog distance in snowy mode for reduced-visibility effect
+        const fogNearTarget = weatherMode === "snowy" ? 300 : theme.fogNear;
+        const fogFarTarget  = weatherMode === "snowy" ? 1400 : theme.fogFar;
+        fog.near = THREE.MathUtils.lerp(fog.near, fogNearTarget, delta * 0.5);
+        fog.far  = THREE.MathUtils.lerp(fog.far,  fogFarTarget,  delta * 0.5);
       }
       scene.background = new THREE.Color(lightningIntensity > 0 ? "#cbd5e1" : fogColorToUse);
 

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1065,6 +1065,18 @@ function Ground({ color, grid1, grid2 }: { color: string; grid1: string; grid2: 
   return null;
 }
 
+// Pre-allocated color constants for snow lerp (avoid per-frame allocations)
+const _SNOW_TOP_COLOR   = new THREE.Color("#f8fafc");
+const _SNOW_TOP_EMIT    = new THREE.Color("#e2e8f0");
+const _PATH_BASE_COLOR  = new THREE.Color("#4a5564");
+const _PATH_BASE_EMIT   = new THREE.Color("#2a3040");
+const _PATH_SNOW_COLOR  = new THREE.Color("#f1f5f9");
+const _PATH_SNOW_EMIT   = new THREE.Color("#cbd5e1");
+const _TORUS_BASE_COLOR = new THREE.Color("#5a7186");
+const _TORUS_BASE_EMIT  = new THREE.Color("#263849");
+const _TORUS_SNOW_COLOR = new THREE.Color("#f8fafc");
+const _TORUS_SNOW_EMIT  = new THREE.Color("#cbd5e1");
+
 function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; color: string; weatherMode?: string }) {
   const platformRadius = radius + 120;
 
@@ -1080,8 +1092,6 @@ function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; 
       ]);
     }
 
-    // Concrete ring paths matching decoration ring positions
-    // These are the same radii used in rebuildCircularCityDecorations
     const CENTER_CLEARANCE = 170;
     const RING_SPACING = 72;
     const paths: number[] = [];
@@ -1094,54 +1104,71 @@ function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; 
     return { supportColumns: columns, concretePaths: paths };
   }, [radius, platformRadius]);
 
+  // Material refs for imperative lerp
+  const topMatRef   = useRef<THREE.MeshStandardMaterial>(null);
+  const pathMatRefs = useRef<(THREE.MeshStandardMaterial | null)[]>([]);
+  const torMatRefs  = useRef<(THREE.MeshStandardMaterial | null)[]>([]);
+  const snowIntRef  = useRef(weatherMode === "snowy" ? 1.0 : 0.0);
+  const weatherRef  = useRef(weatherMode);
+  weatherRef.current = weatherMode;
+  const baseColorRef = useRef(new THREE.Color(color));
+  useEffect(() => { baseColorRef.current.set(color); }, [color]);
+
+  useFrame((_, delta) => {
+    const target = weatherRef.current === "snowy" ? 1.0 : 0.0;
+    snowIntRef.current = THREE.MathUtils.lerp(snowIntRef.current, target, delta * 0.8);
+    const t = snowIntRef.current;
+
+    if (topMatRef.current) {
+      topMatRef.current.color.lerpColors(baseColorRef.current, _SNOW_TOP_COLOR, t);
+      topMatRef.current.emissive.lerpColors(baseColorRef.current, _SNOW_TOP_EMIT, t);
+      topMatRef.current.emissiveIntensity = THREE.MathUtils.lerp(0.18, 0.05, t);
+      topMatRef.current.roughness = THREE.MathUtils.lerp(0.9, 0.98, t);
+    }
+    for (const m of pathMatRefs.current) {
+      if (!m) continue;
+      m.color.lerpColors(_PATH_BASE_COLOR, _PATH_SNOW_COLOR, t);
+      m.emissive.lerpColors(_PATH_BASE_EMIT, _PATH_SNOW_EMIT, t);
+      m.emissiveIntensity = THREE.MathUtils.lerp(0.2, 0.05, t);
+    }
+    for (const m of torMatRefs.current) {
+      if (!m) continue;
+      m.color.lerpColors(_TORUS_BASE_COLOR, _TORUS_SNOW_COLOR, t);
+      m.emissive.lerpColors(_TORUS_BASE_EMIT, _TORUS_SNOW_EMIT, t);
+      m.emissiveIntensity = THREE.MathUtils.lerp(0.35, 0.1, t);
+      m.roughness = THREE.MathUtils.lerp(0.82, 0.95, t);
+    }
+  });
+
   return (
     <group>
       {/* Platform base (cylinder wall) */}
       <mesh position={[0, -14, 0]}>
         <cylinderGeometry args={[platformRadius, platformRadius + 44, 28, 128]} />
-        <meshStandardMaterial
-          color="#05070a"
-          emissive="#000000"
-          emissiveIntensity={0.0}
-          roughness={0.95}
-          metalness={0.1}
-        />
+        <meshStandardMaterial color="#05070a" emissive="#000000" emissiveIntensity={0.0} roughness={0.95} metalness={0.1} />
       </mesh>
       {/* Platform top surface */}
       <mesh position={[0, 0.2, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <circleGeometry args={[platformRadius, 128]} />
-        <meshStandardMaterial
-          color={weatherMode === "snowy" ? "#f8fafc" : color}
-          emissive={weatherMode === "snowy" ? "#e2e8f0" : color}
-          emissiveIntensity={weatherMode === "snowy" ? 0.05 : 0.18}
-          roughness={weatherMode === "snowy" ? 0.98 : 0.9}
-        />
+        <meshStandardMaterial ref={topMatRef} color={color} emissive={color} emissiveIntensity={0.18} roughness={0.9} />
       </mesh>
       {/* Concrete ring paths (walkways where trees/lamps sit) */}
-      {concretePaths.map((r) => (
+      {concretePaths.map((r, i) => (
         <mesh key={`path-${r}`} position={[0, 0.35, 0]} rotation={[-Math.PI / 2, 0, 0]}>
           <ringGeometry args={[r - 16, r + 16, 128]} />
           <meshStandardMaterial
-            color={weatherMode === "snowy" ? "#f1f5f9" : "#4a5564"}
-            emissive={weatherMode === "snowy" ? "#cbd5e1" : "#2a3040"}
-            emissiveIntensity={weatherMode === "snowy" ? 0.05 : 0.2}
-            roughness={0.95}
+            ref={(el) => { pathMatRefs.current[i] = el; }}
+            color="#4a5564" emissive="#2a3040" emissiveIntensity={0.2} roughness={0.95}
           />
         </mesh>
       ))}
       {/* Perimeter decorative torus rings */}
-      {[0.48, 0.68, 0.86, 1].map((scale) => (
-        <mesh
-          key={scale}
-          position={[0, 0.9 + scale, 0]}
-          rotation={[Math.PI / 2, 0, 0]}
-        >
+      {[0.48, 0.68, 0.86, 1].map((scale, i) => (
+        <mesh key={scale} position={[0, 0.9 + scale, 0]} rotation={[Math.PI / 2, 0, 0]}>
           <torusGeometry args={[platformRadius * scale, 2.4, 8, 160]} />
           <meshStandardMaterial
-            color={weatherMode === "snowy" ? "#f8fafc" : "#5a7186"}
-            emissive={weatherMode === "snowy" ? "#cbd5e1" : "#263849"}
-            emissiveIntensity={weatherMode === "snowy" ? 0.1 : 0.35}
-            roughness={weatherMode === "snowy" ? 0.95 : 0.82}
+            ref={(el) => { torMatRefs.current[i] = el; }}
+            color="#5a7186" emissive="#263849" emissiveIntensity={0.35} roughness={0.82}
           />
         </mesh>
       ))}
@@ -1149,12 +1176,7 @@ function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; 
       {supportColumns.map(([x, z], i) => (
         <mesh key={i} position={[x, -48, z]}>
           <cylinderGeometry args={[9, 15, 80, 10]} />
-          <meshStandardMaterial
-            color="#1b2530"
-            emissive="#0f1720"
-            emissiveIntensity={0.25}
-            roughness={0.95}
-          />
+          <meshStandardMaterial color="#1b2530" emissive="#0f1720" emissiveIntensity={0.25} roughness={0.95} />
         </mesh>
       ))}
     </group>

--- a/src/components/CityScene.tsx
+++ b/src/components/CityScene.tsx
@@ -12,6 +12,8 @@ import SunnyWeather from "./SunnyWeather";
 import type { LiveSession } from "@/lib/useCodingPresence";
 import type { CityBuilding } from "@/lib/github";
 import type { BuildingColors } from "./CityCanvas";
+import { SnowWeather } from "./SnowWeather";
+
 
 
 const GRID_CELL_SIZE = 200;
@@ -119,7 +121,7 @@ interface CitySceneProps {
   weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
 }
 
-function WeatherSystem({ weatherMode }: { weatherMode: "sunny" | "rainy" | "windy" | "stormy" | "snowy" }) {
+function WeatherSystem({ weatherMode, buildings, focusedBuilding }: { weatherMode: "sunny" | "rainy" | "windy" | "stormy" | "snowy", buildings?: CityBuilding[], focusedBuilding?: string | null }) {
   const pointsRef = useRef<THREE.Points>(null);
   const leavesRef = useRef<THREE.Points>(null);
   const { camera } = useThree();
@@ -274,6 +276,7 @@ function WeatherSystem({ weatherMode }: { weatherMode: "sunny" | "rainy" | "wind
       />
     );
   }
+  if (weatherMode === "snowy") return <SnowWeather buildings={buildings} focusedBuilding={focusedBuilding} />;
 
   // Weather style adjustments
   let particleColor = "#a7c7ff";
@@ -285,13 +288,9 @@ function WeatherSystem({ weatherMode }: { weatherMode: "sunny" | "rainy" | "wind
     size = 4.5;
     opacity = 0.5;
   } else if (weatherMode === "stormy") {
-    particleColor = "#cbd5e1"; // thick grey-ish downpour particles
+    particleColor = "#cbd5e1";
     size = 6.0;
     opacity = 0.8;
-  } else if (weatherMode === "snowy") {
-    particleColor = "#ffffff"; // Beautiful fluffy white snow flakes
-    size = 6.0;
-    opacity = 0.9;
   }
 
   return (
@@ -446,8 +445,7 @@ export default function CityScene({
         flyMode={flyMode}
         ghostPreviewLogin={ghostPreviewLogin}
       />
-
-      {!introMode && <WeatherSystem weatherMode={weatherMode} />}
+      {!introMode && <WeatherSystem weatherMode={weatherMode} buildings={buildings} focusedBuilding={focusedBuilding} />}
 
       {!introMode && focusedBuildingData && (
         <group

--- a/src/components/InstancedBuildings.tsx
+++ b/src/components/InstancedBuildings.tsx
@@ -262,9 +262,8 @@ export default memo(function InstancedBuildings({
     material.uniforms.uDimOpacity.value = dimOpacity;
     material.uniforms.uDimEmissive.value = dimEmissive;
     material.uniforms.uCityEnergy.value = cityEnergy;
-    material.uniforms.uSnowIntensity.value = weatherMode === "snowy" ? 1.0 : 0.0;
     material.needsUpdate = true;
-  }, [atlasTexture, colors.roof, colors.face, dimOpacity, dimEmissive, cityEnergy, weatherMode, material]);
+  }, [atlasTexture, colors.roof, colors.face, dimOpacity, dimEmissive, cityEnergy, material]);
 
   const { uvFrontData, uvSideData, riseData, tintData, lcData } =
     useMemo(() => {
@@ -438,9 +437,12 @@ export default memo(function InstancedBuildings({
   const lastFogFar = useRef(0);
   const cityEnergyRef = useRef(cityEnergy);
   cityEnergyRef.current = cityEnergy;
+  const weatherModeRef = useRef(weatherMode);
+  weatherModeRef.current = weatherMode;
+  const snowIntensityRef = useRef(weatherMode === "snowy" ? 1.0 : 0.0);
 
   // Global Time Cycle Logic
-  useFrame(({ scene, clock }) => {
+  useFrame(({ scene, clock }, delta) => {
     if (!material.uniforms) return;
     const fog = scene.fog as THREE.Fog | null;
     if (!fog) return;
@@ -465,6 +467,10 @@ export default memo(function InstancedBuildings({
     if (Math.abs(current - target) > 0.001) {
       material.uniforms.uCityEnergy.value += (target - current) * 0.04;
     }
+
+    const snowTarget = weatherModeRef.current === "snowy" ? 1.0 : 0.0;
+    snowIntensityRef.current = THREE.MathUtils.lerp(snowIntensityRef.current, snowTarget, delta * 0.8);
+    material.uniforms.uSnowIntensity.value = snowIntensityRef.current;
   });
 
   useEffect(() => {

--- a/src/components/SnowWeather.tsx
+++ b/src/components/SnowWeather.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useRef, useMemo, useState, useEffect, useLayoutEffect, useCallback } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import type { CityBuilding } from "@/lib/github";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const FLAKE_COUNT = 900;
+const WEATHER_AREA = 2200;
+const WEATHER_HALF_AREA = WEATHER_AREA / 2;
+const WEATHER_TOP = 420;
+const WEATHER_BOTTOM = 10;
+
+const BREATH_COUNT = 80;
+const BREATH_MAX_Y = 38;
+
+const MAX_ICICLE_BUILDINGS = 180;
+const ICICLES_PER_BUILDING = 3;
+const TOTAL_ICICLE_INSTANCES = MAX_ICICLE_BUILDINGS * ICICLES_PER_BUILDING;
+
+const pseudoRandom = (seed: number) => {
+  const x = Math.sin(seed * 12.9898) * 43758.5453123;
+  return x - Math.floor(x);
+};
+
+const wrap = (value: number, center: number) => {
+  const w = ((value - center + WEATHER_HALF_AREA) % WEATHER_AREA + WEATHER_AREA) % WEATHER_AREA;
+  return center + w - WEATHER_HALF_AREA;
+};
+
+// ─── Snowflake Shader ────────────────────────────────────────────────────────
+//
+// Per-particle aSize (world-space units) drives perspective-correct point size.
+// Per-particle aAngle rotates the 6-arm star pattern, giving each flake a
+// unique orientation that persists as it falls.
+
+const snowflakeVertex = `
+  attribute float aSize;
+  attribute float aAngle;
+  varying float vAngle;
+
+  void main() {
+    vAngle = aAngle;
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = aSize * (280.0 / max(-mvPosition.z, 1.0));
+    gl_PointSize = clamp(gl_PointSize, 1.5, 22.0);
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+const snowflakeFragment = `
+  uniform float uOpacity;
+  varying float vAngle;
+
+  void main() {
+    vec2 coord = gl_PointCoord - 0.5;
+    float dist = length(coord);
+    if (dist > 0.5) discard;
+
+    float c = cos(vAngle);
+    float s = sin(vAngle);
+    vec2 r = vec2(c * coord.x - s * coord.y, s * coord.x + c * coord.y);
+
+    // 3 lines at 0°/60°/120° produce a 6-arm snowflake
+    float arm1 = abs(r.x);
+    float arm2 = abs(r.x * 0.5 + r.y * 0.866);
+    float arm3 = abs(r.x * 0.5 - r.y * 0.866);
+    float armAlpha   = 1.0 - smoothstep(0.0, 0.13, min(arm1, min(arm2, arm3)));
+    float centerAlpha = 1.0 - smoothstep(0.08, 0.17, dist);
+    float shape    = max(armAlpha, centerAlpha);
+    float edgeFade = 1.0 - smoothstep(0.35, 0.5, dist);
+
+    gl_FragColor = vec4(0.95, 0.97, 1.0, shape * edgeFade * uOpacity);
+  }
+`;
+
+// ─── SnowflakeParticles ───────────────────────────────────────────────────────
+//
+// Mirrors the snow branch of WeatherSystem (CityScene.tsx) for movement physics
+// but replaces the basic pointsMaterial with a custom shader: per-particle size
+// variation (sizes 3.5–9 world units) and per-particle rotation angle.
+
+function SnowflakeParticles() {
+  const pointsRef = useRef<THREE.Points>(null);
+  const { camera } = useThree();
+
+  const [state] = useState(() => {
+    const cx = camera.position.x;
+    const cz = camera.position.z;
+
+    const positions = new Float32Array(FLAKE_COUNT * 3);
+    const sizes     = new Float32Array(FLAKE_COUNT);
+    const angles    = new Float32Array(FLAKE_COUNT);
+    const speeds    = new Float32Array(FLAKE_COUNT);
+    const anchorX   = new Float32Array(FLAKE_COUNT);
+    const anchorZ   = new Float32Array(FLAKE_COUNT);
+
+    for (let i = 0; i < FLAKE_COUNT; i++) {
+      const base = i * 3;
+      anchorX[i] = cx + (pseudoRandom(i * 3 + 1) - 0.5) * WEATHER_AREA;
+      anchorZ[i] = cz + (pseudoRandom(i * 3 + 3) - 0.5) * WEATHER_AREA;
+      positions[base]     = anchorX[i];
+      positions[base + 1] = WEATHER_BOTTOM + pseudoRandom(i * 3 + 2) * (WEATHER_TOP - WEATHER_BOTTOM);
+      positions[base + 2] = anchorZ[i];
+      sizes[i]  = 3.5 + pseudoRandom(i * 5 + 7) * 5.5;
+      angles[i] = pseudoRandom(i * 7 + 11) * Math.PI * 2;
+      speeds[i] = 120 + pseudoRandom(i * 3 + 4) * 150;
+    }
+
+    return { positions, sizes, angles, speeds, anchorX, anchorZ, respawnCycles: new Uint32Array(FLAKE_COUNT) };
+  });
+
+  const axRef      = useRef(state.anchorX);
+  const azRef      = useRef(state.anchorZ);
+  const respawnRef = useRef(state.respawnCycles);
+
+  const uniforms = useMemo(() => ({ uOpacity: { value: 0.88 } }), []);
+
+  useFrame(({ clock, camera: cam }, delta) => {
+    const pts = pointsRef.current;
+    if (!pts) return;
+
+    const pos = pts.geometry.attributes.position.array as Float32Array;
+    const cx  = cam.position.x;
+    const cz  = cam.position.z;
+    const t   = clock.elapsedTime;
+    const ax  = axRef.current;
+    const az  = azRef.current;
+    const rc  = respawnRef.current;
+
+    for (let i = 0; i < FLAKE_COUNT; i++) {
+      const base = i * 3;
+
+      ax[i] += 35.0 * delta;
+      az[i] += 12.0 * delta;
+
+      pos[base]     = wrap(ax[i], cx) + Math.sin(t * 1.8 + i) * 3.5;
+      pos[base + 2] = wrap(az[i], cz) + Math.cos(t * 1.4 + i) * 3.5;
+      pos[base + 1] -= state.speeds[i] * 0.18 * delta;
+
+      if (pos[base + 1] < WEATHER_BOTTOM) {
+        rc[i] += 1;
+        ax[i] = cx + (pseudoRandom(i * 17 + rc[i] * 31) - 0.5) * WEATHER_AREA;
+        az[i] = cz + (pseudoRandom(i * 19 + rc[i] * 62) - 0.5) * WEATHER_AREA;
+        pos[base]     = wrap(ax[i], cx);
+        pos[base + 1] = WEATHER_TOP;
+        pos[base + 2] = wrap(az[i], cz);
+      }
+    }
+
+    pts.geometry.attributes.position.needsUpdate = true;
+  });
+
+  return (
+    <points ref={pointsRef} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[state.positions, 3]} />
+        <bufferAttribute attach="attributes-aSize"    args={[state.sizes, 1]} />
+        <bufferAttribute attach="attributes-aAngle"   args={[state.angles, 1]} />
+      </bufferGeometry>
+      <shaderMaterial
+        vertexShader={snowflakeVertex}
+        fragmentShader={snowflakeFragment}
+        uniforms={uniforms}
+        transparent
+        depthWrite={false}
+      />
+    </points>
+  );
+}
+
+// ─── BreathFogParticles ───────────────────────────────────────────────────────
+//
+// 80 large, near-ground, slow-rising particles that simulate the misty fog
+// patches that form at street level in cold winter air. Confined to y < 38
+// units, they drift gently and respawn at ground level when they reach the top.
+
+function BreathFogParticles() {
+  const pointsRef = useRef<THREE.Points>(null);
+  const { camera } = useThree();
+
+  const [state] = useState(() => {
+    const cx = camera.position.x;
+    const cz = camera.position.z;
+
+    const positions = new Float32Array(BREATH_COUNT * 3);
+    const speeds    = new Float32Array(BREATH_COUNT);
+    const anchorX   = new Float32Array(BREATH_COUNT);
+    const anchorZ   = new Float32Array(BREATH_COUNT);
+
+    for (let i = 0; i < BREATH_COUNT; i++) {
+      const base = i * 3;
+      anchorX[i] = cx + (pseudoRandom(i * 11 + 1) - 0.5) * WEATHER_AREA;
+      anchorZ[i] = cz + (pseudoRandom(i * 11 + 3) - 0.5) * WEATHER_AREA;
+      positions[base]     = anchorX[i];
+      positions[base + 1] = 5 + pseudoRandom(i * 11 + 2) * BREATH_MAX_Y;
+      positions[base + 2] = anchorZ[i];
+      speeds[i] = 4 + pseudoRandom(i * 11 + 5) * 8;
+    }
+
+    return { positions, speeds, anchorX, anchorZ };
+  });
+
+  const axRef = useRef(state.anchorX);
+  const azRef = useRef(state.anchorZ);
+
+  useFrame(({ clock, camera: cam }, delta) => {
+    const pts = pointsRef.current;
+    if (!pts) return;
+
+    const pos = pts.geometry.attributes.position.array as Float32Array;
+    const cx  = cam.position.x;
+    const cz  = cam.position.z;
+    const t   = clock.elapsedTime;
+    const ax  = axRef.current;
+    const az  = azRef.current;
+
+    for (let i = 0; i < BREATH_COUNT; i++) {
+      const base = i * 3;
+
+      ax[i] += 8.0 * delta;
+      az[i] += 3.0 * delta;
+
+      pos[base]     = wrap(ax[i], cx) + Math.sin(t * 0.4 + i) * 5.0;
+      pos[base + 2] = wrap(az[i], cz) + Math.cos(t * 0.3 + i) * 5.0;
+      pos[base + 1] += state.speeds[i] * 0.15 * delta;
+
+      if (pos[base + 1] > BREATH_MAX_Y) {
+        pos[base + 1] = 2 + pseudoRandom(i * 13 + Math.floor(t)) * 8;
+        ax[i] = cx + (pseudoRandom(i * 23 + Math.floor(t * 0.5)) - 0.5) * WEATHER_AREA;
+        az[i] = cz + (pseudoRandom(i * 29 + Math.floor(t * 0.5)) - 0.5) * WEATHER_AREA;
+      }
+    }
+
+    pts.geometry.attributes.position.needsUpdate = true;
+  });
+
+  return (
+    <points ref={pointsRef} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[state.positions, 3]} />
+      </bufferGeometry>
+      <pointsMaterial
+        color="#dce8f8"
+        size={55}
+        sizeAttenuation={false}
+        transparent
+        opacity={0.055}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+      />
+    </points>
+  );
+}
+
+// ─── Icicles ──────────────────────────────────────────────────────────────────
+//
+// Renders flat 2D triangle icicles along building roof edges. Each icicle
+// is oriented to face outward from the edge it sits on. When a building is
+// focused, only that building's icicles are shown.
+
+// Y-axis rotation per edge so the flat triangle faces outward: [left, right, front, back]
+const EDGE_Y_ROTATIONS = [-Math.PI / 2, Math.PI / 2, Math.PI, 0];
+
+function Icicles({ buildings, focusedLogin }: { buildings: CityBuilding[]; focusedLogin?: string | null }) {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+
+  // Flat downward-pointing triangle in XY-plane: top edge at y=0, tip at y=-1
+  const geo = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    const verts = new Float32Array([-0.5, 0, 0, 0.5, 0, 0, 0, -1, 0]);
+    const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    g.setAttribute("position", new THREE.BufferAttribute(verts, 3));
+    g.setAttribute("normal", new THREE.BufferAttribute(normals, 3));
+    return g;
+  }, []);
+
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: "#d0ecf8", side: THREE.DoubleSide }),
+    []
+  );
+
+  const hiddenMatrix = useMemo(() => new THREE.Matrix4().makeTranslation(0, -99999, 0), []);
+
+  const { matrices, buildingLoginMap } = useMemo(() => {
+    const subset = buildings.filter((b) => b.height > 5).slice(0, MAX_ICICLE_BUILDINGS);
+    const result: THREE.Matrix4[] = [];
+    const loginMap = new Map<string, number[]>();
+    const dummy = new THREE.Object3D();
+
+    for (let bi = 0; bi < subset.length; bi++) {
+      const b = subset[bi];
+      const [bx, by, bz] = b.position;
+      const hw    = b.width / 2;
+      const hd    = b.depth / 2;
+      const roofY = by + b.height;
+      const login = b.login.toLowerCase();
+      const indices: number[] = [];
+
+      for (let k = 0; k < ICICLES_PER_BUILDING; k++) {
+        const r1 = pseudoRandom(bi * 7 + k * 3 + 1);
+        const r2 = pseudoRandom(bi * 7 + k * 3 + 2);
+        const r3 = pseudoRandom(bi * 7 + k * 3 + 3);
+        const r4 = pseudoRandom(bi * 7 + k * 3 + 4);
+
+        const icicleH = 2.0 + r2 * 8.0;
+        const icicleR = 1.0 + r3 * 1.5;
+
+        let ix = bx;
+        let iz = bz;
+        const edge = Math.floor(r4 * 4);
+        if (edge === 0)      { ix = bx - hw; iz = bz + (r1 - 0.5) * b.depth; }
+        else if (edge === 1) { ix = bx + hw; iz = bz + (r1 - 0.5) * b.depth; }
+        else if (edge === 2) { ix = bx + (r1 - 0.5) * b.width; iz = bz - hd; }
+        else                 { ix = bx + (r1 - 0.5) * b.width; iz = bz + hd; }
+
+        // Top of triangle at roofY, rotate to face outward from edge
+        dummy.position.set(ix, roofY, iz);
+        dummy.rotation.set(0, EDGE_Y_ROTATIONS[edge], 0);
+        dummy.scale.set(icicleR * 2, icicleH, 1);
+        dummy.updateMatrix();
+        result.push(dummy.matrix.clone());
+        indices.push(result.length - 1);
+      }
+
+      loginMap.set(login, indices);
+    }
+
+    return { matrices: result, buildingLoginMap: loginMap };
+  }, [buildings]);
+
+  const needsStamp = useRef(true);
+  useEffect(() => { needsStamp.current = true; }, [matrices, focusedLogin]);
+
+  const stamp = useCallback(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    for (let i = 0; i < TOTAL_ICICLE_INSTANCES; i++) mesh.setMatrixAt(i, hiddenMatrix);
+
+    if (focusedLogin) {
+      const indices = buildingLoginMap.get(focusedLogin.toLowerCase());
+      if (indices) indices.forEach((i) => { if (i < matrices.length) mesh.setMatrixAt(i, matrices[i]); });
+    } else {
+      matrices.forEach((m, i) => mesh.setMatrixAt(i, m));
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+    needsStamp.current = false;
+  }, [matrices, buildingLoginMap, focusedLogin, hiddenMatrix]);
+
+  useLayoutEffect(() => { stamp(); }, [stamp]);
+
+  useFrame(() => {
+    if (!needsStamp.current) return;
+    stamp();
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[geo, mat, TOTAL_ICICLE_INSTANCES]}
+      frustumCulled={false}
+    />
+  );
+}
+
+// ─── SnowWeather ─────────────────────────────────────────────────────────────
+//
+// Top-level component composed of three sub-systems:
+//   1. SnowflakeParticles  – 900 particles with shader-driven size variation
+//                            and per-particle snowflake rotation
+//   2. BreathFogParticles  – 80 large near-ground fog wisps
+//   3. Icicles             – instanced cone geometry along roof edges
+//
+// Integration in CityScene.tsx:
+//   import SnowWeather from "./SnowWeather";
+//   // Inside WeatherSystem, before the particle JSX:
+//   if (weatherMode === "snowy") return <SnowWeather buildings={buildings} />;
+//   // Pass buildings down: WeatherSystem({ weatherMode, buildings })
+
+export interface SnowWeatherProps {
+  buildings?: CityBuilding[];
+  focusedBuilding?: string | null;
+}
+
+export function SnowWeather({ buildings = [], focusedBuilding }: SnowWeatherProps) {
+  return (
+    <group name="subsystem-snow-weather">
+      <SnowflakeParticles />
+      <BreathFogParticles />
+      {buildings.length > 0 && <Icicles buildings={buildings} focusedLogin={focusedBuilding} />}
+    </group>
+  );
+}
+
+export default SnowWeather;

--- a/src/lib/useWeather.ts
+++ b/src/lib/useWeather.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+type WeatherMode = "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+
+const STORAGE_KEY = "leetcodecity_weather_mode";
+const MODES: WeatherMode[] = ["sunny", "rainy", "windy", "stormy", "snowy"];
+
+function isWeatherMode(v: unknown): v is WeatherMode {
+  return typeof v === "string" && (MODES as string[]).includes(v);
+}
+
+export function useWeather() {
+  // Always initialize with "sunny" to match SSR — localStorage is read after hydration
+  const [weatherMode, setWeatherModeState] = useState<WeatherMode>("sunny");
+  const [cityName, setCityName] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const setWeatherMode = useCallback((mode: WeatherMode) => {
+    setWeatherModeState(mode);
+    try { localStorage.setItem(STORAGE_KEY, mode); } catch {}
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (typeof window === "undefined" || !navigator.geolocation) return;
+    setIsLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        try {
+          const { latitude: lat, longitude: lon } = pos.coords;
+          const res = await fetch(`/api/weather?lat=${lat}&lon=${lon}`);
+          const data = await res.json();
+          if (isWeatherMode(data.weatherMode)) setWeatherModeState(data.weatherMode);
+          if (typeof data.cityName === "string") setCityName(data.cityName);
+        } catch {}
+        setIsLoading(false);
+      },
+      () => setIsLoading(false),
+      { timeout: 8000 }
+    );
+  }, []);
+
+  const searchByCity = useCallback(async (city: string) => {
+    if (!city.trim()) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/weather?city=${encodeURIComponent(city.trim())}`);
+      const data = await res.json();
+      if (isWeatherMode(data.weatherMode)) setWeatherModeState(data.weatherMode);
+      if (typeof data.cityName === "string") setCityName(data.cityName);
+    } catch {}
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    // Read saved preference after hydration to avoid SSR mismatch
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (isWeatherMode(saved)) {
+        setWeatherModeState(saved);
+        return; // user has a saved preference, skip geolocation
+      }
+    } catch {}
+    // First visit: auto-detect from geolocation
+    refresh();
+  }, [refresh]);
+
+  return { weatherMode, setWeatherMode, cityName, isLoading, refresh, searchByCity };
+}


### PR DESCRIPTION
## What does this PR do?
Implements a full dynamic snow weather system for the 3D city, covering all visual, atmospheric, and API integration requirements.

<!-- Brief description of changes -->

Visual Layer - src/components/SnowWeather.tsx (new)(major)
Snowflake particles: custom-shader particles with per-particle size variation
Breath fog simulating cold-air mist at street level
Icicles' geometry as flat 2D oriented outward from each roof edge ( since 3D appeared abrupt)

Atmosphere changes: Fog color shifts to cool blue-grey in snowy mode
Sun intensity reduced to 45% for an overcast sky feel

API Integration, which falls back to "sunny" on any error

_src/lib/useWeather.ts (new)_ : SSR-safe hook (initialises with "sunny" to avoid hydration mismatch); reads localStorage preference post-hydration; auto-detects via geolocation on first visit; exposes searchByCity(city) for manual lookup; setWeatherMode persists to localStorage
_src/components/ActionToolbar.tsx_ : weather button shows detected city name e.g. SNOWY (Tokyo); anchor icon opens inline city search input; Enter submits via searchByCity
_src/app/page.tsx_ : wires cityName, searchByCity, weatherLoading from useWeather into ActionToolbar; removes duplicate localStorage init (now handled by hook)

## Related issue

<!-- Link to issue: Fixes #149  -->

## Screenshots:
Before(Snow flakes rendered a cube values)
<img width="1799" height="850" alt="image" src="https://github.com/user-attachments/assets/f4a03fb7-0f0b-4ca4-a3b2-de35f28f030e" />

After(Snowflakes render as icicle geometry)
<img width="1900" height="869" alt="image" src="https://github.com/user-attachments/assets/599eec34-5fe8-49b2-bc38-2746388dc9c1" />

<img width="1908" height="870" alt="image" src="https://github.com/user-attachments/assets/bdd0d069-bc6f-46a2-a5c5-45ea2dd20ca3" />

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
