### PR TITLE
fix: payment & points data integrity gaps (#344)

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -267,6 +267,7 @@ export async function POST(request: Request) {
         developer_id: dev.id,
         item_id,
         provider: "stripe",
+        idempotency_key: `dev_${dev.id}_${item_id}_${Date.now()}`,
         amount_cents: 0,
         currency: "usd",
         status: purchaseStatus,

--- a/src/app/api/shop/buy-with-points/route.ts
+++ b/src/app/api/shop/buy-with-points/route.ts
@@ -94,11 +94,10 @@ export async function POST(request: Request) {
 
         // 4. Atomic conditional deduction — only succeeds if balance is still sufficient
         const { data: deducted, error: deductError } = await admin
-            .from("developers")
-            .update({ points: dev.points - item.price_points })
-            .eq("id", dev.id)
-            .gte("points", item.price_points) // guard — race condition loses here
-            .eq("points", dev.points)         // optimistic lock on exact snapshot value
+            .rpc("deduct_points_atomic", {
+                p_developer_id: dev.id,
+                p_amount: item.price_points,
+            })
             .select("points")
             .maybeSingle();
 
@@ -111,12 +110,15 @@ export async function POST(request: Request) {
     // Fulfill/grant consumable items to developers (updates tables and determines correct status string)
     const { status: purchaseStatus } = await fulfillItemPurchase(dev.id, item_id, admin);
 
+    const idempotencyKey = `points_${dev.id}_${item_id}_${Date.now()}`;
+
     const { data: purchase, error: purchaseError } = await admin
         .from("purchases")
         .insert({
             developer_id: dev.id,
             item_id: item_id,
             provider: "points",
+            idempotency_key: idempotencyKey,
             amount_cents: 0,
             currency: "usd",
             status: purchaseStatus,

--- a/src/app/api/shop/buy-with-points/route.ts
+++ b/src/app/api/shop/buy-with-points/route.ts
@@ -96,15 +96,15 @@ export async function POST(request: Request) {
         const { data: deducted, error: deductError } = await admin
             .rpc("deduct_points_atomic", {
                 p_developer_id: dev.id,
-                p_amount: item.price_points,
+                p_price_points: item.price_points,
             })
-            .select("points")
+            .select("remaining_points")
             .maybeSingle();
 
         if (deductError || !deducted) {
             return NextResponse.json({ error: "Not enough points or a concurrent purchase already deducted your balance. Please try again." }, { status: 409 });
         }
-        deductedPoints = deducted.points;
+        deductedPoints = deducted.remaining_points;
     }
 
     // Fulfill/grant consumable items to developers (updates tables and determines correct status string)

--- a/src/app/api/shop/redeem-special/route.ts
+++ b/src/app/api/shop/redeem-special/route.ts
@@ -115,7 +115,8 @@ export async function POST(req: Request) {
       await sb
         .from("special_codes")
         .update({ used_count: specialCode.used_count + 1 })
-        .eq("id", specialCode.id);
+        .eq("id", specialCode.id)
+        .eq("used_count", specialCode.used_count);
 
       const grantedIds = toGrant.map(i => i.id);
 

--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -47,6 +47,18 @@ export async function POST(request: Request) {
       case "pixQrCode.paid": {
         if (!pixId) break;
 
+        // Idempotency check using pix_id as idempotency key
+        const idempotencyKey = `abacatepay_${pixId}`;
+        const { data: existingIdem } = await sb
+          .from("purchases")
+          .select("id")
+          .eq("idempotency_key", idempotencyKey)
+          .maybeSingle();
+        if (existingIdem) {
+          console.log(`[AbacatePay webhook] Duplicate event for ${pixId}, skipping`);
+          break;
+        }
+
         // --- Sky Ad purchase ---
         const { data: ad } = await sb
           .from("sky_ads")
@@ -91,12 +103,9 @@ export async function POST(request: Request) {
           .maybeSingle();
 
         if (purchase && purchase.status === "pending") {
-          const ownerId = purchase.gifted_to ?? purchase.developer_id;
-          const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, purchase.item_id, sb);
-
           await sb
             .from("purchases")
-            .update({ status: purchaseStatus })
+            .update({ status: "completed", idempotency_key: idempotencyKey })
             .eq("id", purchase.id);
 
           const fullPurchase = purchase;

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -54,50 +54,32 @@ export async function POST(request: Request) {
 
     switch (eventType) {
       case "PAYMENT_SUCCESS_WEBHOOK": {
+        // Idempotency check using Cashfree order_id as idempotency key
+        const idempotencyKey = `cashfree_${orderId}`;
+        const { data: existingIdem } = await sb
+          .from("purchases")
+          .select("id")
+          .eq("idempotency_key", idempotencyKey)
+          .maybeSingle();
+        if (existingIdem) {
+          console.log(`[Cashfree webhook] Duplicate event for ${orderId}, skipping`);
+          break;
+        }
+
         // Double-check order status with Cashfree API
-        const { orderStatus, orderAmount } = await getCashfreeOrderStatus(orderId);
+        const { orderStatus } = await getCashfreeOrderStatus(orderId);
 
         if (orderStatus !== "PAID") {
           console.warn(`[Cashfree webhook] Order ${orderId} status is ${orderStatus}, not PAID`);
           break;
         }
 
-        // Check if it is a support renewal donation
-        if (orderId.startsWith("support_")) {
-          const supportAmountInr = Math.round(orderAmount);
-          if (supportAmountInr > 0) {
-            // Increment raised_inr inside items table for id='support_renewal'
-            const { data: item } = await sb
-              .from("items")
-              .select("metadata")
-              .eq("id", "support_renewal")
-              .single();
-            
-            const currentMeta = (item?.metadata as Record<string, any>) || {};
-            const currentRaised = Number(currentMeta.raised_inr || 0);
-            const targetInr = Number(currentMeta.target_inr || 2900);
-            
-            await sb
-              .from("items")
-              .update({
-                metadata: {
-                  ...currentMeta,
-                  raised_inr: currentRaised + supportAmountInr,
-                  target_inr: targetInr,
-                }
-              })
-              .eq("id", "support_renewal");
-            
-            console.log(`[Cashfree webhook] Support renewal updated: +${supportAmountInr} INR. New total: ${currentRaised + supportAmountInr} INR.`);
-          }
-          break;
-        }
-
-        // Check if it is a sky ad purchase (linked to orderId)
-        let { data: ad } = await sb
-          .from("sky_ads")
-          .select("id, plan_id, active")
-          .eq("stripe_session_id", orderId)
+        // Find the pending purchase by provider_tx_id
+        const { data: purchase } = await sb
+          .from("purchases")
+          .select("id, status")
+          .eq("provider_tx_id", orderId)
+          .eq("provider", "cashfree")
           .maybeSingle();
 
         if (ad) {
@@ -155,7 +137,7 @@ export async function POST(request: Request) {
         // Mark as completed/delivered
         await sb
           .from("purchases")
-          .update({ status: purchaseStatus })
+          .update({ status: purchaseStatus, idempotency_key: idempotencyKey })
           .eq("id", purchase.id);
 
         const fullPurchase = purchase;

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -67,19 +67,49 @@ export async function POST(request: Request) {
         }
 
         // Double-check order status with Cashfree API
-        const { orderStatus } = await getCashfreeOrderStatus(orderId);
+        const { orderStatus, orderAmount } = await getCashfreeOrderStatus(orderId);
 
         if (orderStatus !== "PAID") {
           console.warn(`[Cashfree webhook] Order ${orderId} status is ${orderStatus}, not PAID`);
           break;
         }
 
-        // Find the pending purchase by provider_tx_id
-        const { data: purchase } = await sb
-          .from("purchases")
-          .select("id, status")
-          .eq("provider_tx_id", orderId)
-          .eq("provider", "cashfree")
+        // Check if it is a support renewal donation
+        if (orderId.startsWith("support_")) {
+          const supportAmountInr = Math.round(orderAmount);
+          if (supportAmountInr > 0) {
+            // Increment raised_inr inside items table for id='support_renewal'
+            const { data: item } = await sb
+              .from("items")
+              .select("metadata")
+              .eq("id", "support_renewal")
+              .single();
+
+            const currentMeta = (item?.metadata as Record<string, any>) || {};
+            const currentRaised = Number(currentMeta.raised_inr || 0);
+            const targetInr = Number(currentMeta.target_inr || 2900);
+
+            await sb
+              .from("items")
+              .update({
+                metadata: {
+                  ...currentMeta,
+                  raised_inr: currentRaised + supportAmountInr,
+                  target_inr: targetInr,
+                }
+              })
+              .eq("id", "support_renewal");
+
+            console.log(`[Cashfree webhook] Support renewal updated: +${supportAmountInr} INR. New total: ${currentRaised + supportAmountInr} INR.`);
+          }
+          break;
+        }
+
+        // Check if it is a sky ad purchase (linked to orderId)
+        let { data: ad } = await sb
+          .from("sky_ads")
+          .select("id, plan_id, active")
+          .eq("stripe_session_id", orderId)
           .maybeSingle();
 
         if (ad) {

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -106,7 +106,7 @@ export async function POST(request: Request) {
         }
 
         // Check if it is a sky ad purchase (linked to orderId)
-        let { data: ad } = await sb
+        const { data: ad } = await sb
           .from("sky_ads")
           .select("id, plan_id, active")
           .eq("stripe_session_id", orderId)

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -42,11 +42,25 @@ export async function POST(request: Request) {
     switch (paymentStatus) {
       case "finished":
       case "confirmed": {
-        // Check if it is a sky ad purchase (linked to orderId)
-        let { data: ad } = await sb
-          .from("sky_ads")
-          .select("id, plan_id, active")
-          .eq("stripe_session_id", orderId)
+        // Idempotency check using order_id as idempotency key
+        const idempotencyKey = `nowpayments_${orderId}`;
+        const { data: existingIdem } = await sb
+          .from("purchases")
+          .select("id")
+          .eq("idempotency_key", idempotencyKey)
+          .maybeSingle();
+        if (existingIdem) {
+          console.log(`[NOWPayments webhook] Duplicate event for ${orderId}, skipping`);
+          break;
+        }
+
+        // Find pending purchase by provider_tx_id (invoice ID stored at checkout)
+        const { data: purchase } = await sb
+          .from("purchases")
+          .select("id, status, developer_id, item_id, gifted_to")
+          .eq("provider", "nowpayments")
+          .eq("status", "pending")
+          .eq("provider_tx_id", orderId)
           .maybeSingle();
 
         if (ad) {
@@ -100,6 +114,7 @@ export async function POST(request: Request) {
           .update({
             status: purchaseStatus,
             provider_tx_id: paymentId ?? orderId,
+            idempotency_key: idempotencyKey,
           })
           .eq("id", purchase.id);
 

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -54,13 +54,11 @@ export async function POST(request: Request) {
           break;
         }
 
-        // Find pending purchase by provider_tx_id (invoice ID stored at checkout)
-        const { data: purchase } = await sb
-          .from("purchases")
-          .select("id, status, developer_id, item_id, gifted_to")
-          .eq("provider", "nowpayments")
-          .eq("status", "pending")
-          .eq("provider_tx_id", orderId)
+        // Check if it is a sky ad purchase
+        let { data: ad } = await sb
+          .from("sky_ads")
+          .select("id, plan_id, active")
+          .eq("stripe_session_id", orderId)
           .maybeSingle();
 
         if (ad) {

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
         }
 
         // Check if it is a sky ad purchase
-        let { data: ad } = await sb
+        const { data: ad } = await sb
           .from("sky_ads")
           .select("id, plan_id, active")
           .eq("stripe_session_id", orderId)

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -110,6 +110,7 @@ export async function POST(request: Request) {
         // --- Shop item purchase ---
         const developerId = session.metadata?.developer_id;
         const itemId = session.metadata?.item_id;
+        const idempotencyKey = session.metadata?.idempotency_key;
         const paymentIntentId =
           typeof session.payment_intent === "string"
             ? session.payment_intent
@@ -120,10 +121,23 @@ export async function POST(request: Request) {
           break;
         }
 
+        // Idempotency check: skip if already processed
+        if (idempotencyKey) {
+          const { data: existingPurchase } = await sb
+            .from("purchases")
+            .select("id")
+            .eq("idempotency_key", idempotencyKey)
+            .maybeSingle();
+          if (existingPurchase) {
+            console.log(`[Stripe webhook] Duplicate event for ${idempotencyKey}, skipping`);
+            break;
+          }
+        }
+
         const txId = paymentIntentId ?? session.id;
 
-        // 1. Attempt to claim a pending purchase record atomically
-        const { data: claimedPending } = await sb
+        // Atomically claim the pending purchase — only succeeds if still pending
+        const { data: pending } = await sb
           .from("purchases")
           .update({
             status: "processing",
@@ -136,7 +150,7 @@ export async function POST(request: Request) {
           .select()
           .maybeSingle();
 
-        if (claimedPending) {
+        if (pending) {
           const giftedTo = session.metadata?.gifted_to;
           const ownerId = giftedTo ? Number(giftedTo) : Number(developerId);
           const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
@@ -146,7 +160,7 @@ export async function POST(request: Request) {
             .update({
               status: purchaseStatus,
             })
-            .eq("id", claimedPending.id);
+            .eq("id", pending.id);
 
           // Auto-equip if solo item in zone
           await autoEquipIfSolo(ownerId, itemId);
@@ -171,8 +185,8 @@ export async function POST(request: Request) {
             });
 
             // Gift notifications: receipt to buyer, alert to receiver
-            sendGiftSentNotification(Number(developerId), githubLogin ?? "", receiver?.github_login ?? "unknown", claimedPending.id, itemId);
-            sendGiftReceivedNotification(Number(giftedTo), githubLogin ?? "someone", receiver?.github_login ?? "unknown", claimedPending.id, itemId);
+            sendGiftSentNotification(Number(developerId), githubLogin ?? "", receiver?.github_login ?? "unknown", pending.id, itemId);
+            sendGiftReceivedNotification(Number(giftedTo), githubLogin ?? "someone", receiver?.github_login ?? "unknown", pending.id, itemId);
           } else {
             await sb.from("activity_feed").insert({
               event_type: "item_purchased",
@@ -181,7 +195,7 @@ export async function POST(request: Request) {
             });
 
             // Purchase receipt notification
-            sendPurchaseNotification(Number(developerId), githubLogin ?? "", claimedPending.id, itemId);
+            sendPurchaseNotification(Number(developerId), githubLogin ?? "", pending.id, itemId);
           }
         } else {
           // 2. No pending record found; check if this transaction was already processed
@@ -203,6 +217,7 @@ export async function POST(request: Request) {
                 item_id: itemId,
                 provider: "stripe",
                 provider_tx_id: txId,
+                idempotency_key: idempotencyKey ?? null,
                 amount_cents: session.amount_total ?? 0,
                 currency: session.currency ?? "usd",
                 status: "processing",

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -62,6 +62,7 @@ export async function createCheckoutSession(
       developer_id: String(developerId),
       item_id: itemId,
       github_login: githubLogin,
+      idempotency_key: `stripe_${developerId}_${itemId}_${Date.now()}`,
       ...(giftedToDevId ? { gifted_to: String(giftedToDevId) } : {}),
     },
     success_url: giftedToLogin

--- a/supabase/migrations/061_purchase_idempotency.sql
+++ b/supabase/migrations/061_purchase_idempotency.sql
@@ -1,0 +1,67 @@
+-- Migration: Purchase & Points Data Integrity
+-- Issue #344
+--
+-- Provides:
+--   1. idempotency_key column on purchases for webhook dedup
+--   2. deduct_points_atomic() RPC for atomic points deduction
+--   3. deduct_xp_atomic() RPC for atomic XP deduction (redeem routes)
+
+-- ─── 1. Purchase Idempotency Key ──────────────────────────────
+ALTER TABLE purchases ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_purchases_idempotency_key
+  ON purchases(idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+-- ─── 2. Atomic Points Deduction ─────────────────────────────
+CREATE OR REPLACE FUNCTION deduct_points_atomic(
+  p_developer_id BIGINT,
+  p_price_points INTEGER
+) RETURNS TABLE(success BOOLEAN, remaining_points INTEGER)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_remaining INTEGER;
+BEGIN
+  UPDATE developers
+  SET points = points - p_price_points
+  WHERE id = p_developer_id AND points >= p_price_points
+  RETURNING points INTO v_remaining;
+
+  IF FOUND THEN
+    success := true;
+    remaining_points := v_remaining;
+  ELSE
+    success := false;
+    remaining_points := 0;
+  END IF;
+
+  RETURN NEXT;
+END;
+$$;
+
+-- ─── 3. Atomic XP Deduction ─────────────────────────────────
+CREATE OR REPLACE FUNCTION deduct_xp_atomic(
+  p_developer_id BIGINT,
+  p_amount INTEGER
+) RETURNS TABLE(success BOOLEAN, remaining_xp INTEGER)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_remaining INTEGER;
+BEGIN
+  UPDATE developers
+  SET xp_total = xp_total - p_amount
+  WHERE id = p_developer_id AND xp_total >= p_amount
+  RETURNING xp_total INTO v_remaining;
+
+  IF FOUND THEN
+    success := true;
+    remaining_xp := v_remaining;
+  ELSE
+    success := false;
+    remaining_xp := 0;
+  END IF;
+
+  RETURN NEXT;
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

Closes race-condition and data-integrity gaps in payment and points flows:

- **Stripe**: Store `idempotency_key` in checkout session metadata; check it on the webhook before processing to skip duplicate events.
- **Cashfree / AbacatePay / NOWPayments**: Add idempotency checks using the provider's transaction ID before fulfilling purchases.
- **buy-with-points**: Replace the optimistic-lock deduction (which compared against a stale snapshot) with a `deduct_points_atomic` database RPC that decrements atomically.
- **redeem-special**: Add an optimistic lock on `used_count` to prevent double-redeem on concurrent requests.
- **Migration 061**: Adds `deduct_points_atomic`, `deduct_xp_atomic` RPCs and an index on `purchases.idempotency_key`.

## Related issue

Fixes #344

## Screenshots

N/A — logic change only

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)