### PR TITLE
🐛 fix(sharebuttons): update fallback domain

### DIFF
--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -33,7 +33,7 @@ export default function ShareButtons({
   const profileUrl =
     mounted && typeof window !== "undefined"
       ? `${window.location.origin}/dev/${login}`
-      : `https://theleetcode.city/dev/${login}`;
+      : `https://theleetcodecity.tech/dev/${login}`;
 
   const formattedContributions = mounted
     ? contributions.toLocaleString()


### PR DESCRIPTION
## What does this PR do?
Updates the fallback URL in src/components/ShareButtons.tsx from https://theleetcode.city to https://theleetcodecity.tech.

This ensures SSR, search engine crawlers, and social share cards use the correct production domain.

<!-- Brief description of changes -->
Replaced the outdated fallback domain in ShareButtons.tsx with the current production domain to ensure shared profile links resolve correctly.
## Related issue

<!-- Link to issue: Fixes #123 -->
Fixes #504
## Screenshots
N/A (No UI changes)
<!-- Before/after if visual changes -->

Notes
npm run lint currently reports numerous pre-existing repository-wide lint errors unrelated to this change. This PR only modifies the fallback domain in ShareButtons.tsx.

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
