### PR TITLE
fix: clean up arena webview listeners

### DIFF
--- a/packages/vscode-extension/src/arena/ArenaProvider.ts
+++ b/packages/vscode-extension/src/arena/ArenaProvider.ts
@@ -1155,13 +1155,43 @@ export class ArenaProvider implements vscode.WebviewViewProvider {
     let selectedLanguage = 'py';
     let timerEnabled = true;
 
+    // Clear listeners from a previous webview script run before registering new ones.
+    if (window.__leetcodeCityArenaCleanup) {
+      window.__leetcodeCityArenaCleanup();
+    }
+
+    const cleanupListeners = [];
+    function cleanupArenaListeners() {
+      while (cleanupListeners.length > 0) {
+        const cleanup = cleanupListeners.pop();
+        try {
+          cleanup();
+        } catch (err) {
+          console.warn('Failed to clean up arena listener:', err);
+        }
+      }
+      if (window.__leetcodeCityArenaCleanup === cleanupArenaListeners) {
+        delete window.__leetcodeCityArenaCleanup;
+      }
+    }
+
+    window.__leetcodeCityArenaCleanup = cleanupArenaListeners;
+
+    const addManagedListener = (target, event, handler, options) => {
+      if (!target) return;
+      target.addEventListener(event, handler, options);
+      cleanupListeners.push(() => target.removeEventListener(event, handler, options));
+    };
+
+    addManagedListener(window, 'pagehide', cleanupArenaListeners, { once: true });
+
     // ── Init ──
     vscode.postMessage({ type: "requestState" });
 
     // ── Event Listeners ──
     const addListener = (id, event, handler) => {
       const el = document.getElementById(id);
-      if (el) el.addEventListener(event, handler);
+      addManagedListener(el, event, handler);
     };
 
     addListener('nav-back-btn', 'click', goBack);
@@ -1180,7 +1210,7 @@ export class ArenaProvider implements vscode.WebviewViewProvider {
     // Set up toggle event listener for daily challenges
     const dailySection = document.getElementById('section-daily');
     if (dailySection) {
-      dailySection.addEventListener('toggle', () => {
+      addManagedListener(dailySection, 'toggle', () => {
         if (dailySection.open && dailyChallenges.length === 0) {
           vscode.postMessage({ type: "fetchDailyChallenges" });
         }
@@ -1619,7 +1649,7 @@ export class ArenaProvider implements vscode.WebviewViewProvider {
     }
 
     // ── Message handler ──
-    window.addEventListener('message', (event) => {
+    addManagedListener(window, 'message', (event) => {
       const msg = event.data;
       switch (msg.type) {
         case 'dailyLoading':


### PR DESCRIPTION
## What does this PR do?

This PR fixes event-listener lifecycle cleanup in the VS Code arena webview script.

The webview previously registered static DOM/window listeners directly. If the webview script ran again during reload or lifecycle restoration, older handlers could remain active and cause duplicate click, toggle, or message handling.

Changes:
- add a managed listener registry inside the arena webview script
- clear listeners from a previous script run before registering new ones
- route static button handlers, the daily toggle handler, the `pagehide` cleanup, and the `message` handler through the same cleanup path

## Related issue

Fixes #267

## Screenshots

Not applicable. This is a lifecycle cleanup fix with no UI change.

## Checklist

- [x] `npm run build` passes in `packages/vscode-extension`
- [x] `git diff --check` passes
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

## Validation notes

- `npm run build` in `packages/vscode-extension` passes.
- `git diff --check` passes.
- Root `npm run lint` is still blocked by existing repo-wide lint errors outside this patch, including generated `packages/vscode-extension/dist/extension.js`, pre-existing `no-explicit-any` issues in extension files, and unrelated React compiler warnings.
