### PR TITLE
fix: preserve paid Stripe purchases when granting achievement item rewards

### DIFF
--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -172,10 +172,14 @@ export async function checkAchievements(
       status: "completed",
     }));
 
-    // Batch upsert — unique index on (developer_id, item_id) prevents duplicates
+    // Use ignoreDuplicates:true instead of a destructive upsert.
+    // If the user already owns this item via a paid Stripe purchase the existing
+    // record (provider:"stripe", amount_cents > 0, Stripe tx id) must NOT be
+    // overwritten. ignoreDuplicates:true translates to INSERT … ON CONFLICT DO NOTHING,
+    // so paid records are preserved and no financial audit data is lost.
     await sb
       .from("purchases")
-      .upsert(purchaseRows, { onConflict: "developer_id,item_id" });
+      .upsert(purchaseRows, { onConflict: "developer_id,item_id", ignoreDuplicates: true });
   }
 
   // Grant XP for each achievement unlock


### PR DESCRIPTION
## Summary

Fixes #405

### Problem
In \src/lib/achievements.ts\, when an achievement grants an item reward (\eward_type === 'unlock_item'\), the code inserted into the \purchases\ table using an **upsert without \ignoreDuplicates\**:

\\\	ypescript
// ❌ Before — destructively overwrites existing Stripe records
await sb
  .from('purchases')
  .upsert(purchaseRows, { onConflict: 'developer_id,item_id' });
\\\

Without \ignoreDuplicates: true\, Supabase emits \INSERT … ON CONFLICT DO UPDATE\, which **overwrites** the conflicting row. If the user previously bought this item via Stripe, their purchase record — \provider: 'stripe'\, \mount_cents > 0\, and their Stripe transaction ID — would be permanently erased and replaced with \provider: 'achievement'\, \mount_cents: 0\, destroying the financial audit trail.

### Fix
Add \ignoreDuplicates: true\ to the upsert. This changes the generated SQL to \INSERT … ON CONFLICT DO NOTHING\, so any pre-existing paid purchase records are left completely untouched. Users who don't already own the item still receive it correctly.

\\\	ypescript
// ✅ After — safe insert, never overwrites paid records
await sb
  .from('purchases')
  .upsert(purchaseRows, { onConflict: 'developer_id,item_id', ignoreDuplicates: true });
\\\

### Files Changed
- \src/lib/achievements.ts\ — one-line fix: added \ignoreDuplicates: true\ to the purchases upsert