### PR TITLE
fix: preserve earned XP during LeetCode re-verification

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -44,7 +44,7 @@ const LC_HEADERS = {
 };
 
 import { parseMaxStreak } from "@/lib/leetcode";
-import { calculateLeetcodeXp } from "@/lib/xp";
+import { calculateLeetcodeXp, mergeBaseXp } from "@/lib/xp";
 
 async function fetchLeetCodeUser(username: string) {
   const currentYear = new Date().getFullYear();
@@ -268,13 +268,15 @@ export async function GET(
       lc_streak: record.lc_streak
     });
 
-    // We must merge new Base XP with existing Base XP safely. 
+    // We must merge new Base XP with existing Base XP safely.
     // Wait to upsert until we check if the user exists so we know what to append.
-    const mergeRecord = { ...record, xp_github: newBaseXp, xp_total: newBaseXp };
-    
-    if (cached) {
-        mergeRecord.xp_total = (cached.xp_total - cached.xp_github) + newBaseXp;
-    }
+    // mergeBaseXp preserves earned (non-base) XP and never goes negative; for a
+    // brand-new record (no cache) prev values are 0, so it returns newBaseXp.
+    const mergeRecord = {
+      ...record,
+      xp_github: newBaseXp,
+      xp_total: mergeBaseXp(cached?.xp_total, cached?.xp_github, newBaseXp),
+    };
 
     const { data: upsertedResult, error: upsertError } = await sb
       .from("developers")

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { fetchLeetCodeAboutMe, parseMaxStreak } from "@/lib/leetcode";
-import { calculateLeetcodeXp } from "@/lib/xp";
+import { calculateLeetcodeXp, mergeBaseXp } from "@/lib/xp";
 
 type TagProblem = {
     tagName: string;
@@ -239,12 +239,18 @@ export async function POST(req: Request) {
         const newBaseXp = calculateLeetcodeXp({ easy_solved, medium_solved, hard_solved, contest_rating, lc_streak });
 
         // Atomic claim check: First, try to claim an unclaimed building or update own claim
-        // This prevents TOCTOU race conditions by using database-level constraints
+        // This prevents TOCTOU race conditions by using database-level constraints.
+        // Also pull existing XP so re-verification preserves earned (non-base) XP.
         const { data: existingDev } = await admin
             .from("developers")
-            .select("id, claimed_by")
+            .select("id, claimed_by, xp_total, xp_github")
             .eq("github_login", leetcode_username.toLowerCase())
             .maybeSingle();
+
+        // Re-verification must update the base XP without wiping XP earned from
+        // other sources (check-ins, dailies, rewards, redemptions, raids, etc.).
+        // For a first-time claim existingDev is null, so this is just newBaseXp.
+        const newXpTotal = mergeBaseXp(existingDev?.xp_total, existingDev?.xp_github, newBaseXp);
 
         let devId: string | undefined;
 
@@ -300,7 +306,7 @@ export async function POST(req: Request) {
                     lc_github: lc_github,
                     lc_tag_stats: lc_tag_stats,
                     xp_github: newBaseXp,
-                    xp_total: newBaseXp,
+                    xp_total: newXpTotal,
                     contributions_total: Math.round(litPercentage * 1000),
                 })
                 .eq("id", existingDev.id)

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -5,6 +5,7 @@ import {
   tierFromLevel,
   levelProgress,
   calculateLeetcodeXp,
+  mergeBaseXp,
   xpForAchievementTier,
 } from "../xp";
 
@@ -138,6 +139,41 @@ describe("calculateLeetcodeXp", () => {
   it("streak contributes positively", () => {
     const withStreak = calculateLeetcodeXp({ easy_solved: 0, medium_solved: 0, hard_solved: 0, contest_rating: 0, lc_streak: 10 });
     expect(withStreak).toBeGreaterThan(0);
+  });
+});
+
+describe("mergeBaseXp", () => {
+  it("preserves earned XP when base XP increases (re-verification)", () => {
+    // xp_github=1000, xp_total=1300 → earned=300; new base=1500 → 1800
+    expect(mergeBaseXp(1300, 1000, 1500)).toBe(1800);
+  });
+
+  it("does not reset total to the new base XP", () => {
+    expect(mergeBaseXp(1300, 1000, 1500)).not.toBe(1500);
+  });
+
+  it("returns the new base XP for a first-time verification (null prev)", () => {
+    expect(mergeBaseXp(null, null, 1500)).toBe(1500);
+    expect(mergeBaseXp(undefined, undefined, 1500)).toBe(1500);
+  });
+
+  it("treats no earned XP as base-only total", () => {
+    // earned = 1000 - 1000 = 0 → total = new base
+    expect(mergeBaseXp(1000, 1000, 1500)).toBe(1500);
+  });
+
+  it("preserves earned XP when base XP drops", () => {
+    // earned = 300; reduced base 800 → 1100
+    expect(mergeBaseXp(1300, 1000, 800)).toBe(1100);
+  });
+
+  it("treats missing/null XP values as zero", () => {
+    expect(mergeBaseXp(undefined, 1000, 500)).toBe(500); // earned clamps to 0
+    expect(mergeBaseXp(1300, undefined, 500)).toBe(1800); // earned = 1300
+  });
+
+  it("never produces negative XP when prev total is below prev base", () => {
+    expect(mergeBaseXp(500, 1000, 300)).toBe(300); // earned clamped to 0
   });
 });
 

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -165,6 +165,31 @@ export function calculateLeetcodeXp(dev: {
   return solvedXp + ratingXp + streakXp;
 }
 
+// ─── Base XP Merge (preserve earned XP on re-verification) ───
+
+/**
+ * Merge freshly computed base XP (GitHub/LeetCode-derived) into a developer's
+ * total XP while preserving XP earned from every other source — check-ins,
+ * dailies, rewards, redemptions, raids, referrals, bonuses, etc.
+ *
+ * Earned XP is whatever in the previous total wasn't base XP:
+ *   earned   = prevTotal - prevBase
+ * The new total re-applies that earned XP on top of the new base:
+ *   newTotal = earned + newBase
+ *
+ * Null/undefined previous values are treated as 0 (e.g. first-time
+ * verification), and both the earned portion and the result are clamped to be
+ * non-negative so the merge can never introduce negative XP.
+ */
+export function mergeBaseXp(
+  prevTotal: number | null | undefined,
+  prevBase: number | null | undefined,
+  newBase: number,
+): number {
+  const earned = Math.max(0, (prevTotal ?? 0) - (prevBase ?? 0));
+  return Math.max(0, earned + newBase);
+}
+
 // ─── Achievement XP ─────────────────────────────────────────
 
 const ACHIEVEMENT_XP: Record<string, number> = {


### PR DESCRIPTION
## What does this PR do?

Fixes a data integrity issue where re-running LeetCode verification could overwrite `xp_total` with the recalculated base XP (`xp_github`), causing previously earned XP to be lost.

This PR:

* Adds a shared `mergeBaseXp()` helper for preserving earned XP.
* Updates the LeetCode verification flow to retain earned XP during re-verification.
* Refactors the profile refresh flow to use the same XP merge logic.
* Adds unit tests covering XP preservation and edge cases.

## Related issue

Fixes #491

## Screenshots
<img width="1187" height="218" alt="Screenshot 2026-06-14 231720" src="https://github.com/user-attachments/assets/ec8dd8d6-a505-418f-81bd-4949ceb944db" />


### Test Results

* Added tests for XP preservation logic.
* All new tests pass successfully.
* Existing failing suites are unrelated to this PR and were already present in the repository.

## Checklist

* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ I have starred this repository!

### Notes

No database migration is required.

Historical XP already lost before this fix is not automatically recoverable because the overwritten earned XP is no longer available in the current columns. This PR prevents future data loss during LeetCode re-verification.
