### PR TITLE
fix: use detected currency in ad checkout request

### DIFF
--- a/src/app/advertise/AdPurchaseForm.tsx
+++ b/src/app/advertise/AdPurchaseForm.tsx
@@ -140,7 +140,7 @@ export function AdPurchaseForm() {
           text: text.trim(),
           color,
           bgColor,
-          currency: "usd",
+          currency,
           provider,
           phone: phoneVal,
           dev_mode: typeof window !== "undefined" && localStorage.getItem("leetcodecity:dev_mode") === "true",


### PR DESCRIPTION
## What does this PR do?

Fixes a currency mismatch in the Advertise checkout flow.

The Advertise page detects the user's locale and stores the corresponding currency in component state, but the checkout request payload always sent a hardcoded `"usd"` value.

This change updates the checkout request to use the detected currency state, ensuring the client-side currency and checkout payload remain consistent.

## Related issue

Fixes #472

## Screenshots

N/A (non-visual bug fix)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
