### PR TITLE
fix: force WebGL context loss on CityCanvas unmount (#301)

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1989,6 +1989,16 @@ function CityExposure({ cityEnergy }: { cityEnergy: number }) {
 // Plaza indices for rabbit sightings (progressively further from center)
 const RABBIT_PLAZA_INDICES = [1, 2, 4, 7, 10]; // plazas[1]=slot3, [2]=slot7, [4]=slot18, [7]=slot42, [10]=slot75
 
+function GLCleanup() {
+  const gl = useThree((s) => s.gl);
+  useEffect(() => {
+    return () => {
+      try { gl.forceContextLoss(); } catch { /* best-effort */ }
+    };
+  }, []);
+  return null;
+}
+
 export default function CityCanvas({ buildings, plazas, decorations, river, bridges, flyMode, flyVehicle, onExitFly, onCollect, themeIndex, dayNightCycleActive, onHud, onPause, focusedBuilding, focusedBuildingB, accentColor, onClearFocus, onBuildingClick, onFocusInfo, flyPauseSignal, flyHasOverlay, flyStartPaused, skyAds, onAdClick, onAdViewed, introMode, onIntroEnd, raidPhase, raidData, raidAttacker, raidDefender, onRaidPhaseComplete, onLandmarkClick, rabbitSighting, onRabbitCaught, rabbitCinematic, onRabbitCinematicEnd, rabbitCinematicTarget, ghostPreviewLogin, holdRise, celebrationActive, wallpaperMode, wallpaperSpeed, liveByLogin, cityEnergy, weatherMode = "sunny" }: Props) {
   const { isRaining } = useWeather();
   const t = THEMES[themeIndex] ?? THEMES[0];
@@ -2055,6 +2065,7 @@ export default function CityCanvas({ buildings, plazas, decorations, river, brid
       gl={{ antialias: false, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.3 }}
       style={{ position: "fixed", inset: 0, width: "100vw", height: "100vh" }}
     >
+      <GLCleanup />
       {showPerf && <Stats />}
       <CityExposure cityEnergy={cityEnergy ?? 1} />
       <AtmosphereCycleManager


### PR DESCRIPTION
## ✦ Description

When navigating away from the city page and back, the WebGL context from the previous visit was never explicitly lost. Each navigation created a new context without releasing the old one, causing GPU memory to accumulate over multiple trips. The browser's WebGL implementation does not free the associated GPU memory until the context is explicitly lost or the canvas element is garbage collected.

The fix adds an unmount-time `gl.forceContextLoss()` call via a lightweight child component inside the R3F Canvas.

Fixes #301

---

## ⟡ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run `npm run lint` and `npm run format` locally before pushing.

---

## ⟡ Screenshots / Screen Recordings (Required for UI changes)

N/A — backend fix, no visible UI change.

| Before | After |
| :--- | :--- |
| WebGL context persisted across navigations, GPU memory accumulated | Context is forcefully lost on unmount, GPU memory freed per trip |

---

## Description

### Root Cause

React Three Fiber's `<Canvas>` calls `gl.dispose()` on unmount, which releases Three.js-managed resources (textures, geometries, materials). However, `gl.dispose()` does not call `gl.forceContextLoss()`, so the browser's WebGL context remains alive. The browser holds the associated GPU memory until the canvas element is garbage collected, which may not happen promptly or at all if a reference lingers.

### Changes Made

- **`src/components/CityCanvas.tsx`** — Added a `GLCleanup` child component that:
  - Captures `gl` via `useThree((s) => s.gl)`
  - Calls `gl.forceContextLoss()` in a `useEffect` cleanup on unmount
  - Renders nothing (`return null`)

### Testing Performed

- Navigated from city → settings → city → leaderboard → city (5+ cycles)
- Verified no "Too many active WebGL contexts" warnings in console
- Confirmed `npm run lint` passes

---

## Additional Notes

- No frontend or UI regressions introduced.
- Branch pushed: `Pcmhacker-piro:fix/webgl-dispose-301`
- Compare URL: