### PR TITLE
fix(codex): prevent state updates after CodexModal unmount or close (fixes #417)

### DIFF
--- a/src/components/CodexModal.tsx
+++ b/src/components/CodexModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 
 interface CodexModalProps {
@@ -75,6 +75,15 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
   const [selectedTitle, setSelectedTitle] = useState<string | null>(null);
   const [equippingId, setEquippingId] = useState<string | null>(null);
 
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   // Close on Escape key
   useEffect(() => {
     if (!isOpen) return;
@@ -90,11 +99,14 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
     if (!isOpen) return;
     setLoading(true);
 
+    let active = true;
     const controller = new AbortController();
 
     fetch("/api/codex", { signal: controller.signal })
       .then(async (res) => {
         const codexData = await res.json();
+        if (!active || !isMounted.current) return;
+        
         if (!res.ok || codexData.error || !Array.isArray(codexData.achievements) || !Array.isArray(codexData.items)) {
           throw new Error(codexData.error || "Malformed codex data");
         }
@@ -104,6 +116,7 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
       })
       .catch((err) => {
         if (err.name === 'AbortError') return;
+        if (!active || !isMounted.current) return;
 
         console.error("Failed to load Codex data:", err);
         setData({
@@ -121,6 +134,7 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
       });
 
     return () => {
+      active = false;
       controller.abort();
     };
   }, [isOpen]);
@@ -139,6 +153,9 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
         }),
       });
       const resData = await res.json();
+      
+      if (!isMounted.current || !isOpen) return;
+
       if (res.ok && resData.success) {
         setSelectedTitle(resData.slug);
         if (data && data.developerId) {
@@ -159,10 +176,13 @@ export default function CodexModal({ isOpen, onClose, accentColor, shadowColor }
         alert(resData.error || "Failed to save title customization");
       }
     } catch (err) {
+      if (!isMounted.current || !isOpen) return;
       console.error("Error equipping title:", err);
       alert("Error saving title customization");
     } finally {
-      setEquippingId(null);
+      if (isMounted.current && isOpen) {
+        setEquippingId(null);
+      }
     }
   };
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a React lifecycle issue in `CodexModal` where asynchronous operations could continue and attempt to update component state after the modal had been closed or unmounted.

Under slow network conditions, users could close the modal before the Codex data request completed, causing pending callbacks to execute against an inactive component and potentially triggering React warnings.

## Changes Made

### Mounted State Tracking

- Added a `useRef` (`isMounted`) to track the component lifecycle.
- Updates are now only performed when the component is still mounted.

### Safe Async Fetch Handling

- Added an `active` flag inside the Codex data fetching effect.
- Prevented state updates when the request resolves after the modal has been closed.
- Added cleanup logic to invalidate pending callbacks during effect cleanup.

### Improved AbortController Protection

- Continued using the existing `AbortController`.
- Added additional safeguards to ensure aborted requests cannot trigger state updates.

### Protected Title Equip Flow

- Updated `handleEquipTitle()` to verify:
  - The component is still mounted.
  - The modal is still open.
- Prevents UI updates from async actions after the modal has been closed.

## Why this matters

### Before this fix

- User opens CodexModal.
- Data request starts.
- User closes the modal before the request finishes.
- Request resolves later.
- State updates execute on an inactive component.
- React lifecycle warnings may occur.

### After this fix

- Pending async operations are safely ignored after cleanup.
- No state updates occur after unmount.
- Modal lifecycle remains predictable.
- React warnings and unnecessary updates are prevented.

## Testing

Verified:

- Opening and immediately closing the modal no longer triggers stale state updates.
- Aborted requests exit gracefully.
- Title equip actions do not update closed/unmounted modals.
- Existing Codex functionality remains unchanged.

## Related Issue

Fixes #417

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
