### PR TITLE
Fix disposed geometry reuse in InstancedLabels

### DIFF
--- a/src/components/InstancedLabels.tsx
+++ b/src/components/InstancedLabels.tsx
@@ -386,13 +386,27 @@ export default memo(function InstancedLabels({
   });
 
   // Cleanup
+  // Dispose geometry only on unmount.
+  // geo is memoized once, so it should not be disposed when material or atlas changes.
   useEffect(() => {
     return () => {
       geo.dispose();
+    };
+  }, [geo]);
+
+  // Dispose old material when material changes.
+  useEffect(() => {
+    return () => {
       material?.dispose();
+    };
+  }, [material]);
+
+  // Dispose old atlas texture when atlas changes.
+  useEffect(() => {
+    return () => {
       atlas?.dispose();
     };
-  }, [geo, material, atlas]);
+  }, [atlas]);
 
   if (!material || count === 0) return null;
 


### PR DESCRIPTION
## What does this PR do?

Fixes disposed geometry reuse in src/components/InstancedLabels.tsx.

Previously, the cleanup effect disposed geo, material, and atlas together whenever material or atlas changed. Since geo is memoized with useMemo([]), the same disposed geometry instance could be reused by <instancedMesh />, causing invisible labels and WebGL rendering issues.

This PR separates cleanup so that:

- Geometry is disposed only on component unmount.
- Material is disposed when the material changes.
- Atlas texture is disposed when the atlas changes.

## Related issue

 Fixes #358 

## Screenshots

**Before Fix**

Attached video demonstrating the issue before the fix. The recording shows the city update process and the behavior prior to separating geometry cleanup.

https://github.com/user-attachments/assets/51f1ff11-ccf2-4005-a66c-79b961d33edf

**After Fix**

Attached video demonstrating the fix. Labels render normally and no disposed-geometry/WebGL rendering issues are observed.

https://github.com/user-attachments/assets/d6c5630e-613b-4f8c-a752-d0689d482706

Note: Local username search may return API errors in the development environment because server-side keys are unavailable. The cleanup logic was verified locally and the geometry is no longer disposed when the atlas or material changes.

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
