### PR TITLE
fix: use atomic DB increment for raid_xp to prevent race condition data loss

### DIFF
--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -335,14 +335,18 @@ export async function POST(request: Request) {
       expires_at: new Date(Date.now() + RAID_TAG_DURATION_DAYS * 86400000).toISOString(),
     });
 
+    // Use atomic DB-level increments to prevent race condition data loss.
+    // Passing raw SQL expressions via rpc avoids the stale-read overwrite
+    // that would occur if we used in-memory values computed before execute_raid().
     await Promise.all([
-      admin.from("developers").update({ raid_xp: (attacker.raid_xp ?? 0) + XP_WIN_ATTACKER }).eq("id", attacker.id),
-      admin.from("developers").update({ raid_xp: (defender.raid_xp ?? 0) + XP_WIN_DEFENDER }).eq("id", defender.id),
+      admin.rpc("increment_raid_xp", { p_developer_id: attacker.id, p_amount: XP_WIN_ATTACKER }),
+      admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_WIN_DEFENDER }),
     ]);
     await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
     await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
   } else {
-    await admin.from("developers").update({ raid_xp: (defender.raid_xp ?? 0) + XP_LOSE_DEFENDER }).eq("id", defender.id);
+    // Atomic increment — avoid overwriting concurrent XP changes.
+    await admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_LOSE_DEFENDER });
     await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
     await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
   }
@@ -364,8 +368,14 @@ export async function POST(request: Request) {
   if (success) await trackDailyMission(attacker.id, "win_battle");
   sendRaidAlertNotification(defender.id, defender.github_login, attacker.github_login, raidId, success, attack.total, defense.total);
 
-  const newAttackerXp = (attacker.raid_xp ?? 0) + (success ? XP_WIN_ATTACKER : 0);
-  const newDefenderXp = (defender.raid_xp ?? 0) + (success ? XP_WIN_DEFENDER : XP_LOSE_DEFENDER);
+  // Re-fetch updated raid_xp to ensure response and achievements use the latest atomic value
+  const [{ data: updatedAttacker }, { data: updatedDefender }] = await Promise.all([
+    admin.from("developers").select("raid_xp").eq("id", attacker.id).maybeSingle(),
+    admin.from("developers").select("raid_xp").eq("id", defender.id).maybeSingle(),
+  ]);
+
+  const newAttackerXp = updatedAttacker?.raid_xp ?? ((attacker.raid_xp ?? 0) + (success ? XP_WIN_ATTACKER : 0));
+  const newDefenderXp = updatedDefender?.raid_xp ?? ((defender.raid_xp ?? 0) + (success ? XP_WIN_DEFENDER : XP_LOSE_DEFENDER));
 
   const [attackerAchievements] = await Promise.all([
     checkAchievements(attacker.id, {

--- a/supabase/migrations/060_atomic_raid_xp_increment.sql
+++ b/supabase/migrations/060_atomic_raid_xp_increment.sql
@@ -1,0 +1,29 @@
+-- Migration: Atomic raid_xp increment RPC
+-- Fixes Issue #404: Concurrency Race Condition causes silent data loss in Raid XP
+--
+-- Problem: The Node.js route computed new XP values from application-memory reads
+-- made before execute_raid() ran. Concurrent XP changes (other raids, missions) would
+-- be silently overwritten because the update used a stale value.
+--
+-- Solution: A simple RPC that performs an atomic SQL increment inside a transaction,
+-- using row-level locking so concurrent updates are serialised, not lost.
+
+create or replace function increment_raid_xp(
+  p_developer_id integer,
+  p_amount       integer
+)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  update developers
+  set    raid_xp = coalesce(raid_xp, 0) + p_amount
+  where  id = p_developer_id;
+end;
+$$;
+
+-- Only the service-role key (used by getSupabaseAdmin) may call this function.
+-- Authenticated end-users are not allowed to call it directly.
+revoke execute on function increment_raid_xp(integer, integer) from anon, authenticated;
+grant  execute on function increment_raid_xp(integer, integer) to service_role;


### PR DESCRIPTION
## Summary

Fixes #404

### Problem
In src/app/api/raid/execute/route.ts, the attacker and defender's aid_xp were updated using values computed in **application memory** from reads that occurred at the very start of the request:

\\\	ypescript
// ❌ Before — stale read + overwrite
await Promise.all([
  admin.from('developers').update({ raid_xp: (attacker.raid_xp ?? 0) + XP_WIN_ATTACKER }).eq('id', attacker.id),
  admin.from('developers').update({ raid_xp: (defender.raid_xp ?? 0) + XP_WIN_DEFENDER }).eq('id', defender.id),
]);
\\\

Because \execute_raid()\ runs in between the initial read and this write, any concurrent XP change (e.g. another raid completing concurrently, or a daily mission granting XP) would be **silently overwritten**, causing invisible data loss.

### Fix
Replace the stale-read writes with calls to a new \increment_raid_xp()\ Supabase RPC that performs an **atomic SQL increment**:

\\\sql
UPDATE developers SET raid_xp = COALESCE(raid_xp, 0) + p_amount WHERE id = p_developer_id;
\\\

This runs inside a transaction with row-level locking, so concurrent updates are serialised rather than lost.

\\\	ypescript
// ✅ After — atomic increment
await Promise.all([
  admin.rpc('increment_raid_xp', { p_developer_id: attacker.id, p_amount: XP_WIN_ATTACKER }),
  admin.rpc('increment_raid_xp', { p_developer_id: defender.id, p_amount: XP_WIN_DEFENDER }),
]);
\\\

### Files Changed
- \src/app/api/raid/execute/route.ts\ — replaced stale writes with \increment_raid_xp\ RPC calls (success and failure branches)
- \supabase/migrations/060_atomic_raid_xp_increment.sql\ — new RPC restricted to service-role key only