### PR TITLE
fix(weather): correctly report loading state during geolocation and prevent unmounted state updates (fixes #382)

### DIFF
--- a/src/hooks/useWeatherMap.ts
+++ b/src/hooks/useWeatherMap.ts
@@ -7,29 +7,47 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export function useWeatherMap() {
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [geoError, setGeoError] = useState<string | null>(null);
+  const [isGeoLoading, setIsGeoLoading] = useState(true);
 
   // 1. Get User Coordinates
   useEffect(() => {
+    let isMounted = true;
+
     if (!navigator.geolocation) {
-      setGeoError("Geolocation is not supported by your browser");
+      if (isMounted) {
+        setGeoError("Geolocation is not supported by your browser");
+        setIsGeoLoading(false);
+      }
       return;
     }
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        setCoords({
-          lat: position.coords.latitude,
-          lon: position.coords.longitude,
-        });
+        if (isMounted) {
+          setCoords({
+            lat: position.coords.latitude,
+            lon: position.coords.longitude,
+          });
+          setIsGeoLoading(false);
+        }
       },
-      (err) => setGeoError(err.message)
+      (err) => {
+        if (isMounted) {
+          setGeoError(err.message);
+          setIsGeoLoading(false);
+        }
+      }
     );
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   // 2. Fetch Weather Data via SWR (only runs if coords exist)
   // Note: You will need a free OpenWeatherMap API key in your .env.local
   const apiKey = process.env.NEXT_PUBLIC_OPENWEATHER_API_KEY; 
-  const { data, error, isLoading } = useSWR(
+  const { data, error, isLoading: isSWRILoading } = useSWR(
     coords ? ['weather', coords.lat, coords.lon] : null,
     () => fetchWeatherByCoords(coords!.lat, coords!.lon),
     { refreshInterval: 600000 }
@@ -45,6 +63,9 @@ const errorMessage = geoError
   : error 
     ? (error instanceof Error ? error.message : String(error)) 
     : null;
+
+// Hook is loading if either geolocation or SWR is loading
+const isLoading = isGeoLoading || (isSWRILoading && !geoError);
 
 return { isRaining, data, isLoading, error: errorMessage };
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where `useWeatherMap` could report `isLoading` as `false` while the browser was still waiting for the user to respond to the geolocation permission prompt.

It also prevents state updates from occurring after the component has unmounted, avoiding potential React warnings and lifecycle issues.

## Changes Made

### useWeatherMap.ts

* Added a dedicated `isGeoLoading` state to track geolocation initialization.
* Added unmount protection using an `isMounted` guard.
* Prevented state updates after component unmount.
* Updated geolocation success and error handlers to correctly update loading state.
* Combined geolocation loading and SWR loading into a single unified `isLoading` value.

## Why this matters

Without this fix:

* The hook may report loading as complete while the browser is still waiting for location permission.
* Components may render incorrect UI states during geolocation initialization.
* Geolocation callbacks may attempt to update state after unmount.

With this fix:

* Loading state accurately reflects the entire weather initialization process.
* Components receive consistent loading information.
* State updates are safely ignored after unmount.

## Related Issue

Fixes #382

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
