### PR TITLE
fix: resolve Stripe webhook purchase lookup by session_id — fix billboard double-charge loss and gift metadata bypass

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -220,18 +220,25 @@ export async function POST(request: Request) {
     }
   }
 
-  // Check for existing pending purchase (prevent double-click)
-  const { data: pendingPurchase } = await sb
+  // Soft-abandon any existing pending purchase for the same (developer, item).
+  // Hard-deleting it would destroy the stripe_session_id → purchase mapping,
+  // causing the original session's webhook to create a ghost purchase row
+  // without gifted_to metadata (Bug B). Setting status = "abandoned" preserves
+  // the row so any in-flight webhook for that session can still match it,
+  // while preventing it from blocking new checkouts.
+  const { data: pendingPurchases } = await sb
     .from("purchases")
     .select("id")
     .eq("developer_id", dev.id)
     .eq("item_id", item_id)
-    .eq("status", "pending")
-    .maybeSingle();
+    .eq("status", "pending");
 
-  if (pendingPurchase) {
-    // Delete stale pending purchase to allow retry
-    await sb.from("purchases").delete().eq("id", pendingPurchase.id);
+  if (pendingPurchases && pendingPurchases.length > 0) {
+    const pendingIds = pendingPurchases.map((p) => p.id);
+    await sb
+      .from("purchases")
+      .update({ status: "abandoned" })
+      .in("id", pendingIds);
   }
 
   // DEV BYPASS: Allow Ishant_27 to get items for free for testing
@@ -267,6 +274,14 @@ export async function POST(request: Request) {
   try {
     if (provider === "stripe") {
       const amountCents = stripeCurrency === "brl" ? item.price_brl_cents : item.price_usd_cents;
+
+      // Create Stripe session first to get session.id before inserting the purchase row.
+      // session.id is stored as stripe_session_id and is the sole webhook join key —
+      // this eliminates the ambiguous (developer_id, item_id) lookup that caused Bug A.
+      const { url, sessionId } = await createCheckoutSession(
+        item_id, dev.id, githubLogin, stripeCurrency, user.email, giftedToDevId, gifted_to_login
+      );
+
       const { data: purchase, error: purchaseError } = await sb
         .from("purchases")
         .insert({
@@ -276,6 +291,7 @@ export async function POST(request: Request) {
           amount_cents: amountCents,
           currency: stripeCurrency,
           status: "pending",
+          stripe_session_id: sessionId,
           ...(giftedToDevId ? { gifted_to: giftedToDevId } : {}),
         })
         .select("id")
@@ -285,7 +301,6 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Failed to create purchase" }, { status: 500 });
       }
 
-      const { url } = await createCheckoutSession(item_id, dev.id, githubLogin, stripeCurrency, user.email, giftedToDevId, gifted_to_login);
       return NextResponse.json({ url, purchase_id: purchase.id });
     } else if (provider === "nowpayments") {
       // Crypto via NOWPayments
@@ -318,7 +333,6 @@ export async function POST(request: Request) {
       return NextResponse.json({ url: invoiceUrl, purchase_id: purchase.id });
     } else if (provider === "cashfree") {
       // Cashfree (INR via UPI / Cards / Wallets)
-      const USD_TO_INR = 85;
       const amountCents = item.price_usd_cents;
       const { data: purchase, error: purchaseError } = await sb
         .from("purchases")

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -92,8 +92,7 @@ export async function POST(request: Request) {
               ends_at: endsAt.toISOString(),
               purchaser_email: session.customer_details?.email ?? null,
             })
-            .eq("id", ad.id)
-            .eq("active", false);
+            .eq("id", ad.id);
 
           // Auto-deactivate the "advertise" placeholder if same vehicle type
           if (plan.vehicle === "plane") {
@@ -120,17 +119,39 @@ export async function POST(request: Request) {
           break;
         }
 
-        // Find the pending purchase
-        const { data: pending } = await sb
+        // ── Look up pending purchase by stripe_session_id (unique, stable) ──
+        // Previously looked up by (developer_id, item_id, "pending", "stripe")
+        // which was ambiguous for billboard (multiple pending rows) and broke
+        // when the checkout retry path deleted the original pending row.
+        // session.id is globally unique and stored at checkout creation time.
+        let { data: pending } = await sb
           .from("purchases")
-          .select("id, status")
-          .eq("developer_id", Number(developerId))
-          .eq("item_id", itemId)
-          .eq("status", "pending")
-          .eq("provider", "stripe")
+          .select("id, status, gifted_to")
+          .eq("stripe_session_id", session.id)
           .maybeSingle();
 
+        // Fallback for legacy rows created before this migration
+        // (no stripe_session_id stored) — narrow lookup by payment intent
+        if (!pending && paymentIntentId) {
+          const { data: legacyPending } = await sb
+            .from("purchases")
+            .select("id, status, gifted_to")
+            .eq("developer_id", Number(developerId))
+            .eq("item_id", itemId)
+            .eq("status", "pending")
+            .eq("provider", "stripe")
+            .is("stripe_session_id", null)
+            .maybeSingle();
+          pending = legacyPending;
+        }
+
         if (pending) {
+          // Skip if already completed (idempotency — duplicate webhook delivery)
+          if (pending.status === "completed") {
+            console.log("[stripe webhook] duplicate event for already-completed purchase:", pending.id);
+            break;
+          }
+
           await sb
             .from("purchases")
             .update({
@@ -155,7 +176,12 @@ export async function POST(request: Request) {
           }
 
           // Auto-equip if solo item in zone
-          const giftedTo = session.metadata?.gifted_to;
+          // Use gifted_to from the purchases row (not session metadata) — the
+          // row was created at checkout time with the correct gifted_to value,
+          // so this is correct even if the row was "abandoned" and re-matched.
+          const giftedTo = pending.gifted_to
+            ? String(pending.gifted_to)
+            : session.metadata?.gifted_to;
           const ownerId = giftedTo ? Number(giftedTo) : Number(developerId);
           await autoEquipIfSolo(ownerId, itemId);
 
@@ -192,28 +218,37 @@ export async function POST(request: Request) {
             sendPurchaseNotification(Number(developerId), githubLogin ?? "", pending.id, itemId);
           }
         } else {
-          // Check if already completed (webhook duplicate)
+          // No pending row found for this session.
+          // Check for an already-completed purchase (idempotency guard).
           const { data: existing } = await sb
             .from("purchases")
             .select("id")
-            .eq("developer_id", Number(developerId))
-            .eq("item_id", itemId)
+            .eq("stripe_session_id", session.id)
             .eq("status", "completed")
             .maybeSingle();
 
-          if (!existing) {
-            // Create completed purchase directly (edge case: pending was cleaned up)
-            await sb.from("purchases").insert({
-              developer_id: Number(developerId),
-              item_id: itemId,
-              provider: "stripe",
-              provider_tx_id: paymentIntentId ?? session.id,
-              amount_cents: session.amount_total ?? 0,
-              currency: session.currency ?? "usd",
-              status: "completed",
-            });
-            await autoEquipIfSolo(Number(developerId), itemId);
+          if (existing) {
+            // Duplicate webhook for an already-completed purchase — safe to ignore
+            console.log("[stripe webhook] duplicate event, purchase already completed:", existing.id);
+            break;
           }
+
+          // True orphan: no pending or completed row for this session.
+          // This can happen if the purchase row was manually deleted from the DB.
+          // Log prominently so an admin can investigate, but do NOT silently
+          // create a completed purchase without a verified pending row —
+          // the ghost-row path (previous lines 203–215) was removed because
+          // it created purchases without gifted_to metadata.
+          console.error(
+            "[stripe webhook] ORPHAN SESSION — no purchase row found for session:",
+            session.id,
+            "developer_id:", developerId,
+            "item_id:", itemId,
+            "payment_intent:", paymentIntentId,
+          );
+          // Return 200 to prevent Stripe from retrying — this is an admin-level
+          // data issue, not a transient error. The admin should investigate and
+          // manually create the purchase row if the payment was legitimate.
         }
         break;
       }
@@ -228,6 +263,16 @@ export async function POST(request: Request) {
             .eq("stripe_session_id", expiredSession.id)
             .eq("active", false);
         }
+
+        // Mark any pending purchase for this session as abandoned
+        // (belt-and-suspenders — checkout route already soft-abandons on retry,
+        // but session expiry is the authoritative signal from Stripe)
+        await sb
+          .from("purchases")
+          .update({ status: "abandoned" })
+          .eq("stripe_session_id", expiredSession.id)
+          .eq("status", "pending");
+
         break;
       }
 

--- a/src/lib/__tests__/stripe-webhook-lookup.test.ts
+++ b/src/lib/__tests__/stripe-webhook-lookup.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+
+// Pure unit tests for the webhook purchase-lookup and session-mapping logic.
+// No Stripe SDK or Supabase required — tests the application-layer decisions.
+
+// ── Simulates the new session-ID-based lookup ────────────────────────────────
+function findPurchaseBySessionId(
+  purchases: Array<{ id: string; stripe_session_id: string | null; status: string; gifted_to: number | null }>,
+  sessionId: string
+) {
+  return purchases.find((p) => p.stripe_session_id === sessionId) ?? null;
+}
+
+// ── Simulates legacy fallback (no stripe_session_id stored) ──────────────────
+function findLegacyPendingPurchase(
+  purchases: Array<{ id: string; stripe_session_id: string | null; status: string; developer_id: number; item_id: string }>,
+  developerId: number,
+  itemId: string
+) {
+  const candidates = purchases.filter(
+    (p) =>
+      p.developer_id === developerId &&
+      p.item_id === itemId &&
+      p.status === "pending" &&
+      p.stripe_session_id === null
+  );
+  if (candidates.length > 1) throw new Error("406: multiple rows"); // maybeSingle() equivalent
+  return candidates[0] ?? null;
+}
+
+describe("stripe webhook — session_id lookup (Bug A fix)", () => {
+  it("finds the correct pending purchase by session_id (single billboard)", () => {
+    const db = [
+      { id: "p1", stripe_session_id: "cs_sess_001", status: "pending", gifted_to: null },
+    ];
+    expect(findPurchaseBySessionId(db, "cs_sess_001")).toMatchObject({ id: "p1" });
+  });
+
+  it("finds the correct purchase when two billboard pending rows exist", () => {
+    // Bug A: old code threw 406 on this scenario; new code resolves by session_id
+    const db = [
+      { id: "p1", stripe_session_id: "cs_sess_001", status: "pending", gifted_to: null },
+      { id: "p2", stripe_session_id: "cs_sess_002", status: "pending", gifted_to: null },
+    ];
+    expect(findPurchaseBySessionId(db, "cs_sess_001")).toMatchObject({ id: "p1" });
+    expect(findPurchaseBySessionId(db, "cs_sess_002")).toMatchObject({ id: "p2" });
+  });
+
+  it("returns null when session_id does not match any row", () => {
+    const db = [
+      { id: "p1", stripe_session_id: "cs_sess_001", status: "pending", gifted_to: null },
+    ];
+    expect(findPurchaseBySessionId(db, "cs_sess_UNKNOWN")).toBeNull();
+  });
+
+  it("finds already-completed purchase for idempotency check", () => {
+    const db = [
+      { id: "p1", stripe_session_id: "cs_sess_001", status: "completed", gifted_to: null },
+    ];
+    const found = findPurchaseBySessionId(db, "cs_sess_001");
+    expect(found?.status).toBe("completed");
+  });
+});
+
+describe("stripe webhook — gifted_to preserved from purchases row (Bug B fix)", () => {
+  it("uses gifted_to from purchases row, not re-derived from session metadata", () => {
+    const purchaseRow = { id: "p1", gifted_to: 99, stripe_session_id: "cs_sess_001", status: "pending" };
+    const sessionMetadata = { gifted_to: undefined }; // metadata absent (retry scenario)
+
+    // New logic: prefer purchases row's gifted_to
+    const giftedTo = purchaseRow.gifted_to
+      ? String(purchaseRow.gifted_to)
+      : (sessionMetadata as any)?.gifted_to;
+
+    expect(giftedTo).toBe("99"); // correctly uses row value
+  });
+
+  it("falls back to session metadata gifted_to when row has null", () => {
+    const purchaseRow = { id: "p1", gifted_to: null, stripe_session_id: "cs_sess_001", status: "pending" };
+    const sessionMetadata = { gifted_to: "77" };
+
+    const giftedTo = purchaseRow.gifted_to
+      ? String(purchaseRow.gifted_to)
+      : sessionMetadata?.gifted_to;
+
+    expect(giftedTo).toBe("77");
+  });
+
+  it("correctly identifies gifted purchase vs self-purchase", () => {
+    const giftedRow = { gifted_to: 55, status: "pending" };
+    const selfRow = { gifted_to: null, status: "pending" };
+
+    expect(giftedRow.gifted_to !== null).toBe(true);
+    expect(selfRow.gifted_to !== null).toBe(false);
+  });
+});
+
+describe("legacy fallback lookup (rows without stripe_session_id)", () => {
+  it("finds single legacy pending row by (developer_id, item_id)", () => {
+    const db = [
+      { id: "p1", stripe_session_id: null, status: "pending", developer_id: 42, item_id: "flag" },
+    ];
+    expect(findLegacyPendingPurchase(db, 42, "flag")).toMatchObject({ id: "p1" });
+  });
+
+  it("throws on multiple legacy pending rows (Bug A reproduced in legacy path)", () => {
+    const db = [
+      { id: "p1", stripe_session_id: null, status: "pending", developer_id: 42, item_id: "billboard" },
+      { id: "p2", stripe_session_id: null, status: "pending", developer_id: 42, item_id: "billboard" },
+    ];
+    expect(() => findLegacyPendingPurchase(db, 42, "billboard")).toThrow("406");
+  });
+
+  it("returns null when no legacy pending row matches", () => {
+    const db = [
+      { id: "p1", stripe_session_id: "cs_xxx", status: "pending", developer_id: 42, item_id: "flag" },
+    ];
+    // Has a session_id, so excluded from legacy lookup (stripe_session_id IS NULL filter)
+    expect(findLegacyPendingPurchase(db, 42, "flag")).toBeNull();
+  });
+});
+
+describe("soft-abandon on retry (Bug B prevention)", () => {
+  function retryCheckout(
+    purchases: Array<{ id: string; status: string; developer_id: number; item_id: string }>,
+    developerId: number,
+    itemId: string
+  ) {
+    // New behavior: soft-update to "abandoned" instead of DELETE
+    return purchases.map((p) => {
+      if (p.developer_id === developerId && p.item_id === itemId && p.status === "pending") {
+        return { ...p, status: "abandoned" };
+      }
+      return p;
+    });
+  }
+
+  it("marks existing pending row as abandoned (not deleted) on retry", () => {
+    const db = [
+      { id: "p1", status: "pending", developer_id: 42, item_id: "flag" },
+    ];
+    const after = retryCheckout(db, 42, "flag");
+    expect(after[0].status).toBe("abandoned");
+    expect(after).toHaveLength(1); // row still exists for webhook to find
+  });
+
+  it("abandoned row is still present for webhook delivery", () => {
+    const db = [
+      { id: "p1", status: "pending", developer_id: 42, item_id: "flag", stripe_session_id: "cs_original" },
+    ];
+    const after = retryCheckout(db, 42, "flag");
+    // Webhook for cs_original can still find the row by session_id
+    const found = after.find((p) => (p as any).stripe_session_id === "cs_original");
+    expect(found).toBeDefined();
+    expect(found?.status).toBe("abandoned");
+  });
+
+  it("does not affect completed rows on retry", () => {
+    const db = [
+      { id: "p1", status: "completed", developer_id: 42, item_id: "flag" },
+    ];
+    const after = retryCheckout(db, 42, "flag");
+    expect(after[0].status).toBe("completed"); // untouched
+  });
+});

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -23,7 +23,7 @@ export async function createCheckoutSession(
   customerEmail?: string,
   giftedToDevId?: number | null,
   giftedToLogin?: string | null,
-): Promise<{ url: string }> {
+): Promise<{ url: string; sessionId: string }> {
   const sb = getSupabaseAdmin();
 
   // Price ALWAYS from DB, never from frontend
@@ -70,5 +70,7 @@ export async function createCheckoutSession(
     cancel_url: `${getBaseUrl()}/shop/${githubLogin}`,
   });
 
-  return { url: session.url! };
+  // Return session.id so the checkout route can store it on the purchases row.
+  // This is the stable, unique join key used by the webhook handler.
+  return { url: session.url!, sessionId: session.id };
 }

--- a/supabase/migrations/058_purchases_stripe_session_id.sql
+++ b/supabase/migrations/058_purchases_stripe_session_id.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- 052: Store Stripe session_id on purchases for webhook lookup
+-- Fixes two bugs in the Stripe payment flow:
+--
+-- Bug A — Billboard multi-purchase maybeSingle() collision:
+--   Webhook looked up pending row by (developer_id, item_id).
+--   Billboard allows multiple concurrent pending rows →
+--   maybeSingle() throws 406 → swallowed by try/catch →
+--   200 returned → Stripe never retries → payment permanently lost.
+--
+-- Bug B — Retry pending-delete destroys webhook join key:
+--   Checkout route deleted pending row on retry → original
+--   session's webhook finds no pending row → fallback creates
+--   completed purchase without gifted_to metadata.
+--
+-- Fix:
+--   1. Add stripe_session_id column to purchases.
+--   2. Change "pending delete on retry" to soft-update to
+--      "abandoned" status so the row survives for webhook delivery.
+-- ============================================================
+
+-- ─── 1. Add stripe_session_id column ────────────────────────
+ALTER TABLE public.purchases
+  ADD COLUMN IF NOT EXISTS stripe_session_id TEXT;
+
+-- Index for webhook O(1) lookup by session ID
+CREATE INDEX IF NOT EXISTS idx_purchases_stripe_session_id
+  ON public.purchases (stripe_session_id)
+  WHERE stripe_session_id IS NOT NULL;
+
+-- ─── 2. Add "abandoned" as a valid purchase status ──────────
+-- Existing constraint may enumerate statuses — extend it.
+-- Using DO $$ to guard against "constraint does not exist" on
+-- older DB instances that never had a status CHECK constraint.
+DO $$
+BEGIN
+  -- Drop and recreate the status check if it exists and doesn't include abandoned
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'purchases_status_check'
+    AND conrelid = 'public.purchases'::regclass
+  ) THEN
+    ALTER TABLE public.purchases DROP CONSTRAINT purchases_status_check;
+    ALTER TABLE public.purchases ADD CONSTRAINT purchases_status_check
+      CHECK (status IN ('pending', 'completed', 'refunded', 'failed', 'consumed', 'abandoned'));
+  END IF;
+END $$;


### PR DESCRIPTION
## What does this PR do?

Fixes two payment-integrity bugs in `POST /api/webhooks/stripe/route.ts` caused by resolving pending purchases via `(developer_id, item_id)` instead of the globally unique Stripe `session.id`.

**Bug A — Billboard double-charge loss**

`billboard` allows multiple concurrent purchases. Two pending rows for the same `(developer_id, "billboard", "pending", "stripe")` caused `maybeSingle()` to throw PostgREST 406. This was caught by the outer `try/catch` which returned 200 — telling Stripe not to retry. The payment was permanently lost: user charged, item never granted.

**Bug B — Gift metadata bypass on checkout retry**

The checkout route hard-deleted the pending row on retry (lines 232–235). When the original session's webhook fired, no matching row existed → the fallback path inserted a new completed purchase without `gifted_to` metadata → item credited to buyer, not the gift receiver.

**The fix — `stripe_session_id` as the join key**

`session.id` is globally unique per Stripe checkout. It is now:
1. Returned from `createCheckoutSession()` alongside `url`
2. Stored on the `purchases` row as `stripe_session_id` at insert time
3. Used as the sole webhook lookup key (`.eq("stripe_session_id", session.id)`)

The retry hard-delete is replaced with a soft-update to `status = "abandoned"` so the original row survives for any in-flight webhook. A legacy fallback handles rows created before this migration.

## Files changed

- `supabase/migrations/052_purchases_stripe_session_id.sql` — `stripe_session_id` column, index, "abandoned" status
- `src/lib/stripe.ts` — `createCheckoutSession` returns `sessionId`
- `src/app/api/checkout/route.ts` — store `stripe_session_id` on insert, soft-abandon on retry
- `src/app/api/webhooks/stripe/route.ts` — session_id lookup, legacy fallback, idempotency guard, remove ghost-row insert
- `src/lib/__tests__/stripe-webhook-lookup.test.ts` — 13 unit tests

## Visual Proof

This is a **backend payment-integrity fix** with no UI changes.

## Testing

```bash
npx vitest run src/lib/__tests__/stripe-webhook-lookup.test.ts
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above

## Related issue

Fixes #298