### PR TITLE
fix: prevent state updates after unmount during payment verification

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -25,20 +25,29 @@ function SupportContent() {
   const [loadingProgress, setLoadingProgress] = useState(true);
 
   useEffect(() => {
+    const ac = new AbortController();
+    let isMounted = true;
+
     if (orderIdParam) {
       const verify = async () => {
         try {
-          const res = await fetch(`/api/support/status?order_id=${orderIdParam}`);
-          if (res.ok) {
+          const res = await fetch(`/api/support/status?order_id=${orderIdParam}`, {
+            signal: ac.signal,
+          });
+          if (isMounted && res.ok) {
             const data = await res.json();
-            if (data.isPaid) {
+            if (data.isPaid && isMounted) {
               setVerifiedThanks(true);
             }
           }
         } catch (err) {
-          console.error("Error verifying payment:", err);
+          if (err instanceof Error && err.name !== "AbortError") {
+            console.error("Error verifying payment:", err);
+          }
         } finally {
-          setVerifyingPayment(false);
+          if (isMounted) {
+            setVerifyingPayment(false);
+          }
         }
       };
       verify();
@@ -46,6 +55,11 @@ function SupportContent() {
       setVerifiedThanks(true);
       setVerifyingPayment(false);
     }
+
+    return () => {
+      isMounted = false;
+      ac.abort();
+    };
   }, [thanksParam, orderIdParam]);
 
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes a React lifecycle issue on the support page where payment verification could continue after the component unmounted.

The fix:
- Adds an AbortController to cancel pending verification requests
- Prevents state updates after component unmount using an isMounted guard
- Ignores expected AbortError exceptions during cleanup

## Related issue

Fixes #473

## Screenshots

N/A (non-visual bug fix)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)