### PR TITLE
fix: normalize Sky Ads analytics owner login

### DIFF
--- a/src/app/api/sky-ads/analytics/route.ts
+++ b/src/app/api/sky-ads/analytics/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
-const OWNER_LOGIN = "Ixotic27";
+const OWNER_LOGIN = "ixotic27";
 
 // Historical baselines from Himetrica (tracking was lost in Supabase due to www origin bug).
 // These get added on top of live Supabase counts. Remove once Supabase data catches up.


### PR DESCRIPTION
## What does this PR do?\nThis PR fixes issue #456 by normalizing the Sky Ads analytics owner login check so the authenticated project admin can access the dashboard without hitting a false 403.\n\n## Related issue\nFixes #456\n\n## Checklist\n- [x] I kept the change scoped to the analytics auth check.\n- [x] I ran validation locally with 
> leetcode-city@2.0.0 lint
> eslint src/app/api/sky-ads/analytics/route.ts.\n- [x] The PR only changes the case-sensitive owner comparison needed for the bug fix.