### PR TITLE
🐛 fix(checkout): fulfill consumable and auto-equip to gift recipient …

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -7,7 +7,7 @@ import { createCryptoInvoice } from "@/lib/nowpayments";
 import { createCashfreeCheckout } from "@/lib/cashfree";
 import { rateLimit } from "@/lib/rate-limit";
 
-import { fulfillItemPurchase } from "@/lib/items";
+import { fulfillItemPurchase, autoEquipIfSolo } from "@/lib/items";
 
 // Defense-in-depth: per-user rate limit IN ADDITION to the IP-based
 // middleware rate limit.  This one is keyed by Supabase user ID so it
@@ -261,7 +261,8 @@ export async function POST(request: Request) {
 
   if (isDev || isFree) {
     console.log(`Bypassing payment for ${githubLogin} (Dev: ${isDev}, Free: ${isFree})`);
-    const { status: purchaseStatus } = await fulfillItemPurchase(dev.id, item_id, sb);
+    const recipientId = giftedToDevId ?? dev.id;
+    const { status: purchaseStatus } = await fulfillItemPurchase(recipientId, item_id, sb);
     const { data: purchase, error: purchaseError } = await sb
       .from("purchases")
       .insert({
@@ -280,6 +281,8 @@ export async function POST(request: Request) {
     if (purchaseError) {
       return NextResponse.json({ error: "Failed to create dev/free purchase" }, { status: 500 });
     }
+
+    await autoEquipIfSolo(recipientId, item_id);
 
     // Return a success URL that redirects back to the shop/city
     return NextResponse.json({


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where dev-mode or free-bypass gift purchases would incorrectly credit consumable items (like streak freezes or battle items) to the buyer's account instead of the intended recipient.

* **Fulfillment Target Corrected:** Defined `recipientId` to resolve to `giftedToDevId` (if it's a gift) and fallback to `dev.id` (buyer's ID) if it's a self-purchase. Passed `recipientId` to `fulfillItemPurchase` instead of hardcoding `dev.id`.
* **Auto-Equip Triggered for Recipient:** Imported `autoEquipIfSolo` from `@/lib/items` and called it for the `recipientId` on successful database insertions, mirroring the correct logic used in standard payment webhooks.

## Related issue

Fixes #534

## Screenshots

N/A (Backend logic fix in the checkout API route `/api/checkout`)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
