### PR TITLE
perf: lazy-load RaidPreviewModal to reduce initial homepage bundle size

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,6 @@ import { useCodingPresence } from "@/lib/useCodingPresence";
 import { useRaidSequence } from "@/lib/useRaidSequence";
 import { useDailies } from "@/lib/useDailies";
 import DailiesWidget from "@/components/DailiesWidget";
-import RaidPreviewModal from "@/components/RaidPreviewModal";
 import RaidOverlay from "@/components/RaidOverlay";
 import PillModal from "@/components/PillModal";
 import FounderMessage from "@/components/FounderMessage";
@@ -115,6 +114,13 @@ const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
       </div>
     </div>
   ),
+});
+
+// Lazy-loaded: pulls in Three.js / @react-three/fiber, so it must stay out of
+// the initial homepage bundle. The Three.js chunk only loads when the raid
+// preview modal is actually opened (raidState.phase === "preview").
+const RaidPreviewModal = dynamic(() => import("@/components/RaidPreviewModal"), {
+  ssr: false,
 });
 
 // Feature flags — flip to switch milestone banner


### PR DESCRIPTION
## What does this PR do?

This PR improves homepage performance by lazy-loading `RaidPreviewModal` using `next/dynamic`.

Previously, `RaidPreviewModal` was imported eagerly from `src/app/page.tsx`, which caused its transitive dependencies (`@react-three/fiber`, `three`, and `RaidSequence3D`) to be included in the initial homepage bundle even though the raid preview is only used when a user explicitly opens the raid preview modal.

### Changes made

* Replaced the static import of `RaidPreviewModal` with a dynamic import.
* Added `ssr: false` to ensure Three.js/WebGL-related code only runs on the client.
* Kept existing functionality unchanged while moving Three.js-related dependencies into an on-demand chunk.

### Expected impact

* Smaller initial homepage bundle.
* Reduced JavaScript download, parse, and execution time.
* Improved page load performance and responsiveness, especially on slower devices and networks.

## Related issue

Fixes #492

## Screenshots

N/A (Performance optimization / no UI changes)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
