### PR TITLE
fix: prevent manual weather changes from being overwritten by automatic sync (#383)

### DIFF
--- a/src/context/WeatherContext.tsx
+++ b/src/context/WeatherContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { useWeatherMap } from '@/hooks/useWeatherMap'; // We will import our API hook
 
 interface WeatherContextType {
@@ -15,14 +15,21 @@ const WeatherContext = createContext<WeatherContextType | undefined>(undefined);
 export function WeatherProvider({ children }: { children: React.ReactNode }) {
   const { isRaining: apiIsRaining, isLoading, error } = useWeatherMap();
   const [isRaining, setIsRaining] = useState(false);
+  const isManuallySet = useRef(false);
+
+  const handleSetIsRaining = (raining: boolean) => {
+    isManuallySet.current = true;
+    setIsRaining(raining);
+  };
+
   useEffect(() => {
-    if (!isLoading && !error) {
+    if (!isLoading && !error && !isManuallySet.current) {
       setIsRaining(apiIsRaining);
     }
   }, [apiIsRaining, isLoading, error]);
 
   return (
-    <WeatherContext.Provider value={{ isRaining, setIsRaining, isLoading, error }}>
+    <WeatherContext.Provider value={{ isRaining, setIsRaining: handleSetIsRaining, isLoading, error }}>
       {children}
     </WeatherContext.Provider>
   );

--- a/src/context/WeatherContext.tsx
+++ b/src/context/WeatherContext.tsx
@@ -15,21 +15,20 @@ const WeatherContext = createContext<WeatherContextType | undefined>(undefined);
 export function WeatherProvider({ children }: { children: React.ReactNode }) {
   const { isRaining: apiIsRaining, isLoading, error } = useWeatherMap();
   const [isRaining, setIsRaining] = useState(false);
-  const isManuallySet = useRef(false);
-
-  const handleSetIsRaining = (raining: boolean) => {
-    isManuallySet.current = true;
-    setIsRaining(raining);
-  };
+  const lastSyncedApiValue = useRef<boolean | null>(null);
 
   useEffect(() => {
-    if (!isLoading && !error && !isManuallySet.current) {
-      setIsRaining(apiIsRaining);
+    if (!isLoading && !error) {
+      // Only update local state if the API value has actually changed since our last sync
+      if (lastSyncedApiValue.current === null || apiIsRaining !== lastSyncedApiValue.current) {
+        setIsRaining(apiIsRaining);
+        lastSyncedApiValue.current = apiIsRaining;
+      }
     }
   }, [apiIsRaining, isLoading, error]);
 
   return (
-    <WeatherContext.Provider value={{ isRaining, setIsRaining: handleSetIsRaining, isLoading, error }}>
+    <WeatherContext.Provider value={{ isRaining, setIsRaining, isLoading, error }}>
       {children}
     </WeatherContext.Provider>
   );


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where manually triggered weather changes could be unintentionally overwritten by automatic weather synchronization.

Previously, whenever the weather API revalidated, the provider would sync the API value directly into local state, potentially reverting weather changes that were intentionally applied through the Weather Context.

## Changes Made

### WeatherContext.tsx

* Added tracking for the last synchronized API weather state.
* Updated synchronization logic to only apply API updates when the weather condition actually changes.
* Preserved manual weather overrides across API revalidations.
* Avoided permanently disabling weather synchronization.

## Why this matters

Without this fix:

* Manual weather changes could be unexpectedly reverted.
* Components using weather overrides might lose their intended state after weather data refreshes.
* Weather behavior could become inconsistent for users.

With this fix:

* Manual weather changes remain intact during normal API refreshes.
* Automatic synchronization still works when the actual weather condition changes.
* The weather system remains predictable while preserving API-driven updates.

## Related Issue

Fixes #383

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)