### PR TITLE
fix(webhook): add idempotency to support donations (#455)

### DIFF
--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -66,6 +66,18 @@ export async function POST(request: Request) {
         if (orderId.startsWith("support_")) {
           const supportAmountInr = Math.round(orderAmount);
           if (supportAmountInr > 0) {
+            // Try to record this transaction in support_donations table
+            const { data: inserted, error: insertError } = await sb
+              .from("support_donations")
+              .insert({ order_id: orderId, amount_inr: supportAmountInr })
+              .select("id")
+              .maybeSingle();
+            
+            if (insertError || !inserted) {
+              console.log(`[Cashfree webhook] Support donation ${orderId} already processed — skipping`);
+              break;
+            }
+
             // Increment raised_inr inside items table for id='support_renewal'
             const { data: item } = await sb
               .from("items")

--- a/supabase/migrations/062_support_donations_idempotency.sql
+++ b/supabase/migrations/062_support_donations_idempotency.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS public.support_donations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id TEXT UNIQUE NOT NULL,
+    amount_inr INTEGER NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE public.support_donations ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
 ## What does this PR do?                                                                             
                                                                                                         
    
Implements an idempotency check for support donations handled via the Cashfree webhook. This adds a new migration to create a `support_donations` tracking table, and updates `src/app/api/webhooks/cashfree/route.ts` to attempt an atomic insert into this table using the `order_id` before processing the donation amount, preventing double-counting in case of retried webhooks.
  
    
## Related issue
  
    
Fixes #455
  
    
## Screenshots
  
    
N/A
  
    
## Checklist
  
- [x] `npm run lint` passes (Note: pre-existing warnings persist, but no new errors were added by this PR)
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.      
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers) 