### PR TITLE
fix: validate limit parameter in feed API to prevent NaN values

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -8,7 +8,16 @@ const MIN_EVENTS = 8;
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") ?? "20", 10)));
+  const rawLimit = parseInt(searchParams.get("limit") ?? "20", 10);
+
+  if (!Number.isFinite(rawLimit)) {
+    return NextResponse.json(
+      { error: "Invalid limit parameter: must be a number." },
+      { status: 400 }
+    );
+  }
+
+  const limit = Math.min(50, Math.max(1, rawLimit));
   const before = searchParams.get("before"); // UUID cursor
 
   const todayOnly = searchParams.get("today") === "1";


### PR DESCRIPTION
## What does this PR do?

Validates the `limit` parameter in `GET /api/feed` to prevent `NaN` values from flowing into the Supabase query layer.

Added `Number.isFinite` check for the `limit` query parameter after `parseInt`. Returns a 400 error with a clear message if the value is invalid, instead of passing `NaN` to `.limit()`.

## Related issue

Fixes #373

## Screenshots

No visual changes — this is an API validation fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
