### PR TITLE
fix: normalize sky ads analytics owner login

### DIFF
--- a/src/app/api/sky-ads/analytics/route.ts
+++ b/src/app/api/sky-ads/analytics/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
-const OWNER_LOGIN = "Ixotic27";
+const OWNER_LOGIN = "ixotic27";
 
 // Historical baselines from Himetrica (tracking was lost in Supabase due to www origin bug).
 // These get added on top of live Supabase counts. Remove once Supabase data catches up.


### PR DESCRIPTION
## What does this PR do?
Normalizes the Sky Ads analytics owner login check so the API matches the lowercase GitHub username stored in the repo.

## Related issue
Fixes #456

## Checklist
- [x] I have tested my changes locally.
- [x] I have followed the repository contribution guidelines.
- [x] I have linked the related issue.
