### PR TITLE
fix: require arena encryption key from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzd
 # Ask @Ixotic27 for the key if you need it for your issue.
 SUPABASE_SERVICE_ROLE_KEY=
 
+# ── Arena hidden-test encryption ─────────────────────────────
+# Required by the arena challenge API.
+# Generate a strong value with: openssl rand -hex 32
+# Keep this value private and configure it in the deployment environment.
+ARENA_CRYPTO_KEY=
+
 # ── GitHub Token (LEAVE BLANK for most work) ────────────────
 # Only needed if you're working on the GitHub API integration.
 # Generate one at: https://github.com/settings/tokens

--- a/src/lib/__tests__/arena-crypto.test.ts
+++ b/src/lib/__tests__/arena-crypto.test.ts
@@ -1,0 +1,137 @@
+import crypto from "crypto";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest";
+
+vi.mock("../supabase", () => ({
+  getSupabaseAdmin: vi.fn()
+}));
+
+vi.mock("../supabase-server", () => ({
+  createServerSupabase: vi.fn()
+}));
+
+import { encryptHiddenTests } from "../arena";
+
+const originalArenaCryptoKey = process.env.ARENA_CRYPTO_KEY;
+const validArenaCryptoKey = "a".repeat(64);
+
+function decryptHiddenTests(
+  encryptedData: string,
+  ivHex: string,
+  secret: string
+): unknown {
+  const key = crypto
+    .createHash("sha256")
+    .update(secret, "utf8")
+    .digest();
+
+  const iv = Buffer.from(ivHex, "hex");
+  const decipher = crypto.createDecipheriv(
+    "aes-256-cbc",
+    key,
+    iv
+  );
+
+  let decrypted = decipher.update(
+    encryptedData,
+    "hex",
+    "utf8"
+  );
+  decrypted += decipher.final("utf8");
+
+  return JSON.parse(decrypted);
+}
+
+describe("arena hidden-test encryption", () => {
+  beforeEach(() => {
+    delete process.env.ARENA_CRYPTO_KEY;
+  });
+
+  afterEach(() => {
+    if (originalArenaCryptoKey === undefined) {
+      delete process.env.ARENA_CRYPTO_KEY;
+    } else {
+      process.env.ARENA_CRYPTO_KEY =
+        originalArenaCryptoKey;
+    }
+  });
+
+  it("rejects encryption when ARENA_CRYPTO_KEY is missing", () => {
+    expect(() => encryptHiddenTests([])).toThrow(
+      "ARENA_CRYPTO_KEY must be configured"
+    );
+  });
+
+  it("rejects encryption when the key is too short", () => {
+    process.env.ARENA_CRYPTO_KEY = "short-key";
+
+    expect(() => encryptHiddenTests([])).toThrow(
+      "ARENA_CRYPTO_KEY must contain at least 32 characters"
+    );
+  });
+
+  it("encrypts hidden tests using a configured key", () => {
+    process.env.ARENA_CRYPTO_KEY = validArenaCryptoKey;
+
+    const tests = [
+      {
+        input: "1 2",
+        output: "3"
+      }
+    ];
+
+    const result = encryptHiddenTests(tests);
+
+    expect(result.iv).toMatch(/^[0-9a-f]{32}$/);
+    expect(result.encryptedData).toMatch(/^[0-9a-f]+$/);
+    expect(result.encryptedData).not.toContain(
+      JSON.stringify(tests)
+    );
+  });
+
+  it("produces output that can be decrypted with the configured key", () => {
+    process.env.ARENA_CRYPTO_KEY = validArenaCryptoKey;
+
+    const tests = [
+      {
+        input: "5 7",
+        output: "12"
+      }
+    ];
+
+    const result = encryptHiddenTests(tests);
+
+    expect(
+      decryptHiddenTests(
+        result.encryptedData,
+        result.iv,
+        validArenaCryptoKey
+      )
+    ).toEqual(tests);
+  });
+
+  it("uses a fresh IV for each encryption", () => {
+    process.env.ARENA_CRYPTO_KEY = validArenaCryptoKey;
+
+    const tests = [
+      {
+        input: "10",
+        output: "20"
+      }
+    ];
+
+    const first = encryptHiddenTests(tests);
+    const second = encryptHiddenTests(tests);
+
+    expect(first.iv).not.toBe(second.iv);
+    expect(first.encryptedData).not.toBe(
+      second.encryptedData
+    );
+  });
+});

--- a/src/lib/arena.ts
+++ b/src/lib/arena.ts
@@ -2,7 +2,28 @@ import { getSupabaseAdmin } from "./supabase";
 import { createServerSupabase } from "./supabase-server";
 import crypto from "crypto";
 
-const ENCRYPTION_KEY = process.env.ARENA_CRYPTO_KEY || "leetcode-city-arena-secret-key-32ch";
+const MIN_ARENA_CRYPTO_KEY_LENGTH = 32;
+
+function getArenaCryptoKey(): Buffer {
+  const secret = process.env.ARENA_CRYPTO_KEY?.trim();
+
+  if (!secret) {
+    throw new Error(
+      "ARENA_CRYPTO_KEY must be configured before encrypting arena hidden tests"
+    );
+  }
+
+  if (secret.length < MIN_ARENA_CRYPTO_KEY_LENGTH) {
+    throw new Error(
+      `ARENA_CRYPTO_KEY must contain at least ${MIN_ARENA_CRYPTO_KEY_LENGTH} characters`
+    );
+  }
+
+  return crypto
+    .createHash("sha256")
+    .update(secret, "utf8")
+    .digest();
+}
 
 export interface CFProblem {
   contestId?: number;
@@ -488,13 +509,13 @@ export async function getAuthenticatedDeveloper(req: Request) {
 /** Encrypt hidden tests using AES-256-CBC */
 export function encryptHiddenTests(tests: any[]): { iv: string; encryptedData: string } {
   const algorithm = "aes-256-cbc";
-  const key = crypto.createHash("sha256").update(ENCRYPTION_KEY).digest();
+  const key = getArenaCryptoKey();
   const iv = crypto.randomBytes(16);
-  
+
   const cipher = crypto.createCipheriv(algorithm, key, iv);
   let encrypted = cipher.update(JSON.stringify(tests), "utf8", "hex");
   encrypted += cipher.final("hex");
-  
+
   return {
     iv: iv.toString("hex"),
     encryptedData: encrypted


### PR DESCRIPTION
## What does this PR do?

This PR removes the hardcoded fallback used for Arena hidden-test encryption and requires the encryption key to be supplied through the `ARENA_CRYPTO_KEY` environment variable.

## Related issue
Fixes #272

### Changes made
- Removed the hardcoded server-side Arena encryption key.
- Added lazy validation for `ARENA_CRYPTO_KEY`.
- Rejects missing keys with a clear configuration error.
- Rejects keys shorter than 32 characters.
- Preserves the existing AES-256-CBC encryption flow by deriving a 32-byte key using SHA-256.
- Added `ARENA_CRYPTO_KEY` documentation to `.env.example`.
- Added focused tests covering:
  - missing environment variable;
  - insufficient key length;
  - successful encryption;
  - successful decryption with the configured key;
  - generation of a fresh IV for each encryption.

### Testing performed

```bash
npx vitest run src/lib/__tests__/arena-crypto.test.ts
```

Result:

```text
1 test file passed
5 tests passed
```

```bash
npx eslint src/lib/__tests__/arena-crypto.test.ts
```

Result: passed with no errors.

```bash
npx vitest run
```

Result:

```text
27 test files passed
284 tests passed
```

Two existing suites failed during collection:
- `src/lib/__tests__/dailies-mobile-flag.test.ts` uses the Jest global while running under Vitest.
- `src/app/api/arena/submit/__tests__/ratings-atomic.test.ts` has an existing module-alias resolution failure.

Neither failing file is modified by this PR.

`npx tsc --noEmit` also reports existing errors in those test files and `streak-freeze-atomic.test.ts`. No TypeScript errors were reported in the files added or modified by this PR.

### Compatibility note

The current VS Code extension still contains the old hardcoded key in:

```text
packages/vscode-extension/src/arena/cryptoUtils.ts
```

The extension uses that key to decrypt hidden tests locally. Therefore, configuring the server with a newly generated `ARENA_CRYPTO_KEY` would make the current extension unable to decrypt the payload.

This PR is opened as a draft so the maintainer can confirm whether:

1. this issue should remain limited to removing the server-side fallback; or
2. extension-side key handling should also be updated as part of this issue.

A broader design where hidden tests are executed only on the server may be required to fully prevent extraction of the decryption key from the distributed extension.

## Screenshots

Not applicable. This PR does not introduce visual changes.

## Checklist

- [ ] `npm run lint` passes
  - The new test file passes ESLint.
  - `src/lib/arena.ts` reports eight pre-existing lint violations already present on `upstream/main`.
- [x] Tested locally
- [x] No secrets or `.env` values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
