### PR TITLE
fix: use contributions column for both ranking and display in solved leaderboard

### DIFF
--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -29,14 +29,13 @@ export async function GET(request: Request) {
   let metricValue = "";
 
   if (tab === "solved") {
-    const contribs = (dev.contributions_total && dev.contributions_total > 0) ? dev.contributions_total : dev.contributions;
     const { count } = await sb
       .from("developers")
       .select("id", { count: "exact", head: true })
       .not("easy_solved", "is", null)
-      .gt("contributions", dev.contributions); // Assuming contributions holds the "solved" count
+      .gt("contributions", dev.contributions);
     position = (count ?? 0) + 1;
-    metricValue = contribs.toLocaleString() + " solved";
+    metricValue = dev.contributions.toLocaleString() + " solved";
   } else if (tab === "lc_rank") {
     position = dev.lc_global_rank;
     metricValue = dev.lc_global_rank && dev.lc_global_rank < 999999 ? `#${dev.lc_global_rank.toLocaleString()}` : "Unranked";


### PR DESCRIPTION
## What does this PR do?

Fixes the solved leaderboard position API using different fields for ranking and display. The position was calculated using `contributions` but the displayed metric used `contributions_total`, causing incorrect rank display when the two values diverge.

Now both ranking and display use the same `contributions` column, matching the leaderboard page's ordering.

## Related issue

Fixes #371

## Screenshots

No visual changes — this is a data consistency fix. The "YOU" row in the Solved leaderboard now shows the correct rank.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
