### PR TITLE
🐛 fix(sharebuttons): update fallback domain

### DIFF
--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -33,7 +33,7 @@ export default function ShareButtons({
   const profileUrl =
     mounted && typeof window !== "undefined"
       ? `${window.location.origin}/dev/${login}`
-      : `https://theleetcode.city/dev/${login}`;
+      : `https://theleetcodecity.tech/dev/${login}`;
 
   const formattedContributions = mounted
     ? contributions.toLocaleString()


### PR DESCRIPTION
## What does this PR do?
Updated the fallback URL in src/components/ShareButtons.tsx from: https://theleetcode.city/dev/${login}
to: https://theleetcodecity.tech/dev/${login}

This ensures that SSR, crawlers, and social share cards use the correct production domain.

<!-- Brief description of changes -->
Updated the fallback URL in ShareButtons.tsx from the outdated domain (theleetcode.city) to the current production domain (theleetcodecity.tech). This ensures SSR, crawlers, and social share cards generate links using the correct website URL.

## Related issue
Fixes #504

<!-- Link to issue: Fixes #123 -->

## Screenshots
NA

<!-- Before/after if visual changes -->
NA

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
