### PR TITLE
fix: validate lat/lon coordinates in weather API to prevent 500 errors

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -2,11 +2,22 @@ import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const lat = searchParams.get('lat');
-  const lon = searchParams.get('lon');
+  const latStr = searchParams.get('lat');
+  const lonStr = searchParams.get('lon');
   
-  if (!lat || !lon) {
+  if (!latStr || !lonStr) {
     return NextResponse.json({ error: "Missing coordinates" }, { status: 400 });
+  }
+
+  const lat = parseFloat(latStr);
+  const lon = parseFloat(lonStr);
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return NextResponse.json({ error: "Invalid coordinates: lat and lon must be numbers." }, { status: 400 });
+  }
+
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+    return NextResponse.json({ error: "Invalid coordinates: lat must be -90..90, lon must be -180..180." }, { status: 400 });
   }
 
   const apiKey = process.env.OPENWEATHER_API_KEY; 


### PR DESCRIPTION
## What does this PR do?

Validates latitude and longitude coordinates in `GET /api/weather` to prevent 500 errors from OpenWeatherMap when invalid values are provided.

Added `parseFloat` and `Number.isFinite` checks for `lat` and `lon` parameters, plus range validation (`-90..90` for lat, `-180..180` for lon). Returns 400 error for invalid values instead of forwarding them to OpenWeatherMap.

## Related issue

Fixes #374

## Screenshots

No visual changes — this is an API validation fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
