### PR TITLE
Fix disposed geometry reuse in FlyingCityShips

### DIFF
--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -901,12 +901,16 @@ function FlyingCityShips({ cityRadius }: { cityRadius: number }) {
           s.bannerResources.tex.dispose();
         }
       });
+    };
+  }, [ships]);
+
+  useEffect(() => {
+    return () => {
       boxGeo.dispose();
       coneGeo.dispose();
       cylinderGeo.dispose();
     };
-  }, [ships, boxGeo, coneGeo, cylinderGeo]);
-
+  }, [boxGeo, coneGeo, cylinderGeo]);
   useFrame((state, delta) => {
     const time = state.clock.elapsedTime;
     if (!groupRef.current) return;


### PR DESCRIPTION
## What does this PR do?

Fixes a geometry disposal issue in FlyingCityShips.

Previously, shared memoized geometries (boxGeo, coneGeo, and cylinderGeo) were disposed whenever the ships array changed. Since the same disposed geometry instances were reused afterwards, this could cause invisible flying ships, WebGL rendering errors, and potential crashes.

This PR separates banner texture cleanup from shared geometry cleanup so that geometries are disposed only when the component unmounts.

## Related issue

Fixes #362 

## Screenshots
**Before:**
Recorded the flying ships before the fix while triggering component updates/hot reloads.

https://github.com/user-attachments/assets/f484a1f2-3594-4b15-b80c-499a1c8324ea

**After**

Recorded the flying ships after the fix, demonstrating that they remain visible and stable during updates and hot reloads without rendering issues or crashes.

https://github.com/user-attachments/assets/5784a854-00f3-4a8f-9488-df4c90785797

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
