### PR TITLE
fix: prevent presence polling from overwriting recent WebSocket updates (#290)

### DIFF
--- a/src/lib/useCodingPresence.ts
+++ b/src/lib/useCodingPresence.ts
@@ -9,6 +9,7 @@ export interface LiveSession {
   avatarUrl: string;
   status: "active" | "idle";
   language?: string;
+  lastUpdated?: number;
 }
 
 export function useCodingPresence() {
@@ -28,12 +29,14 @@ export function useCodingPresence() {
       .then((data) => {
         if (data.developers) {
           const map = new Map<string, LiveSession>();
+          const now = Date.now();
           for (const d of data.developers) {
             map.set(d.githubLogin, {
               githubLogin: d.githubLogin,
               avatarUrl: d.avatarUrl,
               status: d.status,
               language: d.language,
+              lastUpdated: now,
             });
           }
           mapRef.current = map;
@@ -64,6 +67,7 @@ export function useCodingPresence() {
           avatarUrl: payload.avatarUrl,
           status: payload.status ?? "active",
           language: payload.language,
+          lastUpdated: Date.now(),
         });
         updateMap();
       })
@@ -75,16 +79,34 @@ export function useCodingPresence() {
         .then((r) => r.json())
         .then((data) => {
           if (data.developers) {
-            const map = new Map<string, LiveSession>();
+            const currentMap = mapRef.current;
+            const fetchedLogins = new Set<string>();
+            const now = Date.now();
+
             for (const d of data.developers) {
-              map.set(d.githubLogin, {
-                githubLogin: d.githubLogin,
-                avatarUrl: d.avatarUrl,
-                status: d.status,
-                language: d.language,
-              });
+              fetchedLogins.add(d.githubLogin);
+              const existing = currentMap.get(d.githubLogin);
+              // Overwrite only if we haven't received a recent heartbeat (within last 35s)
+              if (!existing || !existing.lastUpdated || (now - existing.lastUpdated > 35_000)) {
+                currentMap.set(d.githubLogin, {
+                  githubLogin: d.githubLogin,
+                  avatarUrl: d.avatarUrl,
+                  status: d.status,
+                  language: d.language,
+                  lastUpdated: now,
+                });
+              }
             }
-            mapRef.current = map;
+
+            // Remove users that are missing from the server response AND haven't broadcasted recently
+            for (const [login, session] of currentMap.entries()) {
+              if (!fetchedLogins.has(login)) {
+                if (!session.lastUpdated || (now - session.lastUpdated > 35_000)) {
+                  currentMap.delete(login);
+                }
+              }
+            }
+            
             updateMap();
           }
         })


### PR DESCRIPTION


## What does this PR do?

This PR fixes a race condition in the presence synchronization system where periodic polling could overwrite more recent WebSocket presence updates.

Previously, when the polling request resolved, it replaced the current presence map entirely. If a user joined or updated their presence through a WebSocket event while the request was still in flight, the newer state could be lost until the next heartbeat.

###Changes made

useCodingPresence.ts

- Added an optional lastUpdated timestamp to LiveSession
- Added timestamps to:
    1. Initial presence bootstrap data
    2. Incoming WebSocket presence updates
- Replaced the destructive polling replacement logic with a merge strategy
- Preserved recent WebSocket updates when processing polling results
- Added safe cleanup logic for stale users that have not received recent updates

### Why this matters

Without this fix:

- Polling responses can overwrite newer WebSocket updates
- Active users may temporarily disappear from the city
- Presence data can become inconsistent during network delays
With this fix:

- Recent WebSocket events always take priority
- Polling and real-time updates remain synchronized
- Active users remain visible even when polling requests resolve later

## Related issue
Fixes #290

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
