### PR TITLE
fix: XP grant loss on concurrent grants (#343)

### DIFF
--- a/src/app/api/arena/submit/__tests__/ratings-atomic.test.ts
+++ b/src/app/api/arena/submit/__tests__/ratings-atomic.test.ts
@@ -57,7 +57,7 @@ function setupMocks({
   mockRpc.mockImplementation((name: string) => {
     if (name === "claim_first_solve")
       return Promise.resolve({ data: claimResult, error: null });
-    if (name === "grant_xp")
+    if (name === "grant_xp_atomic")
       return Promise.resolve({ data: null, error: null });
     if (name === "update_arena_ratings_atomic")
       return Promise.resolve({ data: null, error: ratingsError });

--- a/src/app/api/arena/submit/route.ts
+++ b/src/app/api/arena/submit/route.ts
@@ -190,7 +190,7 @@ export async function POST(request: NextRequest) {
 
     if (isFirstSolve) {
       // Grant XP via existing RPC (idempotency handled by claim_first_solve above)
-      await sb.rpc("grant_xp", {
+      await sb.rpc("grant_xp_atomic", {
         p_developer_id: dev.id,
         p_source: `arena_${difficulty}`,
         p_amount: grantedXp,

--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -212,7 +212,7 @@ export async function POST(request: Request) {
 
     if (!xpLogError) {
       // Insert succeeded — we are the first instance, safe to grant XP
-      const { data: xpData } = await sb.rpc("grant_xp", {
+      const { data: xpData } = await sb.rpc("grant_xp_atomic", {
         p_developer_id: dev.id,
         p_source: "checkin",
         p_amount: 10,

--- a/src/app/api/dailies/claim/route.ts
+++ b/src/app/api/dailies/claim/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: Request) {
 
   const points_granted = 15;
   // Grant XP for completing all dailies
-  await admin.rpc("grant_xp", { p_developer_id: dev.id, p_source: "dailies", p_amount: 25 });
+  await admin.rpc("grant_xp_atomic", { p_developer_id: dev.id, p_source: "dailies", p_amount: 25 });
 
   // Grant streak freeze every 7 completions (cap at 2)
   // ── BEFORE (read-then-write race): ─────────────────────────────────────────

--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -140,7 +140,7 @@ export async function POST(request: Request) {
 
   const flyXp = Math.floor(score * 0.1);
   if (flyXp > 0) {
-    await admin.rpc("grant_xp", { p_developer_id: dev.id, p_source: "fly", p_amount: flyXp });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: dev.id, p_source: "fly", p_amount: flyXp });
   }
 
   await trackDailyMission(dev.id, "fly_score_50", { score });

--- a/src/app/api/interactions/kudos/route.ts
+++ b/src/app/api/interactions/kudos/route.ts
@@ -80,8 +80,8 @@ export async function POST(request: Request) {
 
   await admin.rpc("increment_kudos_count", { target_dev_id: receiver.id });
 
-  await admin.rpc("grant_xp", { p_developer_id: giver.id, p_source: "kudos_given", p_amount: 3 });
-  await admin.rpc("grant_xp", { p_developer_id: receiver.id, p_source: "kudos_received", p_amount: 1 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: giver.id, p_source: "kudos_given", p_amount: 3 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: receiver.id, p_source: "kudos_received", p_amount: 1 });
 
   await admin.from("activity_feed").insert({
     event_type: "kudos_given",

--- a/src/app/api/interactions/visit/route.ts
+++ b/src/app/api/interactions/visit/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: Request) {
     await admin.rpc("increment_visit_count", { target_dev_id: building.id });
 
     // Grant XP for visiting a building
-    await admin.rpc("grant_xp", { p_developer_id: visitor.id, p_source: "visit", p_amount: 2 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: visitor.id, p_source: "visit", p_amount: 2 });
 
     // Check if building crossed visit milestone (>5 visits today)
     const { count: todayVisits } = await admin

--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -339,12 +339,12 @@ export async function POST(request: Request) {
       admin.from("developers").update({ raid_xp: (attacker.raid_xp ?? 0) + XP_WIN_ATTACKER }).eq("id", attacker.id),
       admin.from("developers").update({ raid_xp: (defender.raid_xp ?? 0) + XP_WIN_DEFENDER }).eq("id", defender.id),
     ]);
-    await admin.rpc("grant_xp", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
-    await admin.rpc("grant_xp", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
   } else {
     await admin.from("developers").update({ raid_xp: (defender.raid_xp ?? 0) + XP_LOSE_DEFENDER }).eq("id", defender.id);
-    await admin.rpc("grant_xp", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
-    await admin.rpc("grant_xp", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
   }
 
   await admin.from("activity_feed").insert({

--- a/src/lib/__tests__/arena-first-solve.test.ts
+++ b/src/lib/__tests__/arena-first-solve.test.ts
@@ -21,7 +21,7 @@ function buildMockSb(wonRace: boolean, claimError: any = null) {
           error: claimError,
         });
       }
-      if (name === "grant_xp") {
+      if (name === "grant_xp_atomic") {
         return Promise.resolve({ data: { granted: 10, new_total: 110, new_level: 1 }, error: null });
       }
       return Promise.resolve({ data: null, error: null });
@@ -84,21 +84,21 @@ describe("Arena first-solve idempotency — application layer", () => {
 
   it("grant_xp is called only when won_race is true", async () => {
     const sb = buildMockSb(true);
-    // Simulate the route's conditional: only call grant_xp if isFirstSolve
+    // Simulate the route's conditional: only call grant_xp_atomic if isFirstSolve
     const isFirstSolve = true;
     if (isFirstSolve) {
-      await sb.rpc("grant_xp", { p_developer_id: 1, p_source: "arena_medium", p_amount: 10 });
+      await sb.rpc("grant_xp_atomic", { p_developer_id: 1, p_source: "arena_medium", p_amount: 10 });
     }
-    expect(sb.rpc).toHaveBeenCalledWith("grant_xp", expect.objectContaining({ p_amount: 10 }));
+    expect(sb.rpc).toHaveBeenCalledWith("grant_xp_atomic", expect.objectContaining({ p_amount: 10 }));
   });
 
   it("grant_xp is NOT called when won_race is false", async () => {
     const sb = buildMockSb(false);
     const isFirstSolve = false;
     if (isFirstSolve) {
-      await sb.rpc("grant_xp", { p_developer_id: 1, p_source: "arena_medium", p_amount: 10 });
+      await sb.rpc("grant_xp_atomic", { p_developer_id: 1, p_source: "arena_medium", p_amount: 10 });
     }
-    expect(sb.rpc).not.toHaveBeenCalledWith("grant_xp", expect.anything());
+    expect(sb.rpc).not.toHaveBeenCalledWith("grant_xp_atomic", expect.anything());
   });
 
   // ── Multiplier calculation ─────────────────────────────────────

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -178,15 +178,24 @@ export async function checkAchievements(
       .upsert(purchaseRows, { onConflict: "developer_id,item_id" });
   }
 
-  // Grant XP for each achievement unlock
+  // Grant XP for each achievement unlock (atomic + idempotent)
   for (const a of newUnlocks) {
     const xpAmount = xpForAchievementTier(a.tier);
     if (xpAmount > 0) {
-      sb.rpc("grant_xp", {
-        p_developer_id: developerId,
-        p_source: "achievement",
-        p_amount: xpAmount,
-      }).then();
+      try {
+        const { data: xpResult, error: xpError } = await sb.rpc("grant_xp_atomic", {
+          p_developer_id: developerId,
+          p_source: `achievement_${a.id}`,
+          p_amount: xpAmount,
+        });
+        if (xpError) {
+          console.error(`[achievements] XP grant failed for ${a.id}:`, xpError);
+        } else if (xpResult === null) {
+          // Duplicate grant — already logged, safe to skip
+        }
+      } catch (err) {
+        console.error(`[achievements] XP grant error for ${a.id}:`, err);
+      }
     }
   }
 

--- a/supabase/migrations/060_xp_grant_idempotency.sql
+++ b/supabase/migrations/060_xp_grant_idempotency.sql
@@ -1,0 +1,99 @@
+-- Migration: XP Grant Atomicity & Idempotency
+-- Issue #343
+--
+-- Provides:
+--   1. xp_grant_log table — idempotency anchor for every XP grant
+--   2. grant_xp_atomic() RPC — atomically increments XP, caps daily
+--      engagement sources, logs each grant, and returns null for
+--      duplicate calls
+
+-- ─── 1. XP Grant Log ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS xp_grant_log (
+  developer_id  BIGINT       NOT NULL REFERENCES developers(id) ON DELETE CASCADE,
+  source        TEXT         NOT NULL,
+  source_date   DATE         NOT NULL DEFAULT CURRENT_DATE,
+  amount        INTEGER      NOT NULL,
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, source, source_date)
+);
+
+-- ─── 2. grant_xp_atomic() RPC ────────────────────────────────
+CREATE OR REPLACE FUNCTION grant_xp_atomic(
+  p_developer_id BIGINT,
+  p_source       TEXT,
+  p_amount       INTEGER,
+  p_source_date  DATE DEFAULT CURRENT_DATE
+) RETURNS JSON
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actual    INTEGER;
+  v_new_total INTEGER;
+  v_new_level INTEGER;
+  v_daily     INTEGER;
+  v_today     DATE := CURRENT_DATE;
+BEGIN
+  -- Idempotency: if this exact grant was already logged, return null
+  -- The caller should treat null as "already granted, skip"
+  INSERT INTO xp_grant_log (developer_id, source, source_date, amount)
+  VALUES (p_developer_id, p_source, p_source_date, p_amount)
+  ON CONFLICT (developer_id, source, source_date) DO NOTHING;
+
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  -- Reset daily counter if new day
+  UPDATE developers
+  SET xp_daily = 0, xp_daily_date = v_today
+  WHERE id = p_developer_id AND (xp_daily_date IS NULL OR xp_daily_date < v_today);
+
+  SELECT xp_daily INTO v_daily FROM developers WHERE id = p_developer_id;
+
+  -- Daily cap only for engagement sources
+  IF p_source IN ('checkin', 'dailies', 'kudos_given', 'visit', 'fly') THEN
+    v_actual := LEAST(p_amount, GREATEST(0, 150 - COALESCE(v_daily, 0)));
+  ELSE
+    v_actual := p_amount;
+  END IF;
+
+  IF v_actual <= 0 THEN
+    DELETE FROM xp_grant_log
+    WHERE developer_id = p_developer_id
+      AND source = p_source
+      AND source_date = p_source_date;
+    RETURN json_build_object('granted', 0, 'reason', 'daily_cap');
+  END IF;
+
+  -- Atomic increment
+  UPDATE developers
+  SET xp_total = xp_total + v_actual,
+      xp_daily = COALESCE(xp_daily, 0) +
+        CASE WHEN p_source IN ('checkin','dailies','kudos_given','visit','fly')
+        THEN v_actual ELSE 0 END,
+      xp_daily_date = v_today
+  WHERE id = p_developer_id
+  RETURNING xp_total INTO v_new_total;
+
+  -- Calculate level (25 * level^2.2)
+  v_new_level := 1;
+  WHILE v_new_total >= (25 * POWER(v_new_level + 1, 2.2))::integer LOOP
+    v_new_level := v_new_level + 1;
+  END LOOP;
+
+  UPDATE developers SET xp_level = GREATEST(xp_level, v_new_level)
+  WHERE id = p_developer_id;
+
+  -- Update the log row with the actual amount granted
+  UPDATE xp_grant_log SET amount = v_actual
+  WHERE developer_id = p_developer_id
+    AND source = p_source
+    AND source_date = p_source_date;
+
+  -- Also log to the existing audit trail
+  INSERT INTO xp_log (developer_id, source, amount)
+  VALUES (p_developer_id, p_source, v_actual);
+
+  RETURN json_build_object('granted', v_actual, 'new_total', v_new_total, 'new_level', v_new_level);
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

Prevents XP loss when multiple XP grants happen concurrently. Creates an `xp_grant_log` table with a composite primary key `(developer_id, source, source_date)` for idempotency, and a `grant_xp_atomic` RPC that atomically inserts the log entry and updates the developer's XP in one transaction. Replaces all 8 ad-hoc `grant_xp` calls (checkin, dailies/claim, kudos, visit, raid/execute, arena/submit, fly-scores, achievements) with the atomic RPC. Also fixes a fire-and-forget `.then()` in `achievements.ts` that could swallow errors, changing it to `await` with try/catch.

## Related issue

Fixes #343

## Screenshots

N/A — logic change only, no visual impact

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)