### PR TITLE
fix(fly): require mission quota score to exceed threshold

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,10 @@ import { useLiveUsers } from "@/lib/useLiveUsers";
 import { useCodingPresence } from "@/lib/useCodingPresence";
 import { useRaidSequence } from "@/lib/useRaidSequence";
 import { useDailies } from "@/lib/useDailies";
+import {
+  FLY_MISSION_QUOTA_POINTS,
+  hasExceededFlyMissionQuota,
+} from "@/lib/fly-quota";
 import DailiesWidget from "@/components/DailiesWidget";
 import RaidPreviewModal from "@/components/RaidPreviewModal";
 import RaidOverlay from "@/components/RaidOverlay";
@@ -2501,7 +2505,7 @@ function HomeContent() {
       !quotaNotified &&
       !quotaDismissed &&
       !quotaMissionCompleted &&
-      flyScore.score >= 50
+      hasExceededFlyMissionQuota(flyScore.score)
     ) {
       setQuotaReached(true);
       setQuotaNotified(true);
@@ -3064,7 +3068,8 @@ function HomeContent() {
                   MISSION QUOTA MATCHED!
                 </div>
                 <div className="text-[10px] text-cream/80">
-                  You&apos;ve reached 50 PX. Exit now to complete quest?
+                  You&apos;ve exceeded {FLY_MISSION_QUOTA_POINTS} PX. Exit now
+                  to complete quest?
                 </div>
                 <div className="mt-2 flex gap-3">
                   <button

--- a/src/lib/fly-quota.test.ts
+++ b/src/lib/fly-quota.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLY_MISSION_QUOTA_POINTS,
+  hasExceededFlyMissionQuota,
+} from "./fly-quota";
+
+describe("hasExceededFlyMissionQuota", () => {
+  it("does not match the mission quota at exactly 50 PX", () => {
+    expect(hasExceededFlyMissionQuota(FLY_MISSION_QUOTA_POINTS)).toBe(false);
+  });
+
+  it("matches the mission quota only after the player exceeds 50 PX", () => {
+    expect(hasExceededFlyMissionQuota(FLY_MISSION_QUOTA_POINTS + 1)).toBe(true);
+  });
+
+  it("keeps lower fly scores below the mission quota", () => {
+    expect(hasExceededFlyMissionQuota(FLY_MISSION_QUOTA_POINTS - 1)).toBe(false);
+  });
+});

--- a/src/lib/fly-quota.ts
+++ b/src/lib/fly-quota.ts
@@ -1,0 +1,5 @@
+export const FLY_MISSION_QUOTA_POINTS = 50;
+
+export function hasExceededFlyMissionQuota(score: number): boolean {
+  return score > FLY_MISSION_QUOTA_POINTS;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the fly mission quota popover so it appears only after the player exceeds 50 PX, not at exactly 50 PX.

Changes included:
- moves the quota threshold into `src/lib/fly-quota.ts`
- replaces the inclusive `>= 50` check with a strict helper-backed `> 50` check
- updates the HUD copy to say "exceeded 50 PX"
- adds a focused Vitest regression test for 49, 50, and 51 PX

## Related issue

Fixes #210

## Screenshots

Before fix: exact 50 PX incorrectly shows the quota popover.

![before 50](https://raw.githubusercontent.com/saurabhhhcodes/The-Leetcode-City/proof/210-mission-quota/issue-210/before-50.png)

After fix: exact 50 PX stays below the quota threshold.

![after 50](https://raw.githubusercontent.com/saurabhhhcodes/The-Leetcode-City/proof/210-mission-quota/issue-210/after-50.png)

After fix: 51 PX shows the quota popover.

![after 51](https://raw.githubusercontent.com/saurabhhhcodes/The-Leetcode-City/proof/210-mission-quota/issue-210/after-51.png)

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

Local verification:
- `npm test -- --run src/lib/fly-quota.test.ts`
- `npx eslint src/lib/fly-quota.ts src/lib/fly-quota.test.ts`
- `npm run build`
- `git diff --check`

Note: I did not mark the full lint checkbox because local `npm run lint` currently reports existing unrelated lint issues outside this PR's touched files.
