### PR TITLE
fix: prevent manual weather changes from being overwritten by automatic sync (#383)

### DIFF
--- a/src/context/WeatherContext.tsx
+++ b/src/context/WeatherContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { useWeatherMap } from '@/hooks/useWeatherMap'; // We will import our API hook
 
 interface WeatherContextType {
@@ -15,14 +15,21 @@ const WeatherContext = createContext<WeatherContextType | undefined>(undefined);
 export function WeatherProvider({ children }: { children: React.ReactNode }) {
   const { isRaining: apiIsRaining, isLoading, error } = useWeatherMap();
   const [isRaining, setIsRaining] = useState(false);
+  const isManuallySet = useRef(false);
+
+  const handleSetIsRaining = (raining: boolean) => {
+    isManuallySet.current = true;
+    setIsRaining(raining);
+  };
+
   useEffect(() => {
-    if (!isLoading && !error) {
+    if (!isLoading && !error && !isManuallySet.current) {
       setIsRaining(apiIsRaining);
     }
   }, [apiIsRaining, isLoading, error]);
 
   return (
-    <WeatherContext.Provider value={{ isRaining, setIsRaining, isLoading, error }}>
+    <WeatherContext.Provider value={{ isRaining, setIsRaining: handleSetIsRaining, isLoading, error }}>
       {children}
     </WeatherContext.Provider>
   );


### PR DESCRIPTION
## What does this PR do?

This PR addresses an issue where manually triggered weather changes could be immediately overwritten by automatic weather synchronization from the weather API.

Previously, whenever the weather data was refreshed or revalidated, the provider would always synchronize the API value into local state, potentially overriding weather changes made through `setIsRaining()`.

## Changes made

### WeatherContext.tsx

* Added tracking for manually triggered weather updates
* Prevented automatic synchronization from overwriting manually set weather state
* Wrapped the exposed `setIsRaining` function to mark manual overrides before updating state

## Why this matters

Without this fix:

* Manual weather changes may be unexpectedly reverted
* Components using weather overrides can lose their intended state after API refreshes
* Weather behavior becomes difficult to control predictably

With this fix:

* Manual weather changes are preserved
* Automatic synchronization no longer immediately overrides user-triggered weather updates
* Components can reliably control weather effects

## Related Issue

Fixes #383


## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
