### PR TITLE
🐛 fix(city): select raid_xp in city-snapshot and GET /api/city queries

### DIFF
--- a/src/app/api/city/route.ts
+++ b/src/app/api/city/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
     sb
       .from("developers")
       .select(
-        "id, github_login, name, avatar_url, contributions, total_stars, public_repos, primary_language, rank, claimed, kudos_count, visit_count, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, active_days_last_year, language_diversity, app_streak, rabbit_completed, district, district_chosen, xp_total, xp_level, easy_solved, medium_solved, hard_solved, contest_rating, lc_streak, acceptance_rate"
+        "id, github_login, name, avatar_url, contributions, total_stars, public_repos, primary_language, rank, claimed, kudos_count, visit_count, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, active_days_last_year, language_diversity, app_streak, rabbit_completed, district, district_chosen, xp_total, xp_level, raid_xp, easy_solved, medium_solved, hard_solved, contest_rating, lc_streak, acceptance_rate"
       )
       .not("easy_solved", "is", null)
       .order("rank", { ascending: true })

--- a/src/app/api/cron/city-snapshot/route.ts
+++ b/src/app/api/cron/city-snapshot/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
       fetchAll<Record<string, any>>(
         sb,
         "developers",
-        "id, github_login, name, avatar_url, contributions, total_stars, public_repos, primary_language, rank, claimed, kudos_count, visit_count, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, active_days_last_year, language_diversity, app_streak, rabbit_completed, district, district_chosen, xp_total, xp_level",
+        "id, github_login, name, avatar_url, contributions, total_stars, public_repos, primary_language, rank, claimed, kudos_count, visit_count, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, active_days_last_year, language_diversity, app_streak, rabbit_completed, district, district_chosen, xp_total, xp_level, raid_xp",
         undefined,
         "rank",
       ),


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where developers' `raid_xp` was always showing as `0` inside the visual city view and developer cards. 

Specifically, it:
- Adds `raid_xp` to the developers query select list in the `city-snapshot` cron job (`src/app/api/cron/city-snapshot/route.ts`).
- Adds `raid_xp` to the developers select list in the main city GET endpoint (`src/app/api/city/route.ts`).

Since `raid_xp` was omitted from the select projections, it was evaluating to `undefined` and defaulting to `0` at the mapping stage. This change ensures the database actually retrieves the field.

## Related issue

Fixes #510

## Screenshots

N/A (Backend data projection fix, no UI changes).

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
