### PR TITLE
fix: prevent stale state updates in CodexModal on close (#288)

### DIFF
--- a/src/components/CodexModal.tsx
+++ b/src/components/CodexModal.tsx
@@ -71,17 +71,23 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
   // Fetch Codex data on mount/open
   useEffect(() => {
     if (!isOpen) return;
+    let cancelled = false;
     setLoading(true);
     fetch("/api/codex")
       .then((res) => res.json())
       .then((codexData) => {
+        if (cancelled) return;
         setData(codexData);
         setLoading(false);
       })
       .catch((err) => {
+        if (cancelled) return;
         console.error("Failed to load Codex data:", err);
         setLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
## What does this PR do?

This PR fixes a race condition in `CodexModal` where an in-flight fetch request could still update component state after the modal had been closed.

If the modal was closed before the `/api/codex` request completed, the pending promise handlers could still call `setData` and `setLoading`, resulting in stale updates and unnecessary work.

## Changes made

### CodexModal.tsx

- Added a local cancellation flag inside the Codex data loading effect
- Added cleanup logic when the modal closes/unmounts
- Prevented `setData` from running after the modal is no longer active
- Prevented `setLoading` from running after the modal is no longer active

## Why this matters

Without cleanup:

- Stale requests can update state after the modal closes
- Rapid open/close interactions can produce inconsistent UI state
- Unnecessary state updates occur after the component is no longer active

With this fix:

- Only the active modal instance can update state
- Closed modal instances safely ignore completed requests
- Async state updates are properly scoped to the component lifecycle

## Related Issue

Fixes #288


## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
