### PR TITLE
feat(weather): add sunset sunrise city effect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -578,10 +578,10 @@ function HomeContent() {
   const [themeIndex, setThemeIndex] = useState(0);
   const [isCodexOpen, setIsCodexOpen] = useState(false);
   const [dayNightCycleActive, setDayNightCycleActive] = useState(true);
-  const [weatherMode, setWeatherMode] = useState<"sunny" | "rainy" | "windy" | "stormy" | "snowy">("sunny");
+  const [weatherMode, setWeatherMode] = useState<"sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy">("sunny");
 
   const cycleWeather = () => {
-    const modes: ("sunny" | "rainy" | "windy" | "stormy" | "snowy")[] = ["sunny", "rainy", "windy", "stormy", "snowy"];
+    const modes: ("sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy")[] = ["sunny", "sunset", "rainy", "windy", "stormy", "snowy"];
     const idx = modes.indexOf(weatherMode);
     const next = modes[(idx + 1) % modes.length];
     setWeatherMode(next);
@@ -605,8 +605,8 @@ function HomeContent() {
     } catch { }
     try {
       const savedWeather = localStorage.getItem("leetcodecity_weather_mode");
-      if (savedWeather === "sunny" || savedWeather === "rainy" || savedWeather === "windy" || savedWeather === "stormy" || savedWeather === "snowy") {
-        setWeatherMode(savedWeather as any);
+      if (savedWeather === "sunny" || savedWeather === "sunset" || savedWeather === "rainy" || savedWeather === "windy" || savedWeather === "stormy" || savedWeather === "snowy") {
+        setWeatherMode(savedWeather as "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy");
       }
     } catch { }
   }, []);

--- a/src/components/ActionToolbar.tsx
+++ b/src/components/ActionToolbar.tsx
@@ -12,7 +12,7 @@ interface ActionToolbarProps {
   isMounted: boolean;
   dayNightCycleActive: boolean;
   setDayNightCycleActive: React.Dispatch<React.SetStateAction<boolean>>;
-  weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
   cycleWeather?: () => void;
 }
 

--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -247,9 +247,11 @@ interface CloudData {
 function VoxelClouds({
   active,
   timeRef,
+  weatherMode,
 }: {
   active: boolean;
   timeRef: React.MutableRefObject<number>;
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
 }) {
   const groupRef = useRef<THREE.Group>(null);
 
@@ -304,7 +306,7 @@ function VoxelClouds({
     });
 
     // 2. Interpolate cloud colors matching Midnight -> Dawn -> Noon -> Sunset -> Midnight
-    const t = active ? timeRef.current : 0.0;
+    const t = (active || weatherMode === "sunset") ? timeRef.current : 0.0;
     const numStates = ATMOSPHERE_STATES.length;
     const val = t * numStates;
     const idx1 = Math.floor(val) % numStates;
@@ -1249,7 +1251,7 @@ const sunGlowFragmentShader = `
 `;
 
 // ─── Starfield Component ───────────────────────────────────────
-function Starfield({ timeRef, active }: { timeRef: React.MutableRefObject<number>; active: boolean }) {
+function Starfield({ timeRef, active, weatherMode }: { timeRef: React.MutableRefObject<number>; active: boolean; weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy" }) {
   const pointsRef = useRef<THREE.Points>(null);
 
   const { positions, sizes, phases } = useMemo(() => {
@@ -1333,9 +1335,11 @@ function Starfield({ timeRef, active }: { timeRef: React.MutableRefObject<number
       pointsRef.current.position.copy(camera.position);
     }
 
-    const t = active ? timeRef.current : 0.0;
+    const t = (active || weatherMode === "sunset") ? timeRef.current : 0.0;
     let nightFactor = 0;
-    if (t < 0.25) {
+    if (weatherMode === "sunset") {
+      nightFactor = 0.25; // Keep stars slightly visible in the sunset purple sky
+    } else if (t < 0.25) {
       nightFactor = 1.0 - (t / 0.25);
     } else if (t > 0.75) {
       nightFactor = (t - 0.75) / 0.25;
@@ -1422,7 +1426,7 @@ interface AtmosphereCycleManagerProps {
   active: boolean;
   timeRef: React.MutableRefObject<number>;
   cityRadius?: number;
-  weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
 }
 
 export default function AtmosphereCycleManager({
@@ -1574,24 +1578,26 @@ export default function AtmosphereCycleManager({
       }
     }
 
-    if (active) {
-      // Global Day/Night Cycle based on India Standard Time (IST: UTC+5:30)
-      const now = Date.now();
-      const istOffset = 5.5 * 60 * 60 * 1000;
-      const istTime = new Date(now + istOffset);
-      
-      const hours = istTime.getUTCHours();
-      const minutes = istTime.getUTCMinutes();
-      const seconds = istTime.getUTCSeconds();
-      const ms = istTime.getUTCMilliseconds();
-      
-      const totalMs = 24 * 60 * 60 * 1000;
-      const elapsed = (hours * 3600000) + (minutes * 60000) + (seconds * 1000) + ms;
-      
-      // t goes linearly from 0.0 (midnight) -> 0.25 (6 AM) -> 0.5 (noon) -> 0.75 (6 PM) -> 1.0 (midnight)
-      t = elapsed / totalMs;
-
-      timeRef.current = t;
+    const activeCycle = active || weatherMode === "sunset";
+    if (activeCycle) {
+      if (weatherMode === "sunset") {
+        // Slow sunset oscillation on the horizon
+        t = 0.745 + Math.sin(state.clock.elapsedTime * 0.03) * 0.015;
+        timeRef.current = t;
+      } else {
+        // Global Day/Night Cycle based on user's actual local browser time
+        const localTime = new Date();
+        const hours = localTime.getHours();
+        const minutes = localTime.getMinutes();
+        const seconds = localTime.getSeconds();
+        const ms = localTime.getMilliseconds();
+        
+        const totalMs = 24 * 60 * 60 * 1000;
+        const elapsed = (hours * 3600000) + (minutes * 60000) + (seconds * 1000) + ms;
+        
+        t = elapsed / totalMs;
+        timeRef.current = t;
+      }
 
       // Interpolate atmosphere states
       const numStates = ATMOSPHERE_STATES.length;
@@ -1777,8 +1783,8 @@ export default function AtmosphereCycleManager({
       <directionalLight ref={fillLightRef} position={theme.fillPos} intensity={theme.fillIntensity * 3} color={theme.fillColor} />
       <hemisphereLight ref={hemiLightRef} args={[theme.hemiSky, theme.hemiGround, theme.hemiIntensity * 3.5]} />
 
-      <SkyDome timeRef={timeRef} theme={theme} active={active} />
-      <VoxelClouds active={active} timeRef={timeRef} />
+      <SkyDome timeRef={timeRef} theme={theme} active={active || weatherMode === "sunset"} />
+      <VoxelClouds active={active || weatherMode === "sunset"} timeRef={timeRef} weatherMode={weatherMode} />
       <AmbientOceanShips cityRadius={cityRadius ?? 800} />
       <FlyingCityShips cityRadius={cityRadius ?? 800} />
 
@@ -1827,7 +1833,7 @@ export default function AtmosphereCycleManager({
       </group>
 
       {/* Starfield for Night Sky */}
-      <Starfield timeRef={timeRef} active={active} />
+      <Starfield timeRef={timeRef} active={active || weatherMode === "sunset"} weatherMode={weatherMode} />
 
       {/* Moonlight Volumetric Rays and Lens Flare */}
       <VolumetricMoonRays moonGroupRef={moonGroupRef} />

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1065,7 +1065,7 @@ function Ground({ color, grid1, grid2 }: { color: string; grid1: string; grid2: 
   return null;
 }
 
-function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; color: string; weatherMode?: string }) {
+function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; color: string; weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy" }) {
   const platformRadius = radius + 120;
 
   const { supportColumns, concretePaths } = useMemo(() => {
@@ -1964,7 +1964,7 @@ interface Props {
   wallpaperSpeed?: number;
   liveByLogin?: Map<string, LiveSession>;
   cityEnergy?: number;
-  weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
 }
 
 // Dynamically adjust scene exposure based on city energy (devs coding)
@@ -2141,6 +2141,8 @@ export default function CityCanvas({ buildings, plazas, decorations, river, brid
         cityEnergy={cityEnergy}
         timeRef={timeRef}
         weatherMode={weatherMode}
+        themeIndex={themeIndex}
+        active={dayNightCycleActive ?? false}
       />
 
       <InstancedDecorations items={decorations} roadMarkingColor={t.roadMarkingColor} sidewalkColor={t.sidewalkColor} />

--- a/src/components/CityScene.tsx
+++ b/src/components/CityScene.tsx
@@ -9,6 +9,7 @@ import InstancedLabels from "./InstancedLabels";
 import EffectsLayer from "./EffectsLayer";
 import LiveDots from "./LiveDots";
 import SunnyWeather from "./SunnyWeather";
+import InstancedShadows from "./InstancedShadows";
 import type { LiveSession } from "@/lib/useCodingPresence";
 import type { CityBuilding } from "@/lib/github";
 import type { BuildingColors } from "./CityCanvas";
@@ -116,10 +117,20 @@ interface CitySceneProps {
   liveByLogin?: Map<string, LiveSession>;
   cityEnergy?: number;
   timeRef?: React.MutableRefObject<number>;
-  weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
+  themeIndex?: number;
+  active?: boolean;
 }
 
-function WeatherSystem({ weatherMode }: { weatherMode: "sunny" | "rainy" | "windy" | "stormy" | "snowy" }) {
+function WeatherSystem({
+  weatherMode,
+  timeRef,
+  active,
+}: {
+  weatherMode: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
+  timeRef?: React.MutableRefObject<number>;
+  active?: boolean;
+}) {
   const pointsRef = useRef<THREE.Points>(null);
   const leavesRef = useRef<THREE.Points>(null);
   const { camera } = useThree();
@@ -266,11 +277,14 @@ function WeatherSystem({ weatherMode }: { weatherMode: "sunny" | "rainy" | "wind
     }
   });
 
-  if (weatherMode === "sunny") {
+  if (weatherMode === "sunny" || weatherMode === "sunset") {
     return (
       <SunnyWeather
+        mode={weatherMode}
         intensity={1.0}
-        sunPosition={[600, 400, -300]}
+        sunPosition={weatherMode === "sunset" ? [600, 50, -400] : [600, 400, -300]}
+        timeRef={timeRef}
+        active={active}
       />
     );
   }
@@ -347,6 +361,8 @@ export default function CityScene({
   cityEnergy,
   timeRef,
   weatherMode = "sunny",
+  themeIndex = 0,
+  active = false,
 }: CitySceneProps) {
   const atlasTexture = useMemo(() => createWindowAtlas(colors), [colors]);
   const grid = useMemo(
@@ -405,6 +421,14 @@ export default function CityScene({
 
   return (
     <>
+      <InstancedShadows
+        buildings={buildings}
+        timeRef={timeRef!}
+        weatherMode={weatherMode}
+        themeIndex={themeIndex}
+        active={active}
+      />
+
       <InstancedBuildings
         buildings={buildings}
         colors={colors}
@@ -418,6 +442,7 @@ export default function CityScene({
         cityEnergy={cityEnergy}
         timeRef={timeRef}
         weatherMode={weatherMode}
+        themeIndex={themeIndex}
       />
 
 
@@ -447,7 +472,7 @@ export default function CityScene({
         ghostPreviewLogin={ghostPreviewLogin}
       />
 
-      {!introMode && <WeatherSystem weatherMode={weatherMode} />}
+      {!introMode && <WeatherSystem weatherMode={weatherMode} timeRef={timeRef} active={active} />}
 
       {!introMode && focusedBuildingData && (
         <group

--- a/src/components/InstancedBuildings.tsx
+++ b/src/components/InstancedBuildings.tsx
@@ -65,6 +65,7 @@ const fragmentShader = /* glsl */ `
   uniform float uDimOpacity;
   uniform float uDimEmissive;
   uniform float uCityEnergy;
+  uniform float uSunsetSilhouette; // 0.0 or 1.0
   uniform float uTimeOfDay; // 0.0 = Night, 1.0 = Day
   uniform float uSnowIntensity; // 0.0 to 1.0
 
@@ -127,6 +128,12 @@ const fragmentShader = /* glsl */ `
     vec3 liveBoost = vec3(1.4, 1.35, 1.2);
     wallFinal = mix(wallFinal, wallFinal * liveBoost, vLive);
 
+    if (uSunsetSilhouette > 0.5) {
+      float NdotL = dot(vNormal, normalize(vec3(0.3, mix(0.2, 1.0, uTimeOfDay), 0.5)));
+      float backlit = smoothstep(0.4, -0.1, NdotL);
+      wallFinal = mix(wallFinal, wallFinal * 0.15, backlit);
+    }
+
     vec3 roofFinal = uRoofColor * (ambientDay + 1.4 * uCityEnergy);
     vec3 snowColor = vec3(0.97, 0.98, 1.0);
     roofFinal = mix(roofFinal, snowColor * (ambientDay + 1.0), uSnowIntensity);
@@ -136,6 +143,13 @@ const fragmentShader = /* glsl */ `
     // Directional light changes based on time
     vec3 lightDir = normalize(vec3(0.3, mix(0.2, 1.0, uTimeOfDay), 0.5));
     float diffuse = max(dot(vNormal, lightDir), 0.0) * mix(0.2, 0.5, uTimeOfDay) + mix(0.5, 0.8, uTimeOfDay);
+    
+    if (uSunsetSilhouette > 0.5) {
+      float NdotL = dot(vNormal, lightDir);
+      float backlit = smoothstep(0.4, -0.1, NdotL);
+      diffuse = mix(diffuse, diffuse * 0.18, backlit);
+    }
+
     color *= diffuse;
 
     float isFocused = step(abs(vInstanceId - uFocusedId), 0.5)
@@ -191,7 +205,9 @@ interface InstancedBuildingsProps {
   liveByLogin?: Map<string, unknown>;
   cityEnergy?: number;
   timeRef?: React.MutableRefObject<number>;
-  weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
+  themeIndex?: number;
+  active?: boolean;
 }
 
 interface RiseState {
@@ -218,6 +234,8 @@ export default memo(function InstancedBuildings({
   cityEnergy = 1.0,
   timeRef,
   weatherMode = "sunny",
+  themeIndex = 0,
+  active = false,
 }: InstancedBuildingsProps) {
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const count = buildings.length;
@@ -247,6 +265,7 @@ export default memo(function InstancedBuildings({
         uCityEnergy: { value: cityEnergy },
         uTimeOfDay: { value: 1.0 },
         uSnowIntensity: { value: weatherMode === "snowy" ? 1.0 : 0.0 },
+        uSunsetSilhouette: { value: (weatherMode === "sunset" || (themeIndex === 1 && weatherMode === "sunny")) ? 1.0 : 0.0 },
       },
       vertexShader,
       fragmentShader,
@@ -263,8 +282,9 @@ export default memo(function InstancedBuildings({
     material.uniforms.uDimEmissive.value = dimEmissive;
     material.uniforms.uCityEnergy.value = cityEnergy;
     material.uniforms.uSnowIntensity.value = weatherMode === "snowy" ? 1.0 : 0.0;
+    material.uniforms.uSunsetSilhouette.value = (weatherMode === "sunset" || (themeIndex === 1 && weatherMode === "sunny")) ? 1.0 : 0.0;
     material.needsUpdate = true;
-  }, [atlasTexture, colors.roof, colors.face, dimOpacity, dimEmissive, cityEnergy, weatherMode, material]);
+  }, [atlasTexture, colors.roof, colors.face, dimOpacity, dimEmissive, cityEnergy, weatherMode, themeIndex, material]);
 
   const { uvFrontData, uvSideData, riseData, tintData, lcData } =
     useMemo(() => {
@@ -449,6 +469,26 @@ export default memo(function InstancedBuildings({
     // Map cycle progress [0, 1] to uTimeOfDay [0, 1] using cosine curve
     const uTimeVal = (1.0 - Math.cos(tVal * 2.0 * Math.PI)) / 2.0;
     material.uniforms.uTimeOfDay.value = uTimeVal;
+
+    const isSunsetWeather = weatherMode === "sunset";
+    const isSunsetTheme = themeIndex === 1 && weatherMode === "sunny";
+
+    let localSunsetSunriseIntensity = 0.0;
+    if (active) {
+      // Sunrise: 5 AM - 7 AM (t between 0.2083 and 0.2917, peak at 0.25)
+      let sunriseIntensity = 0.0;
+      if (tVal >= 0.2083 && tVal <= 0.2917) {
+        sunriseIntensity = 1.0 - Math.abs(tVal - 0.25) / 0.0417;
+      }
+      // Sunset: 5 PM - 7 PM (t between 0.7083 and 0.7917, peak at 0.75)
+      let sunsetIntensity = 0.0;
+      if (tVal >= 0.7083 && tVal <= 0.7917) {
+        sunsetIntensity = 1.0 - Math.abs(tVal - 0.75) / 0.0417;
+      }
+      localSunsetSunriseIntensity = Math.max(sunriseIntensity, sunsetIntensity);
+    }
+    const finalIntensity = Math.max(localSunsetSunriseIntensity, (isSunsetWeather || isSunsetTheme) ? 1.0 : 0.0);
+    material.uniforms.uSunsetSilhouette.value = finalIntensity;
 
     const lastFogColorHex = material.uniforms.uFogColor.value.getHex();
     const currentFogHex = fog.color.getHex();
@@ -671,6 +711,7 @@ export default memo(function InstancedBuildings({
       frustumCulled={false}
       receiveShadow={false}
       castShadow={false}
+      name="instanced-buildings"
     />
   );
 });

--- a/src/components/InstancedShadows.tsx
+++ b/src/components/InstancedShadows.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useRef, useMemo, useEffect, memo } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import type { CityBuilding } from "@/lib/github";
+
+const vertexShader = /* glsl */ `
+  attribute float aRise;
+  varying float vAlpha;
+
+  uniform vec3 uSunDir;
+  uniform float uActive;
+
+  void main() {
+    vec3 localPos = position;
+    
+    // Apply rise animation matching InstancedBuildings
+    localPos.y = localPos.y * aRise + (aRise - 1.0) * 0.5;
+
+    // Transform by instanceMatrix to get world position
+    vec4 worldPos = instanceMatrix * vec4(localPos, 1.0);
+
+    // Height of this vertex above the ground
+    float height = max(worldPos.y, 0.0);
+
+    // Project/shear along the sun direction vector
+    float clampSunY = max(uSunDir.y, 0.08);
+    worldPos.xz += -uSunDir.xz * (height / clampSunY);
+
+    // Squash to ground level with small Y offset to prevent z-fighting
+    worldPos.y = 0.08;
+
+    // Calculate length of the shadow projection to apply a soft fade-out
+    float shadowLength = height / clampSunY;
+    vAlpha = clamp(1.0 - (shadowLength / 450.0), 0.0, 1.0) * uActive;
+
+    gl_Position = projectionMatrix * viewMatrix * worldPos;
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  varying float vAlpha;
+
+  void main() {
+    // Stylized dark purple-tinted shadow
+    gl_FragColor = vec4(0.08, 0.04, 0.12, vAlpha * 0.45);
+  }
+`;
+
+const _matrix = new THREE.Matrix4();
+const _position = new THREE.Vector3();
+const _quaternion = new THREE.Quaternion();
+const _scale = new THREE.Vector3(1, 1, 1);
+const _sunDir = new THREE.Vector3();
+
+interface InstancedShadowsProps {
+  buildings: CityBuilding[];
+  timeRef: React.MutableRefObject<number>;
+  weatherMode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
+  themeIndex: number;
+  active: boolean;
+}
+
+export default memo(function InstancedShadows({
+  buildings,
+  timeRef,
+  weatherMode = "sunny",
+  themeIndex,
+  active,
+}: InstancedShadowsProps) {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const count = buildings.length;
+
+  const geo = useMemo(() => new THREE.BoxGeometry(1, 1, 1), []);
+  const material = useMemo(() => {
+    return new THREE.ShaderMaterial({
+      uniforms: {
+        uSunDir: { value: new THREE.Vector3(0.5, 0.5, 0.5) },
+        uActive: { value: 0.0 },
+      },
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.NormalBlending,
+    });
+  }, []);
+
+  const riseData = useMemo(() => {
+    const rise = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      rise[i] = 0;
+    }
+    return rise;
+  }, [count]);
+
+  // Set up instance matrices and custom attributes
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    for (let i = 0; i < count; i++) {
+      const b = buildings[i];
+      _position.set(b.position[0], b.height / 2, b.position[2]);
+      _scale.set(b.width, b.height, b.depth);
+      _matrix.compose(_position, _quaternion, _scale);
+      mesh.setMatrixAt(i, _matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+
+    // Set bounding sphere to avoid premature culling
+    let maxDist = 0;
+    let maxHeight = 0;
+    for (let i = 0; i < count; i++) {
+      const b = buildings[i];
+      const d = Math.sqrt(b.position[0] ** 2 + b.position[2] ** 2);
+      if (d > maxDist) maxDist = d;
+      if (b.height > maxHeight) maxHeight = b.height;
+    }
+    mesh.boundingSphere = new THREE.Sphere(
+      new THREE.Vector3(0, maxHeight / 2, 0),
+      (maxDist + maxHeight) * 1.5
+    );
+
+    const riseAttr = new THREE.InstancedBufferAttribute(riseData, 1);
+    riseAttr.setUsage(THREE.DynamicDrawUsage);
+    mesh.geometry.setAttribute("aRise", riseAttr);
+
+    mesh.count = count;
+  }, [buildings, count, riseData]);
+
+  // Update rise animation in sync with buildings
+  useFrame(({ scene }) => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    const bMesh = scene.getObjectByName("instanced-buildings") as THREE.InstancedMesh | null;
+    const riseAttr = mesh.geometry.getAttribute("aRise") as THREE.InstancedBufferAttribute | undefined;
+    if (bMesh && riseAttr) {
+      const bRiseAttr = bMesh.geometry.getAttribute("aRise") as THREE.InstancedBufferAttribute | undefined;
+      if (bRiseAttr) {
+        (riseAttr.array as Float32Array).set(bRiseAttr.array as Float32Array);
+        riseAttr.needsUpdate = true;
+      }
+    }
+  });
+
+  // Calculate sun direction and active state
+  useFrame((state) => {
+    if (!material.uniforms) return;
+
+    // Check manual weather overrides
+    const isSunsetWeather = weatherMode === "sunset";
+    const isSunsetTheme = themeIndex === 1 && weatherMode === "sunny";
+
+    // Calculate local sunset/sunrise intensity factor if day-night cycle is active
+    let localSunsetSunriseIntensity = 0.0;
+    const tVal = timeRef ? timeRef.current : 0.0;
+    if (active) {
+      // Sunrise: 5 AM - 7 AM (t between 0.2083 and 0.2917, peak at 0.25)
+      let sunriseIntensity = 0.0;
+      if (tVal >= 0.2083 && tVal <= 0.2917) {
+        sunriseIntensity = 1.0 - Math.abs(tVal - 0.25) / 0.0417;
+      }
+      
+      // Sunset: 5 PM - 7 PM (t between 0.7083 and 0.7917, peak at 0.75)
+      let sunsetIntensity = 0.0;
+      if (tVal >= 0.7083 && tVal <= 0.7917) {
+        sunsetIntensity = 1.0 - Math.abs(tVal - 0.75) / 0.0417;
+      }
+      
+      localSunsetSunriseIntensity = Math.max(sunriseIntensity, sunsetIntensity);
+    }
+
+    // Combine local time intensity with manual overrides
+    const finalIntensity = Math.max(localSunsetSunriseIntensity, (isSunsetWeather || isSunsetTheme) ? 1.0 : 0.0);
+
+    // Update active uniform
+    material.uniforms.uActive.value = finalIntensity;
+
+    if (finalIntensity > 0.01) {
+      // Calculate dynamic sun coordinates matching AtmosphereCycleManager
+      const theta = 2.0 * Math.PI * tVal - Math.PI / 2.0;
+
+      // Position corresponds to AtmosphereCycleManager's sun position
+      const sunX = Math.cos(theta) * 600;
+      const sunY = Math.sin(theta) * 500;
+      const sunZ = -200;
+
+      _sunDir.set(sunX, sunY, sunZ).normalize();
+      material.uniforms.uSunDir.value.copy(_sunDir);
+    }
+  });
+
+  useEffect(() => {
+    return () => {
+      geo.dispose();
+      material.dispose();
+    };
+  }, [geo, material]);
+
+  if (count === 0) return null;
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[geo, material, count]}
+      frustumCulled={false}
+      name="instanced-shadows"
+    />
+  );
+});

--- a/src/components/SunnyWeather.tsx
+++ b/src/components/SunnyWeather.tsx
@@ -21,10 +21,13 @@ import * as THREE from "three";
 // --- 1. TYPE DEFINITIONS & CONSTANTS ---
 
 export interface WeatherProps {
+  mode?: "sunny" | "sunset" | "rainy" | "windy" | "stormy" | "snowy";
   intensity?: number;
   sunPosition?: [number, number, number];
   isTransitioning?: boolean;
   onTransitionComplete?: () => void;
+  timeRef?: React.MutableRefObject<number>;
+  active?: boolean;
 }
 
 const HEAT_SHIMMER_SPEED = 1.4;
@@ -82,10 +85,20 @@ const ShimmerShader = {
 // --- 3. SUB-COMPONENTS ---
 
 /**
- * HeatShimmerPlane
+ * HeatShimmerVolume
  * Generates a bounded ground-volume mesh executing the displacement shader.
  */
-const HeatShimmerVolume = ({ intensity }: { intensity: number }) => {
+const HeatShimmerVolume = ({
+  intensity,
+  active,
+  timeRef,
+  mode,
+}: {
+  intensity: number;
+  active?: boolean;
+  timeRef?: React.MutableRefObject<number>;
+  mode?: string;
+}) => {
   const meshRef = useRef<THREE.Mesh>(null);
   
   const uniforms = useMemo(() => ({
@@ -98,6 +111,35 @@ const HeatShimmerVolume = ({ intensity }: { intensity: number }) => {
     if (meshRef.current) {
       const mat = meshRef.current.material as THREE.ShaderMaterial;
       mat.uniforms.uTime.value = state.clock.getElapsedTime();
+
+      let strengthFactor = 1.0;
+      if (active && timeRef) {
+        const tVal = timeRef.current;
+        const theta = 2.0 * Math.PI * tVal - Math.PI / 2.0;
+        const sunY = Math.sin(theta);
+        
+        let sunriseIntensity = 0.0;
+        if (tVal >= 0.2083 && tVal <= 0.2917) {
+          sunriseIntensity = 1.0 - Math.abs(tVal - 0.25) / 0.0417;
+        }
+        
+        let sunsetIntensity = 0.0;
+        if (tVal >= 0.7083 && tVal <= 0.7917) {
+          sunsetIntensity = 1.0 - Math.abs(tVal - 0.75) / 0.0417;
+        }
+        
+        const localSunsetSunriseIntensity = Math.max(sunriseIntensity, sunsetIntensity);
+        const finalSunsetIntensity = Math.max(localSunsetSunriseIntensity, mode === "sunset" ? 1.0 : 0.0);
+        
+        const isAboveHorizon = sunY > 0;
+        const horizonFactor = isAboveHorizon ? sunY : 0.0;
+        
+        strengthFactor = horizonFactor * (1.0 - finalSunsetIntensity);
+      } else if (mode === "sunset") {
+        strengthFactor = 0.0;
+      }
+      
+      mat.uniforms.uStrength.value = HEAT_SHIMMER_STRENGTH * intensity * strengthFactor;
     }
   });
 
@@ -139,7 +181,7 @@ const SunLensFlare = ({ sunPos }: { sunPos: THREE.Vector3 }) => {
     const projPos = sunPos.clone().project(camera);
     const isBehindCamera = projPos.z > 1;
 
-    if (isBehindCamera) {
+    if (isBehindCamera || sunPos.y < 0) {
       flareRef.current.visible = false;
       return;
     }
@@ -178,10 +220,13 @@ const SunLensFlare = ({ sunPos }: { sunPos: THREE.Vector3 }) => {
 // --- 4. MAIN WEATHER SYSTEM CONTROLLER ---
 
 export const SunnyWeather = ({
+  mode = "sunny",
   intensity = 1.0,
   sunPosition = [600, 400, -300],
   isTransitioning = false,
-  onTransitionComplete
+  onTransitionComplete,
+  timeRef,
+  active = false,
 }: WeatherProps) => {
   const directionalLightRef = useRef<THREE.DirectionalLight>(null);
   const ambientLightRef = useRef<THREE.AmbientLight>(null);
@@ -197,14 +242,98 @@ export const SunnyWeather = ({
     }
   }, [isTransitioning, onTransitionComplete]);
 
+  useFrame(() => {
+    const isSunsetWeather = mode === "sunset";
+    let finalSunsetIntensity = isSunsetWeather ? 1.0 : 0.0;
+    let tVal = 0.0;
+
+    if (active && timeRef) {
+      tVal = timeRef.current;
+      const theta = 2.0 * Math.PI * tVal - Math.PI / 2.0;
+
+      const sunX = Math.cos(theta) * 600;
+      const sunY = Math.sin(theta) * 500;
+      const sunZ = -200;
+
+      parsedSunPos.set(sunX, sunY, sunZ);
+
+      // Sunrise: 5 AM - 7 AM (t between 0.2083 and 0.2917, peak at 0.25)
+      let sunriseIntensity = 0.0;
+      if (tVal >= 0.2083 && tVal <= 0.2917) {
+        sunriseIntensity = 1.0 - Math.abs(tVal - 0.25) / 0.0417;
+      }
+      
+      // Sunset: 5 PM - 7 PM (t between 0.7083 and 0.7917, peak at 0.75)
+      let sunsetIntensity = 0.0;
+      if (tVal >= 0.7083 && tVal <= 0.7917) {
+        sunsetIntensity = 1.0 - Math.abs(tVal - 0.75) / 0.0417;
+      }
+      
+      const localSunsetSunriseIntensity = Math.max(sunriseIntensity, sunsetIntensity);
+      finalSunsetIntensity = Math.max(localSunsetSunriseIntensity, isSunsetWeather ? 1.0 : 0.0);
+
+      // Interpolate colors
+      const sunColorObj = new THREE.Color("#fffaed").lerp(new THREE.Color("#ff7320"), finalSunsetIntensity);
+      const ambientColorObj = new THREE.Color("#ffebcc").lerp(new THREE.Color("#602c40"), finalSunsetIntensity);
+
+      // Scale by sun above horizon factor
+      const isAboveHorizon = sunY > 0;
+      const horizonFactor = isAboveHorizon ? Math.min(1.0, sunY / 100) : 0.0; // smooth fade in near horizon
+
+      const finalSunIntensity = isAboveHorizon
+        ? (2.8 * (1.0 - finalSunsetIntensity) + 3.0 * finalSunsetIntensity) * intensity * horizonFactor
+        : 0.0;
+
+      const finalAmbientIntensity = isAboveHorizon
+        ? (0.45 * (1.0 - finalSunsetIntensity) + 0.3 * finalSunsetIntensity) * intensity * horizonFactor
+        : 0.0;
+
+      if (directionalLightRef.current) {
+        directionalLightRef.current.position.copy(parsedSunPos);
+        directionalLightRef.current.color.copy(sunColorObj);
+        directionalLightRef.current.intensity = finalSunIntensity;
+      }
+
+      if (ambientLightRef.current) {
+        ambientLightRef.current.color.copy(ambientColorObj);
+        ambientLightRef.current.intensity = finalAmbientIntensity;
+      }
+    } else {
+      // Static override settings
+      const sunColorObj = new THREE.Color(isSunsetWeather ? "#ff7320" : "#fffaed");
+      const ambientColorObj = new THREE.Color(isSunsetWeather ? "#602c40" : "#ffebcc");
+      const finalSunIntensity = (isSunsetWeather ? 3.0 : 2.8) * intensity;
+      const finalAmbientIntensity = (isSunsetWeather ? 0.3 : 0.45) * intensity;
+
+      parsedSunPos.set(sunPosition[0], sunPosition[1], sunPosition[2]);
+
+      if (directionalLightRef.current) {
+        directionalLightRef.current.position.copy(parsedSunPos);
+        directionalLightRef.current.color.copy(sunColorObj);
+        directionalLightRef.current.intensity = finalSunIntensity;
+      }
+
+      if (ambientLightRef.current) {
+        ambientLightRef.current.color.copy(ambientColorObj);
+        ambientLightRef.current.intensity = finalAmbientIntensity;
+      }
+    }
+  });
+
+  const isSunset = mode === "sunset";
+  const initialSunColor = isSunset ? "#ff7320" : "#fffaed";
+  const initialSunIntensity = isSunset ? 3.0 * intensity : 2.8 * intensity;
+  const initialAmbientColor = isSunset ? "#602c40" : "#ffebcc";
+  const initialAmbientIntensity = isSunset ? 0.3 * intensity : 0.45 * intensity;
+
   return (
-    <group name="subsystem-sunny-weather">
+    <group name={isSunset ? "subsystem-sunset-weather" : "subsystem-sunny-weather"}>
       {/* Intense Golden Hour Directional Light System */}
       <directionalLight
         ref={directionalLightRef}
         position={parsedSunPos}
-        color="#fffaed"
-        intensity={2.8 * intensity}
+        color={initialSunColor}
+        intensity={initialSunIntensity}
         castShadow
         shadow-mapSize-width={2048}
         shadow-mapSize-height={2048}
@@ -219,12 +348,12 @@ export const SunnyWeather = ({
       {/* Warm Ambient Reflection Secondary Bounce */}
       <ambientLight
         ref={ambientLightRef}
-        color="#ffebcc"
-        intensity={0.45 * intensity}
+        color={initialAmbientColor}
+        intensity={initialAmbientIntensity}
       />
 
       {/* High-Fidelity Rendering Layer Components */}
-      <HeatShimmerVolume intensity={intensity} />
+      <HeatShimmerVolume intensity={intensity} active={active} timeRef={timeRef} mode={mode} />
       <VolumetricGodRays sunPos={parsedSunPos} />
       <SunLensFlare sunPos={parsedSunPos} />
     </group>


### PR DESCRIPTION
## What does this PR do?

This PR implements a dynamic Sunset/Sunrise weather effect for the 3D city.

The feature extends the existing atmosphere and weather systems to create a more immersive golden-hour experience with warm sky gradients, sunset lighting, cloud tinting, star visibility, building silhouettes, and long projected shadows.

The atmosphere now responds to the user's actual local browser time through the existing day/night cycle. A manual **SUNSET** weather mode has also been added for previewing and testing the effect on demand.

### Changes Made

* Added `sunset` support to the weather system.
* Integrated sunset/sunrise visuals into the existing atmosphere cycle.
* Added local time-based atmosphere progression using the user's browser time.
* Added warm orange/purple sky transitions and sunset color grading.
* Enhanced ambient and directional lighting for golden-hour effects.
* Added sunset cloud tinting and gradual star visibility.
* Added building silhouette rendering during sunset conditions.
* Added a performant instanced shadow system for longer sunset-style shadows.
* Integrated the effect with the existing Three.js city scene and weather pipeline.

### Testing

* Verified successful production build using `npm run build`.
* Confirmed visible transition between Sunny and Sunset modes.
* Tested atmosphere updates using local browser time.
* Verified integration with existing weather and atmosphere systems.

## Related issue

Fixes #151

## Checklist

* [x] Implemented Sunset/Sunrise weather effect
* [x] Integrated with existing Three.js city scene
* [x] Added time-based atmosphere behavior
* [x] Added sunset lighting and sky transitions
* [x] Added cloud and star atmosphere effects
* [x] Added building silhouette support
* [x] Added projected shadow system
* [x] Verified successful production build
* [x] Added screenshots demonstrating the effect
