### PR TITLE
fix: Three.js GPU memory leak from undisposed coin geometry (#345)

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1040,6 +1040,10 @@ function SkyCollectibles({ playerPosRef, accentColor, onCollect, cityRadius }: {
     return geo;
   }, []);
 
+  useEffect(() => {
+    return () => coinGeo.dispose();
+  }, [coinGeo]);
+
   return (
     <>
       <instancedMesh ref={meshRef} args={[coinGeo, undefined, COLLECTIBLE_COUNT]}>


### PR DESCRIPTION
## What does this PR do?

Fixes a GPU memory leak in the \SkyCollectibles\ component. The coin geometry (\CylinderGeometry\) was created in \useMemo\ but never disposed on component unmount. Adds a \useEffect\ cleanup that calls \coinGeo.dispose()\ so the GPU resources are released when the component unmounts.

## Related issue

Fixes #345

## Screenshots

N/A — invisible fix, no visual change

## Checklist

- [ ] \
pm run lint\ passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)