### PR TITLE
fix: eliminate TOCTOU race condition in sky ad activation

### DIFF
--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -62,16 +62,19 @@ export async function POST(request: Request) {
             const now = new Date();
             const endsAt = new Date(now.getTime() + plan.duration_days * 24 * 60 * 60 * 1000);
 
-            await sb
+            const { data: activated } = await sb
               .from("sky_ads")
               .update({
                 active: true,
                 starts_at: now.toISOString(),
                 ends_at: endsAt.toISOString(),
               })
-              .eq("id", ad.id);
+              .eq("id", ad.id)
+              .eq("active", false)
+              .select("id");
 
-            if (plan.vehicle === "plane") {
+            // Auto-deactivate the "advertise" placeholder only if this delivery won the race
+            if (activated?.length && plan.vehicle === "plane") {
               await sb
                 .from("sky_ads")
                 .update({ active: false })

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
           const now = new Date();
           const endsAt = new Date(now.getTime() + plan.duration_days * 24 * 60 * 60 * 1000);
 
-          await sb
+          const { data: activated } = await sb
             .from("sky_ads")
             .update({
               active: true,
@@ -92,10 +92,12 @@ export async function POST(request: Request) {
               ends_at: endsAt.toISOString(),
               purchaser_email: session.customer_details?.email ?? null,
             })
-            .eq("id", ad.id);
+            .eq("id", ad.id)
+            .eq("active", false)
+            .select("id");
 
-          // Auto-deactivate the "advertise" placeholder if same vehicle type
-          if (plan.vehicle === "plane") {
+          // Auto-deactivate the "advertise" placeholder only if this delivery won the race
+          if (activated?.length && plan.vehicle === "plane") {
             await sb
               .from("sky_ads")
               .update({ active: false })


### PR DESCRIPTION
## What does this PR do?

Fixes a TOCTOU (Time-of-Check to Time-of-Use) race condition in the Sky Ads payment activation flow.

Previously, both Stripe and AbacatePay webhook handlers performed a read-then-update activation sequence. Under concurrent duplicate webhook deliveries, multiple requests could observe the same inactive advertisement and proceed with activation updates independently.

This PR makes activation atomic by moving the activation guard into the database update condition.

### Changes

* Added `.eq("active", false)` to Sky Ad activation updates.
* Captured update results using `.select("id")`.
* Gated placeholder-ad deactivation side effects on successful activation.
* Applied the same protection to both Stripe and AbacatePay webhook handlers.

### Result

* Duplicate webhook deliveries are now idempotent.
* Only one request can successfully activate a given advertisement.
* Activation metadata is written exactly once.
* Placeholder deactivation side effects execute only for the request that wins the activation race.

## Related issue

Fixes #280

## Screenshots
<img width="1353" height="531" alt="image" src="https://github.com/user-attachments/assets/5fd97331-4323-41ef-802a-8124f2e8051d" />


## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
