### PR TITLE
fix: batch arena_items fetch in rollItemDrops to eliminate redundant DB queries

### DIFF
--- a/src/app/api/arena/submit/route.ts
+++ b/src/app/api/arena/submit/route.ts
@@ -2,59 +2,70 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedDeveloper } from "@/lib/arena";
 
-async function rollItemDrops(sb: any, difficulty: string, devId: number): Promise<any[]> {
+async function rollItemDrops(
+  sb: any,
+  difficulty: string,
+  devId: number,
+): Promise<any[]> {
   const droppedItems: any[] = [];
 
-  const getRandomItemByRarity = async (rarity: string): Promise<any> => {
-    const { data } = await sb
-      .from("arena_items")
-      .select("*")
-      .eq("rarity", rarity);
+  /**
+   * Fetch all items once up front instead of querying per rarity per call.
+   * A single hard-difficulty roll could previously trigger up to 4 sequential
+   * round trips (including duplicate "epic" fetches for the same rarity).
+   */ 
+  const { data: allItems } = await sb.from("arena_items").select("*");
+  const itemsByRarity: Record<string, any[]> = {};
+  for (const item of allItems ?? []) {
+    (itemsByRarity[item.rarity] ??= []).push(item);
+  }
 
-    if (data && data.length > 0) {
-      return data[Math.floor(Math.random() * data.length)];
+  const getRandomItemByRarity = (rarity: string): any => {
+    const pool = itemsByRarity[rarity];
+    if (pool && pool.length > 0) {
+      return pool[Math.floor(Math.random() * pool.length)];
     }
-  return null;
+    return null;
   };
 
   const roll = Math.random();
 
   if (difficulty === "easy") {
-    const common = await getRandomItemByRarity("common");
+    const common = getRandomItemByRarity("common");
     if (common) droppedItems.push(common);
     if (roll < 0.15) {
-      const rare = await getRandomItemByRarity("rare");
+      const rare = getRandomItemByRarity("rare");
       if (rare) droppedItems.push(rare);
     }
   } else if (difficulty === "medium") {
-    const rare = await getRandomItemByRarity("rare");
+    const rare = getRandomItemByRarity("rare");
     if (rare) droppedItems.push(rare);
-    if (roll < 0.20) {
-      const epic = await getRandomItemByRarity("epic");
+    if (roll < 0.2) {
+      const epic = getRandomItemByRarity("epic");
       if (epic) droppedItems.push(epic);
-    } else if (roll < 0.30) {
-      const rare2 = await getRandomItemByRarity("rare");
+    } else if (roll < 0.3) {
+      const rare2 = getRandomItemByRarity("rare");
       if (rare2) droppedItems.push(rare2);
     }
   } else if (difficulty === "hard") {
-    const epic = await getRandomItemByRarity("epic");
+    const epic = getRandomItemByRarity("epic");
     if (epic) droppedItems.push(epic);
 
     // Use a single roll to pick at most one of: rare bonus, legendary, epic+rare bonus.
     // Previously three independent Math.random() calls could all fire at once.
     const bonusRoll = Math.random();
     if (bonusRoll < 0.05) {
-      const legendary = await getRandomItemByRarity("legendary");
+      const legendary = getRandomItemByRarity("legendary");
       if (legendary) droppedItems.push(legendary);
     } else if (bonusRoll < 0.13) {
-      // 0.08 wide window — epic+rare bonus pack
-      const epicBonus = await getRandomItemByRarity("epic");
-      const rareBonus = await getRandomItemByRarity("rare");
+      // 0.08 wide window (epic+rare bonus pack)
+      const epicBonus = getRandomItemByRarity("epic");
+      const rareBonus = getRandomItemByRarity("rare");
       if (epicBonus) droppedItems.push(epicBonus);
       if (rareBonus) droppedItems.push(rareBonus);
     } else if (bonusRoll < 0.38) {
-      // 0.25 wide window — single rare bonus
-      const rare = await getRandomItemByRarity("rare");
+      // 0.25 wide window (single rare bonus)
+      const rare = getRandomItemByRarity("rare");
       if (rare) droppedItems.push(rare);
     }
   }
@@ -65,8 +76,8 @@ async function rollItemDrops(sb: any, difficulty: string, devId: number): Promis
       sb.rpc("upsert_arena_inventory_item", {
         p_user_id: devId,
         p_item_id: item.id,
-      })
-    )
+      }),
+    ),
   );
 
   return droppedItems;
@@ -92,7 +103,10 @@ export async function POST(request: NextRequest) {
   } = body;
 
   if (!problem_id || !status) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing required fields" },
+      { status: 400 },
+    );
   }
 
   const sb = getSupabaseAdmin();
@@ -105,7 +119,11 @@ export async function POST(request: NextRequest) {
 
   const [challengeResult, devProfileResult] = await Promise.all([
     challenge_id
-      ? sb.from("arena_challenges").select("*").eq("id", challenge_id).maybeSingle()
+      ? sb
+          .from("arena_challenges")
+          .select("*")
+          .eq("id", challenge_id)
+          .maybeSingle()
       : Promise.resolve({ data: null }),
     sb.from("developers").select("timezone").eq("id", dev.id).maybeSingle(),
   ]);
@@ -172,26 +190,31 @@ export async function POST(request: NextRequest) {
     grantedXp = Math.round(baseXp * xpMultiplier);
     grantedPoints = Math.round(basePoints * pointsMultiplier);
 
-    // Atomic first-solve claim — INSERT … ON CONFLICT DO NOTHING inside Postgres.
+    // Atomic first-solve claim — INSERT (ON CONFLICT DO NOTHING inside Postgres)
     // Only the first concurrent caller wins (won_race = true).
-    const { data: claimResult, error: claimError } = await sb.rpc("claim_first_solve", {
-      p_user_id:      dev.id,
-      p_challenge_id: challenge_id || null,
-      p_problem_id:   challenge_id ? null : problem_id,
-      p_points:       grantedPoints,
-      p_xp:           grantedXp,
-    });
+    const { data: claimResult, error: claimError } = await sb.rpc(
+      "claim_first_solve",
+      {
+        p_user_id: dev.id,
+        p_challenge_id: challenge_id || null,
+        p_problem_id: challenge_id ? null : problem_id,
+        p_points: grantedPoints,
+        p_xp: grantedXp,
+      },
+    );
 
     if (claimError) {
       console.error("[arena/submit] claim_first_solve error:", claimError);
-      return NextResponse.json({ error: "Failed to process submission" }, { status: 500 });
+      return NextResponse.json(
+        { error: "Failed to process submission" },
+        { status: 500 },
+      );
     }
 
     isFirstSolve = claimResult?.[0]?.won_race === true;
 
     if (isFirstSolve) {
-      // Grant XP via existing RPC (idempotency handled by claim_first_solve above)
-      await sb.rpc("grant_xp_atomic", {
+      await sb.rpc("grant_xp", {
         p_developer_id: dev.id,
         p_source: `arena_${difficulty}`,
         p_amount: grantedXp,
@@ -201,20 +224,28 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // 4. Update rating and streak statistics atomically via DB function.
-  //    p_timezone ensures streak boundaries are evaluated in the developer's local date,
-  //    not always UTC — fixing the bug where a solve at e.g. 23:30 IST broke a streak.
+  /**
+   4. Update rating and streak statistics atomically via DB function.
+      p_timezone ensures streak boundaries are evaluated in the developer's local date,
+      not always UTC — fixing the bug where a solve at e.g. 23:30 IST broke a streak.
+  */
   const { error: ratingsError } = await sb.rpc("update_arena_ratings_atomic", {
-    p_user_id:        dev.id,
-    p_is_accepted:    isAccepted,
+    p_user_id: dev.id,
+    p_is_accepted: isAccepted,
     p_is_first_solve: isFirstSolve,
-    p_difficulty:     difficulty,
-    p_timezone:       devTimezone,   // ← was missing; Fix 2 in the migration was dead without this
+    p_difficulty: difficulty,
+    p_timezone: devTimezone,
   });
 
   if (ratingsError) {
-    console.error("[arena/submit] update_arena_ratings_atomic error:", ratingsError);
-    return NextResponse.json({ error: "Failed to update ratings" }, { status: 500 });
+    console.error(
+      "[arena/submit] update_arena_ratings_atomic error:",
+      ratingsError,
+    );
+    return NextResponse.json(
+      { error: "Failed to update ratings" },
+      { status: 500 },
+    );
   }
 
   return NextResponse.json({

--- a/src/app/api/arena/submit/route.ts
+++ b/src/app/api/arena/submit/route.ts
@@ -214,7 +214,7 @@ export async function POST(request: NextRequest) {
     isFirstSolve = claimResult?.[0]?.won_race === true;
 
     if (isFirstSolve) {
-      await sb.rpc("grant_xp", {
+      await sb.rpc("grant_xp_atomic", {
         p_developer_id: dev.id,
         p_source: `arena_${difficulty}`,
         p_amount: grantedXp,


### PR DESCRIPTION
## What does this PR do?

Fixes the redundant sequential database queries inside `rollItemDrops` in `src/app/api/arena/submit/route.ts`.

Previously, `getRandomItemByRarity` was an async function that fired a separate Supabase query on every invocation up to 4 sequential roundtrips per hard-difficulty submission, including duplicate fetches for the same rarity (e.g. "epic" fetched twice).

**Changes made:**
- Fetch all `arena_items` once at the start of `rollItemDrops` with a single `await sb.from("arena_items").select("*")`
- Group results into an in-memory `itemsByRarity` map keyed by rarity
- Replace the async `getRandomItemByRarity` with a synchronous in-memory lookup

All existing drop probability logic is preserved. No other files changed.

## Related issue
Fixes #453

## Screenshots
Backend-only changes, no UI impact.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)