### PR TITLE
fix: rollback roadmap vote optimistic state on failure

### DIFF
--- a/src/app/roadmap/RoadmapClient.tsx
+++ b/src/app/roadmap/RoadmapClient.tsx
@@ -91,9 +91,9 @@ export default function RoadmapClient({
           <h1 className="text-3xl text-cream md:text-4xl">
             Road<span style={{ color: ACCENT }}>map</span>
           </h1>
-          <p className="mt-3 text-xs text-muted normal-case">
-            What we've built, what we're building, and what's coming next
-          </p>
+            <p className="mt-3 text-xs text-muted normal-case">
+              What we&apos;ve built, what we&apos;re building, and what&apos;s coming next
+            </p>
         </div>
 
         {/* Progress bar */}
@@ -171,8 +171,6 @@ export default function RoadmapClient({
     </main>
   );
 }
-
-// performVoteWithRollback exported from ./vote-helper
 
 /* ─── Phase Block ─── */
 function PhaseBlock({
@@ -263,7 +261,7 @@ function ItemRow({
 
   const [optimistic, setOptimistic] = useOptimistic(
     { votes: initialVotes, hasVoted: initialHasVoted },
-    (state, _: "toggle") => ({
+    (state) => ({
       votes: state.hasVoted ? state.votes - 1 : state.votes + 1,
       hasVoted: !state.hasVoted,
     })

--- a/src/app/roadmap/RoadmapClient.tsx
+++ b/src/app/roadmap/RoadmapClient.tsx
@@ -6,6 +6,7 @@ import { createBrowserSupabase } from "@/lib/supabase";
 import { ROADMAP_PHASES, VOTABLE_ITEM_IDS } from "@/lib/roadmap-data";
 import type { RoadmapPhase, RoadmapItem, ItemStatus } from "@/lib/roadmap-data";
 import { toggleVote } from "./actions";
+import { performVoteWithRollback } from "./vote-helper";
 
 const ACCENT = "#ffa116";
 const CREAM = "#e8dcc8";
@@ -171,6 +172,8 @@ export default function RoadmapClient({
   );
 }
 
+// performVoteWithRollback exported from ./vote-helper
+
 /* ─── Phase Block ─── */
 function PhaseBlock({
   phase,
@@ -260,7 +263,7 @@ function ItemRow({
 
   const [optimistic, setOptimistic] = useOptimistic(
     { votes: initialVotes, hasVoted: initialHasVoted },
-    (state, _action: "toggle") => ({
+    (state, _: "toggle") => ({
       votes: state.hasVoted ? state.votes - 1 : state.votes + 1,
       hasVoted: !state.hasVoted,
     })
@@ -272,8 +275,7 @@ function ItemRow({
       return;
     }
     startTransition(async () => {
-      setOptimistic("toggle");
-      await toggleVote(item.id);
+      await performVoteWithRollback({ setOptimistic, toggleVoteFn: toggleVote, itemId: item.id });
     });
   }
 

--- a/src/app/roadmap/__tests__/rollback.test.ts
+++ b/src/app/roadmap/__tests__/rollback.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { performVoteWithRollback } from "../vote-helper";
+
+describe("performVoteWithRollback", () => {
+  it("rolls back optimistic state when toggleVote throws", async () => {
+    const setOptimistic = vi.fn();
+    const toggleVoteFn = vi.fn(async () => {
+      throw new Error("network");
+    });
+    await expect(
+      performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" })
+    ).rejects.toThrow("network");
+
+    expect(setOptimistic).toHaveBeenCalledTimes(2);
+    expect(setOptimistic).toHaveBeenNthCalledWith(1, "toggle");
+    expect(setOptimistic).toHaveBeenNthCalledWith(2, "toggle");
+    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
+  });
+
+  it("does not rollback when toggleVote succeeds", async () => {
+    const setOptimistic = vi.fn();
+    const toggleVoteFn = vi.fn(async () => ({}));
+
+    await performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" });
+
+    expect(setOptimistic).toHaveBeenCalledTimes(1);
+    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
+  });
+
+  it("reducer toggle is reversible when applied twice", () => {
+    function toggleReducer(state: { votes: number; hasVoted: boolean }) {
+      return {
+        votes: state.hasVoted ? state.votes - 1 : state.votes + 1,
+        hasVoted: !state.hasVoted,
+      };
+    }
+
+    const initial = { votes: 10, hasVoted: false };
+    const afterOne = toggleReducer(initial);
+    const afterTwo = toggleReducer(afterOne);
+
+    expect(afterTwo).toEqual(initial);
+  });
+});
+import { describe, it, expect, vi } from "vitest";
+import { performVoteWithRollback } from "../vote-helper";
+
+describe("performVoteWithRollback", () => {
+  it("rolls back optimistic state when toggleVote throws", async () => {
+    const setOptimistic = vi.fn();
+    const toggleVoteFn = vi.fn(async () => {
+      throw new Error("network");
+    });
+    await expect(
+      performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" })
+    ).rejects.toThrow("network");
+
+    // setOptimistic called to apply optimistic state, then called again to rollback
+    expect(setOptimistic).toHaveBeenCalledTimes(2);
+    expect(setOptimistic).toHaveBeenNthCalledWith(1, "toggle");
+    expect(setOptimistic).toHaveBeenNthCalledWith(2, "toggle");
+    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
+  });
+
+  it("does not rollback when toggleVote succeeds", async () => {
+    const setOptimistic = vi.fn();
+    const toggleVoteFn = vi.fn(async () => ({}));
+
+    await performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" });
+
+    expect(setOptimistic).toHaveBeenCalledTimes(1);
+    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
+  });
+
+  it("reducer toggle is reversible when applied twice", () => {
+    // Recreate the reducer logic used in the component
+    function toggleReducer(state: { votes: number; hasVoted: boolean }) {
+      return {
+        votes: state.hasVoted ? state.votes - 1 : state.votes + 1,
+        hasVoted: !state.hasVoted,
+      };
+    }
+
+    const initial = { votes: 10, hasVoted: false };
+    const afterOne = toggleReducer(initial);
+    const afterTwo = toggleReducer(afterOne);
+
+    expect(afterTwo).toEqual(initial);
+  });
+});

--- a/src/app/roadmap/__tests__/rollback.test.ts
+++ b/src/app/roadmap/__tests__/rollback.test.ts
@@ -11,50 +11,6 @@ describe("performVoteWithRollback", () => {
       performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" })
     ).rejects.toThrow("network");
 
-    expect(setOptimistic).toHaveBeenCalledTimes(2);
-    expect(setOptimistic).toHaveBeenNthCalledWith(1, "toggle");
-    expect(setOptimistic).toHaveBeenNthCalledWith(2, "toggle");
-    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
-  });
-
-  it("does not rollback when toggleVote succeeds", async () => {
-    const setOptimistic = vi.fn();
-    const toggleVoteFn = vi.fn(async () => ({}));
-
-    await performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" });
-
-    expect(setOptimistic).toHaveBeenCalledTimes(1);
-    expect(toggleVoteFn).toHaveBeenCalledWith("feature_x");
-  });
-
-  it("reducer toggle is reversible when applied twice", () => {
-    function toggleReducer(state: { votes: number; hasVoted: boolean }) {
-      return {
-        votes: state.hasVoted ? state.votes - 1 : state.votes + 1,
-        hasVoted: !state.hasVoted,
-      };
-    }
-
-    const initial = { votes: 10, hasVoted: false };
-    const afterOne = toggleReducer(initial);
-    const afterTwo = toggleReducer(afterOne);
-
-    expect(afterTwo).toEqual(initial);
-  });
-});
-import { describe, it, expect, vi } from "vitest";
-import { performVoteWithRollback } from "../vote-helper";
-
-describe("performVoteWithRollback", () => {
-  it("rolls back optimistic state when toggleVote throws", async () => {
-    const setOptimistic = vi.fn();
-    const toggleVoteFn = vi.fn(async () => {
-      throw new Error("network");
-    });
-    await expect(
-      performVoteWithRollback({ setOptimistic, toggleVoteFn, itemId: "feature_x" })
-    ).rejects.toThrow("network");
-
     // setOptimistic called to apply optimistic state, then called again to rollback
     expect(setOptimistic).toHaveBeenCalledTimes(2);
     expect(setOptimistic).toHaveBeenNthCalledWith(1, "toggle");

--- a/src/app/roadmap/vote-helper.ts
+++ b/src/app/roadmap/vote-helper.ts
@@ -4,27 +4,14 @@ export async function performVoteWithRollback(opts: {
   itemId: string;
 }) {
   const { setOptimistic, toggleVoteFn, itemId } = opts;
-  setOptimistic("toggle");
-  try {
-    await toggleVoteFn(itemId);
-  } catch (err) {
-    setOptimistic("toggle");
-    throw err;
-  }
-}
-export async function performVoteWithRollback(opts: {
-  setOptimistic: (action: "toggle") => void;
-  toggleVoteFn: (itemId: string) => Promise<unknown>;
-  itemId: string;
-}) {
-  const { setOptimistic, toggleVoteFn, itemId } = opts;
+  // apply optimistic update
   setOptimistic("toggle");
   try {
     await toggleVoteFn(itemId);
   } catch (err) {
     // rollback optimistic change
     setOptimistic("toggle");
-    // Re-throw so callers can handle or surface the error (do not silently swallow)
+    // Re-throw so callers can handle or surface the error
     throw err;
   }
 }

--- a/src/app/roadmap/vote-helper.ts
+++ b/src/app/roadmap/vote-helper.ts
@@ -1,0 +1,30 @@
+export async function performVoteWithRollback(opts: {
+  setOptimistic: (action: "toggle") => void;
+  toggleVoteFn: (itemId: string) => Promise<unknown>;
+  itemId: string;
+}) {
+  const { setOptimistic, toggleVoteFn, itemId } = opts;
+  setOptimistic("toggle");
+  try {
+    await toggleVoteFn(itemId);
+  } catch (err) {
+    setOptimistic("toggle");
+    throw err;
+  }
+}
+export async function performVoteWithRollback(opts: {
+  setOptimistic: (action: "toggle") => void;
+  toggleVoteFn: (itemId: string) => Promise<unknown>;
+  itemId: string;
+}) {
+  const { setOptimistic, toggleVoteFn, itemId } = opts;
+  setOptimistic("toggle");
+  try {
+    await toggleVoteFn(itemId);
+  } catch (err) {
+    // rollback optimistic change
+    setOptimistic("toggle");
+    // Re-throw so callers can handle or surface the error (do not silently swallow)
+    throw err;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the roadmap vote optimistic state bug by rolling back the optimistic UI update when the server action fails.

Previously, the roadmap vote button applied an optimistic toggle immediately, but if `toggleVote()` threw an error (e.g. network failure or server-side error), the optimistic state was never reverted. This could leave the UI showing an incorrect vote count and vote status that did not match the persisted database state.

### Changes

* Added rollback handling for optimistic roadmap votes.
* Reverts optimistic state when `toggleVote()` fails.
* Rethrows the original error after rollback.
* Added focused regression tests covering:

  * rollback on failure
  * success path behavior
  * reducer reversibility

## Related issue

Fixes #516

## Screenshots

N/A (client-side state management and test coverage change)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
