### PR TITLE
fix: read rank_today and total from fly-scores API response

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2009,10 +2009,10 @@ function HomeContent() {
           })
             .then((r) => (r.ok ? r.json() : null))
             .then((d) => {
-              if (d?.rank) {
+              if (d?.rank_today != null) {
                 setShowFlyResults((prev) =>
                   prev
-                    ? { ...prev, rank: d.rank, totalPilots: d.total_count }
+                    ? { ...prev, rank: d.rank_today, totalPilots: d.total }
                     : null,
                 );
               }


### PR DESCRIPTION
## What does this PR do?

Fixes the post-flight results modal never showing the user's rank and total pilot count due to a field-name mismatch between the client and API.

The client (`page.tsx`) was reading `d.rank` and `d.total_count` from the POST `/api/fly-scores` response, but the API returns `rank_today` and `total`. Updated the client to read the correct field names.

## Related issue

Fixes #370

## Screenshots

No visual changes — this is a data-binding fix. The post-flight modal now correctly displays rank and total pilot count instead of showing 0.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
