### PR TITLE
Fix TOCTOU race condition in verify-leetcode claim #273

### DIFF
--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -93,17 +93,6 @@ export async function POST(req: Request) {
 
         const admin = getSupabaseAdmin();
 
-        // Check if someone else already claimed this LeetCode username
-        const { data: existingClaim } = await admin
-            .from("developers")
-            .select("claimed_by")
-            .eq("github_login", leetcode_username.toLowerCase())
-            .maybeSingle();
-
-        if (existingClaim && existingClaim.claimed_by && existingClaim.claimed_by !== user.id) {
-            return NextResponse.json({ error: "This LeetCode account is already linked to another user." }, { status: 409 });
-        }
-
         // Fetch full LC stats: easy/medium/hard, contest rating, streak
         let lcUserStats: LeetCodeUserStats | null = null;
         let lcContestStats: ContestStats | null = null;
@@ -249,66 +238,148 @@ export async function POST(req: Request) {
 
         const newBaseXp = calculateLeetcodeXp({ easy_solved, medium_solved, hard_solved, contest_rating, lc_streak });
 
-        const { data: upsertData, error: upsertError } = await admin
+        // Atomic claim check: First, try to claim an unclaimed building or update own claim
+        // This prevents TOCTOU race conditions by using database-level constraints
+        const { data: existingDev } = await admin
             .from("developers")
-            .upsert({
-                github_login: leetcode_username.toLowerCase(),
-                lc_username: leetcode_username.toLowerCase(),
-                github_id: github_id,
-                name: name,
-                avatar_url: avatar_url,
-                claimed: true,
-                claimed_by: user.id,
-                claimed_at: new Date().toISOString(),
-                fetch_priority: 1,
-                rank: rank,
-                lc_global_rank: rank,
-                contributions: contributions,
-                public_repos: rankBoost,
-                total_stars: reputation,
-                fetched_at: new Date().toISOString(),
-                // LeetCode-specific stats for building visuals
-                easy_solved: easy_solved,
-                medium_solved: medium_solved,
-                hard_solved: hard_solved,
-                acceptance_rate: acceptance_rate,
-                contest_rating: contest_rating,
-                contest_rank: contest_rank,
-                lc_streak: lc_streak,
-                lc_max_streak: lc_max_streak,
-                active_days_last_year: active_days_last_year,
-                total_active_days: total_active_days,
-                total_submitted: total_submitted,
-                // Contest extended
-                contests_attended: contests_attended,
-                contest_top_percentage: contest_top_percentage,
-                contest_badge_name: contest_badge_name,
-                // Badges
-                lc_badge: lc_badge,
-                lc_badges_all: lc_badges_all,
-                // Profile metadata
-                lc_bio: lc_bio,
-                lc_country_code: lc_country_code,
-                lc_school: lc_school,
-                lc_company: lc_company,
-                lc_website: lc_website,
-                lc_twitter: lc_twitter,
-                lc_linkedin: lc_linkedin,
-                lc_github: lc_github,
-                // Tag stats
-                lc_tag_stats: lc_tag_stats,
-                xp_github: newBaseXp,
-                xp_total: newBaseXp,
-                // Store litPercentage so city layout uses submission-frequency window brightness
-                contributions_total: Math.round(litPercentage * 1000), // encode as int (0-1000)
-            }, { onConflict: "github_login" })
-            .select("id")
-            .single();
+            .select("id, claimed_by")
+            .eq("github_login", leetcode_username.toLowerCase())
+            .maybeSingle();
 
-        if (upsertError) {
-            return NextResponse.json({ error: "Failed to link user record." }, { status: 500 });
+        let devId: string | undefined;
+
+        if (existingDev) {
+            // Building exists - verify claim ownership
+            if (existingDev.claimed_by && existingDev.claimed_by !== user.id) {
+                return NextResponse.json({ 
+                    error: "This LeetCode account is already linked to another user." 
+                }, { status: 409 });
+            }
+
+            // Update existing building (either unclaimed or owned by current user)
+            const { data: updateData, error: updateError } = await admin
+                .from("developers")
+                .update({
+                    lc_username: leetcode_username.toLowerCase(),
+                    github_id: github_id,
+                    name: name,
+                    avatar_url: avatar_url,
+                    claimed: true,
+                    claimed_by: user.id,
+                    claimed_at: new Date().toISOString(),
+                    fetch_priority: 1,
+                    rank: rank,
+                    lc_global_rank: rank,
+                    contributions: contributions,
+                    public_repos: rankBoost,
+                    total_stars: reputation,
+                    fetched_at: new Date().toISOString(),
+                    easy_solved: easy_solved,
+                    medium_solved: medium_solved,
+                    hard_solved: hard_solved,
+                    acceptance_rate: acceptance_rate,
+                    contest_rating: contest_rating,
+                    contest_rank: contest_rank,
+                    lc_streak: lc_streak,
+                    lc_max_streak: lc_max_streak,
+                    active_days_last_year: active_days_last_year,
+                    total_active_days: total_active_days,
+                    total_submitted: total_submitted,
+                    contests_attended: contests_attended,
+                    contest_top_percentage: contest_top_percentage,
+                    contest_badge_name: contest_badge_name,
+                    lc_badge: lc_badge,
+                    lc_badges_all: lc_badges_all,
+                    lc_bio: lc_bio,
+                    lc_country_code: lc_country_code,
+                    lc_school: lc_school,
+                    lc_company: lc_company,
+                    lc_website: lc_website,
+                    lc_twitter: lc_twitter,
+                    lc_linkedin: lc_linkedin,
+                    lc_github: lc_github,
+                    lc_tag_stats: lc_tag_stats,
+                    xp_github: newBaseXp,
+                    xp_total: newBaseXp,
+                    contributions_total: Math.round(litPercentage * 1000),
+                })
+                .eq("id", existingDev.id)
+                .or(`claimed_by.is.null,claimed_by.eq.${user.id}`)
+                .select("id")
+                .maybeSingle();
+
+            if (updateError || !updateData) {
+                // Update failed - likely because someone else claimed it between our check and update
+                return NextResponse.json({ 
+                    error: "This LeetCode account was just claimed by another user. Please try again." 
+                }, { status: 409 });
+            }
+
+            devId = updateData.id;
+        } else {
+            // Building doesn't exist - insert new one
+            const { data: insertData, error: insertError } = await admin
+                .from("developers")
+                .insert({
+                    github_login: leetcode_username.toLowerCase(),
+                    lc_username: leetcode_username.toLowerCase(),
+                    github_id: github_id,
+                    name: name,
+                    avatar_url: avatar_url,
+                    claimed: true,
+                    claimed_by: user.id,
+                    claimed_at: new Date().toISOString(),
+                    fetch_priority: 1,
+                    rank: rank,
+                    lc_global_rank: rank,
+                    contributions: contributions,
+                    public_repos: rankBoost,
+                    total_stars: reputation,
+                    fetched_at: new Date().toISOString(),
+                    easy_solved: easy_solved,
+                    medium_solved: medium_solved,
+                    hard_solved: hard_solved,
+                    acceptance_rate: acceptance_rate,
+                    contest_rating: contest_rating,
+                    contest_rank: contest_rank,
+                    lc_streak: lc_streak,
+                    lc_max_streak: lc_max_streak,
+                    active_days_last_year: active_days_last_year,
+                    total_active_days: total_active_days,
+                    total_submitted: total_submitted,
+                    contests_attended: contests_attended,
+                    contest_top_percentage: contest_top_percentage,
+                    contest_badge_name: contest_badge_name,
+                    lc_badge: lc_badge,
+                    lc_badges_all: lc_badges_all,
+                    lc_bio: lc_bio,
+                    lc_country_code: lc_country_code,
+                    lc_school: lc_school,
+                    lc_company: lc_company,
+                    lc_website: lc_website,
+                    lc_twitter: lc_twitter,
+                    lc_linkedin: lc_linkedin,
+                    lc_github: lc_github,
+                    lc_tag_stats: lc_tag_stats,
+                    xp_github: newBaseXp,
+                    xp_total: newBaseXp,
+                    contributions_total: Math.round(litPercentage * 1000),
+                })
+                .select("id")
+                .single();
+
+            if (insertError) {
+                // Insert failed - check if it's a duplicate key conflict
+                if (insertError.code === "23505") {
+                    return NextResponse.json({ 
+                        error: "This LeetCode account was just claimed by another user. Please try again." 
+                    }, { status: 409 });
+                }
+                return NextResponse.json({ error: "Failed to create user record." }, { status: 500 });
+            }
+
+            devId = insertData?.id;
         }
-        const devId = upsertData?.id;
 
         // Insert feed event
         if (devId) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes a critical Time-of-Check-Time-of-Use (TOCTOU) race condition in the LeetCode verification endpoint that allowed concurrent requests to steal or corrupt building claims.

**The Problem:**
The original code checked if a username was claimed, then performed an upsert - but between the check and the write, concurrent requests could race and cause:
- Duplicate key errors
- Claim stealing (one user overwrites another's claim)
- Data corruption

**The Solution:**
Replaced the vulnerable check-then-upsert pattern with atomic database operations:
- Removed the separate `findOne` check that created the race window
- Split into explicit insert/update paths with claim ownership verification
- Used `.or()` filter to ensure updates only succeed on unclaimed or self-owned buildings
- Added duplicate key error handling (PostgreSQL code 23505) for concurrent insert attempts

This follows the same atomic operation pattern used elsewhere in the codebase (e.g., `src/app/api/shop/redeem/route.ts`).

## Related issue

Fixes #273

## Screenshots

N/A - Backend security fix with no visual changes

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally (TypeScript compilation verified)
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
