### PR TITLE
fix: gate building action buttons behind identity resolution (#265)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -693,6 +693,7 @@ function HomeContent() {
     }
   }, [codingPanelOpen, hasVsCodeKey]);
   const [session, setSession] = useState<Session | null>(null);
+  const [sessionResolved, setSessionResolved] = useState(false);
   const [claiming, setClaiming] = useState(false);
   const [purchasedItem, setPurchasedItem] = useState<string | null>(null);
   const [selectedBuilding, setSelectedBuilding] = useState<CityBuilding | null>(
@@ -949,10 +950,12 @@ function HomeContent() {
           setLinkedLeetCodeUsername(null);
         } finally {
           setLinkStatusResolved(true);
+          setSessionResolved(true);
         }
       } else {
         setLinkedLeetCodeUsername(null);
         setLinkStatusResolved(true);
+        setSessionResolved(true);
       }
     };
 
@@ -1069,7 +1072,7 @@ function HomeContent() {
     ""
   ).toLowerCase();
   const selfLogin = (linkedLeetCodeUsername ?? authLogin).toLowerCase();
-  const identityResolved = !session || linkStatusResolved;
+  const identityResolved = sessionResolved && (!session || linkStatusResolved);
 
   // Extra guard: check if selected building is own by comparing linked account
   const isOwnBuilding =
@@ -4967,7 +4970,8 @@ function HomeContent() {
                   )}
 
                 {/* A7: Show equipped items on other devs' buildings (mimetic desire) */}
-                {!isOwnBuilding &&
+                {identityResolved &&
+                  !isOwnBuilding &&
                   (() => {
                     const equipped: string[] = [];
                     if (selectedBuilding.loadout?.crown)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a UI flicker issue where guest-only building action buttons could briefly appear before user identity resolution was completed.

When a logged-in user opened their own building, ownership checks depended on asynchronously loaded account information. During this loading period, guest actions such as Battle, Kudos, and Compare could temporarily render before being replaced by the correct owner controls.

## Changes made

### Identity Resolution

- Added a dedicated `sessionResolved` state
- Ensured identity resolution is only considered complete after the async session/account lookup finishes

### UI Gating

- Updated the `identityResolved` condition to wait for both:
  - Session resolution
  - Linked account resolution

- Prevented guest-only building actions from rendering until identity resolution is complete

### Result

- Guest controls no longer appear temporarily for building owners
- Ownership-based UI renders consistently
- Eliminates the visible action button flicker during page load

## Related Issue

Fixes #265


### Before

Guest-only actions (Battle, Kudos, Compare, etc.) could briefly appear while identity information was still loading.

### After

Building actions are rendered only after identity resolution completes, preventing incorrect controls from appearing.


## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
