### PR TITLE
fix: clarify verification endpoint error messages

### DIFF
--- a/src/app/api/verify-github-star/route.ts
+++ b/src/app/api/verify-github-star/route.ts
@@ -66,7 +66,7 @@ export async function POST() {
   ).toLowerCase();
 
   if (!githubLogin) {
-    return NextResponse.json({ error: "No LeetCode login" }, { status: 400 });
+    return NextResponse.json({ error: "No GitHub login found in session" }, { status: 400 });
   }
 
   const sb = getSupabaseAdmin();
@@ -98,8 +98,9 @@ export async function POST() {
   let starred = false;
   try {
     starred = await isStargazer(githubLogin);
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message || "Failed to verify star" }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Failed to verify star";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 
   if (!starred) {

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
         const aboutMe = await fetchLeetCodeAboutMe(leetcode_username);
 
         if (aboutMe === null) {
-            return NextResponse.json({ error: "Could not find this GitHub account" }, { status: 404 });
+            return NextResponse.json({ error: "Could not find this LeetCode account" }, { status: 404 });
         }
 
         if (!aboutMe.includes(expectedToken)) {
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
             .maybeSingle();
 
         if (existingClaim && existingClaim.claimed_by && existingClaim.claimed_by !== user.id) {
-            return NextResponse.json({ error: "This GitHub account is already linked to another LeetCode user." }, { status: 409 });
+            return NextResponse.json({ error: "This LeetCode account is already linked to another user." }, { status: 409 });
         }
 
         // Fetch full LC stats: easy/medium/hard, contest rating, streak


### PR DESCRIPTION
Fixes #452\n\nThis PR updates the verification routes to return context-appropriate error messages:\n- LeetCode lookup failures now mention LeetCode instead of GitHub\n- duplicate-link conflicts now mention the LeetCode account\n- missing GitHub login in session now returns a GitHub-specific message\n\nI also cleaned up the error handling in the GitHub-star route to satisfy linting.