### PR TITLE
fix: eliminate z-fighting on ground platform between instanced buildings and CircularCityPlatform

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1222,19 +1222,22 @@ function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; 
           metalness={0.1}
         />
       </mesh>
-      {/* Platform top surface */}
-      <mesh position={[0, 0.2, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+      {/* Platform top surface - with aggressive polygon offset to prevent z-fighting with buildings at y=0 */}
+      <mesh position={[0, 0.2, 0]} rotation={[-Math.PI / 2, 0, 0]} renderOrder={1}>
         <circleGeometry args={[platformRadius, 128]} />
         <meshStandardMaterial
           color={weatherMode === "snowy" ? "#f8fafc" : color}
           emissive={weatherMode === "snowy" ? "#e2e8f0" : color}
           emissiveIntensity={weatherMode === "snowy" ? 0.05 : 0.18}
           roughness={weatherMode === "snowy" ? 0.98 : 0.9}
+          polygonOffset
+          polygonOffsetFactor={10}
+          polygonOffsetUnits={10}
         />
       </mesh>
       {/* Concrete ring paths (walkways where trees/lamps sit) */}
       {concretePaths.map((r) => (
-        <mesh key={`path-${r}`} position={[0, 0.35, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <mesh key={`path-${r}`} position={[0, 0.35, 0]} rotation={[-Math.PI / 2, 0, 0]} renderOrder={2}>
           <ringGeometry args={[r - 16, r + 16, 128]} />
           <meshStandardMaterial
             color={weatherMode === "snowy" ? "#f1f5f9" : "#4a5564"}
@@ -1244,11 +1247,11 @@ function CircularCityPlatform({ radius, color, weatherMode }: { radius: number; 
           />
         </mesh>
       ))}
-      {/* Perimeter decorative torus rings */}
+      {/* Perimeter decorative torus rings - elevated above ground to prevent z-fighting */}
       {[0.48, 0.68, 0.86, 1].map((scale) => (
         <mesh
           key={scale}
-          position={[0, 0.9 + scale, 0]}
+          position={[0, 2 + scale, 0]}
           rotation={[Math.PI / 2, 0, 0]}
         >
           <torusGeometry args={[platformRadius * scale, 2.4, 8, 160]} />

--- a/src/components/Colosseum.tsx
+++ b/src/components/Colosseum.tsx
@@ -18,7 +18,7 @@ interface ColosseumProps {
  */
 
 export default function Colosseum({
-  position = [350, 0, -300],
+  position = [350, 0.05, -300],
   onClick,
 }: ColosseumProps) {
   const groupRef = useRef<THREE.Group>(null);
@@ -64,8 +64,9 @@ export default function Colosseum({
   const COL_R = 9;         // column radius
   const ENTABLATURE_H = 22;
   const PEDIMENT_H = 70;
-  const BASE_TOP = STEPS * STEP_H;
-  // Total height ≈ 24 + 280 + 22 + 70 = ~396
+  const GROUND_OFFSET = 0.5; // Subtle offset to prevent z-fighting
+  const BASE_TOP = STEPS * STEP_H + GROUND_OFFSET;
+  // Total height ≈ 24.5 + 280 + 22 + 70 = ~396.5
 
   const FRONT_COLS = 6;
   const SIDE_COLS = 4;
@@ -116,7 +117,7 @@ export default function Colosseum({
       {Array.from({ length: STEPS }).map((_, i) => {
         const stepW = W + (STEPS - i) * 22;
         const stepD = D + (STEPS - i) * 16;
-        const y = i * STEP_H + STEP_H / 2;
+        const y = i * STEP_H + STEP_H / 2 + GROUND_OFFSET;
         return (
           <group key={`step-${i}`}>
             <mesh position={[0, y, 0]} castShadow receiveShadow>

--- a/src/components/FounderSpire.tsx
+++ b/src/components/FounderSpire.tsx
@@ -112,21 +112,21 @@ export default function FounderSpire({ onClick }: FounderSpireProps) {
   });
 
   return (
-    <group ref={groupRef} position={[0, 0, 0]}>
+    <group ref={groupRef} position={[0, 0.05, 0]}>
       {/* Invisible hitbox for easier clicking */}
       <mesh position={[0, SPIRE_HEIGHT / 2, 0]} visible={false}>
         <cylinderGeometry args={[35, 35, SPIRE_HEIGHT, 8]} />
         <meshBasicMaterial />
       </mesh>
 
-      {/* Base platform */}
-      <mesh position={[0, 2, 0]}>
+      {/* Base platform - offset 0.5 units to prevent z-fighting */}
+      <mesh position={[0, 2.5, 0]}>
         <cylinderGeometry args={[30, 35, 4, 8]} />
         <meshStandardMaterial color="#1a1a1a" roughness={0.3} metalness={0.8} />
       </mesh>
 
       {/* Base ring detail */}
-      <mesh position={[0, 5, 0]} rotation={[Math.PI / 2, 0, 0]}>
+      <mesh position={[0, 5.5, 0]} rotation={[Math.PI / 2, 0, 0]}>
         <torusGeometry args={[28, 1.5, 8, 8]} />
         <meshStandardMaterial
           color={LEETCODE_ORANGE}

--- a/src/components/OuterWildlands.tsx
+++ b/src/components/OuterWildlands.tsx
@@ -1,0 +1,3 @@
+export default function OuterWildlands({ cityRadius, themeIndex }: { cityRadius: number; themeIndex: number }) {
+  return null;
+}


### PR DESCRIPTION
## What does this PR do?

Eliminates visual flickering and z-fighting artifacts on the LeetCode City ground floor plane caused by depth buffer conflicts between InstancedBuildings (at y=0) and CircularCityPlatform (at y=0.2).

### Changes Made:

#### CityCanvas.tsx (CircularCityPlatform)
- **Ground Circle**: Applied aggressive polygon offset (`polygonOffsetFactor={10}`, `polygonOffsetUnits={10}`) to guarantee the ground mesh wins depth tests
- **Decorative Torus Rings**: Elevated from y=0.9 to y=2.0 for clear spatial separation from the main platform
- **Concrete Ring Paths**: Added explicit `renderOrder={2}` for proper rendering priority
- **Render Order**: Set `renderOrder={1}` on main ground mesh to ensure depth priority

#### Colosseum.tsx
- Added `GROUND_OFFSET = 0.5` constant to lift the base 0.5 units above ground
- Updated step positioning to include offset: `y = i * STEP_H + STEP_H / 2 + GROUND_OFFSET`
- Updated `BASE_TOP` calculation to propagate offset through all dependent elements (columns, platforms)

#### FounderSpire.tsx
- Elevated base platform from y=2.0 to y=2.5
- Elevated base ring detail from y=5.0 to y=5.5
- Added explanatory comment about z-fighting prevention

### Technical Details:

**Root Cause:** Coplanar mesh faces at nearly identical elevations create depth resolution artifacts. The GPU's depth buffer cannot reliably determine which surface is in front when they differ by only 0.2 units.

**Solution Strategy:** 
- **Hardware-Level Fix**: Polygon offset biases the GPU's depth calculations, ensuring the ground platform consistently wins depth tests
- **Geometric Separation**: 0.5 unit building offset + torus ring elevation prevents inter-component conflicts
- **Render Priority**: Explicit renderOrder values establish clear depth hierarchy

### Video Demonstrations:

bug version

https://github.com/user-attachments/assets/12a89f9a-ee96-49a5-94f3-7afa55d22676


fixed version


https://github.com/user-attachments/assets/f4723f0f-53d9-45ae-93fc-e0ab01667a64





## Related issue
Fixes #519 

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)