### PR TITLE
fix(seeder): add per-page retry cap so rate-limited pages are skipped instead of looping forever

### DIFF
--- a/scripts/seed-lc-infinite.ts
+++ b/scripts/seed-lc-infinite.ts
@@ -212,16 +212,28 @@ async function main() {
 
     let ok = 0, skip = 0, fail = 0;
     let page = startPage;
+    let retryCount = 0; 
 
     while (page < startPage + MAX_PAGES) { // Practically infinite
         console.log(`\n--- Fetching global ranking page ${page} ---`);
         const usernames = await fetchRankingPage(page);
 
+        const MAX_RETRIES_PER_PAGE = 3;
+
         if (usernames.length === 0) {
-            console.log("⚠️  No users found on page. Rate limited?");
-            await sleep(10000); // 10s backoff
+            retryCount++;
+            if (retryCount >= MAX_RETRIES_PER_PAGE) {
+                console.warn(`⏭️  Page ${page} returned empty ${MAX_RETRIES_PER_PAGE} times — skipping.`);
+                retryCount = 0;
+                page++;
+                saveState(page);
+                continue;
+            }
+            console.log(`⚠️  No users found on page (attempt ${retryCount}/${MAX_RETRIES_PER_PAGE}). Rate limited? Backing off...`);
+            await sleep(10000 * retryCount); // exponential-ish: 10s, 20s
             continue;
         }
+        retryCount = 0;
 
         for (const username of usernames) {
             process.stdout.write(`  Upserting ${username.padEnd(20)} `);


### PR DESCRIPTION
## What does this PR do?

Fixes the one remaining gap in the LeetCode seeder: when `fetchRankingPage` returns an empty array (LeetCode rate-limiting), the old loop retried the same page indefinitely with a flat 10s sleep, capable of burning the entire 15-minute GitHub Actions job timeout on a single stalled page — meaning zero progress per cron run.

**The fix is a 10-line change in `scripts/seed-lc-infinite.ts`:**
- Added `retryCount` tracking per page, reset to 0 on any successful fetch
- After `MAX_RETRIES_PER_PAGE = 3` consecutive empty responses, the page is skipped with a warning, `saveState` advances the cursor, and the seeder moves on
- Backoff scales with the attempt count (10s → 20s) to ease rate pressure before giving up

The `--pages` batch cap and `.github/workflows/seed-cron.yml` were already present in `main` and are unchanged.

## Related issue
Fixes #46

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above