### PR TITLE
feat: add username search inside explore mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,6 @@ import { useCodingPresence } from "@/lib/useCodingPresence";
 import { useRaidSequence } from "@/lib/useRaidSequence";
 import { useDailies } from "@/lib/useDailies";
 import DailiesWidget from "@/components/DailiesWidget";
-import RaidPreviewModal from "@/components/RaidPreviewModal";
 import RaidOverlay from "@/components/RaidOverlay";
 import PillModal from "@/components/PillModal";
 import FounderMessage from "@/components/FounderMessage";
@@ -115,6 +114,13 @@ const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
       </div>
     </div>
   ),
+});
+
+// Lazy-loaded: pulls in Three.js / @react-three/fiber, so it must stay out of
+// the initial homepage bundle. The Three.js chunk only loads when the raid
+// preview modal is actually opened (raidState.phase === "preview").
+const RaidPreviewModal = dynamic(() => import("@/components/RaidPreviewModal"), {
+  ssr: false,
 });
 
 // Feature flags — flip to switch milestone banner

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3514,6 +3514,45 @@ function HomeContent() {
             </button>
           </div>
 
+          {/* Explore-mode search — reuses searchUser() so the camera flies (via CameraFocus) to the matched building */}
+          {!compareBuilding && !comparePair && (
+            <div className="pointer-events-auto absolute top-3 left-32 right-3 z-[31] sm:left-36 sm:right-auto sm:top-4 sm:w-72">
+              <form onSubmit={handleSubmit} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={username}
+                  onChange={(e) => {
+                    setUsername(e.target.value);
+                    if (feedback?.type === "error") setFeedback(null);
+                  }}
+                  aria-label="Search a LeetCode username and fly to their building"
+                  placeholder="search a username"
+                  className="min-w-0 flex-1 border-[3px] border-border bg-bg/70 px-3 py-1.5 text-base text-cream outline-none backdrop-blur-sm transition-colors placeholder:text-dim normal-case sm:text-[11px]"
+                  onFocus={(e) => (e.currentTarget.style.borderColor = theme.accent)}
+                  onBlur={(e) => (e.currentTarget.style.borderColor = "")}
+                />
+                <button
+                  type="submit"
+                  disabled={loading || !username.trim()}
+                  className="btn-press flex-shrink-0 border-[3px] border-transparent px-3 py-1.5 text-[11px] text-bg disabled:opacity-40"
+                  style={{ backgroundColor: theme.accent }}
+                >
+                  {loading ? <span className="blink-dot inline-block">_</span> : "Go"}
+                </button>
+              </form>
+              {feedback && (
+                <div className="mt-1.5">
+                  <SearchFeedback
+                    feedback={feedback}
+                    accentColor={theme.accent}
+                    onDismiss={() => setFeedback(null)}
+                    onRetry={searchUser}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Theme switcher + Cycle + Radio (bottom-left) — above ticker */}
           <div className="pointer-events-auto fixed bottom-10 left-3 z-[31] flex items-center gap-2 sm:left-4">
             <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ import { useCodingPresence } from "@/lib/useCodingPresence";
 import { useRaidSequence } from "@/lib/useRaidSequence";
 import { useDailies } from "@/lib/useDailies";
 import DailiesWidget from "@/components/DailiesWidget";
+import RaidPreviewModal from "@/components/RaidPreviewModal";
 import RaidOverlay from "@/components/RaidOverlay";
 import PillModal from "@/components/PillModal";
 import FounderMessage from "@/components/FounderMessage";
@@ -114,13 +115,6 @@ const CityCanvas = dynamic(() => import("@/components/CityCanvas"), {
       </div>
     </div>
   ),
-});
-
-// Lazy-loaded: pulls in Three.js / @react-three/fiber, so it must stay out of
-// the initial homepage bundle. The Three.js chunk only loads when the raid
-// preview modal is actually opened (raidState.phase === "preview").
-const RaidPreviewModal = dynamic(() => import("@/components/RaidPreviewModal"), {
-  ssr: false,
 });
 
 // Feature flags — flip to switch milestone banner


### PR DESCRIPTION
## What does this PR do?

This PR adds a username search feature to **Explore Mode**, allowing users to quickly locate and navigate to a developer's building while roaming the city.

Previously, username search was only available from the landing page. Once users entered Explore Mode, there was no way to search for another developer without returning to the initial screen.

### Changes made

* Added a search box to the Explore Mode overlay.
* Reused the existing `searchUser()` workflow.
* Reused the existing camera navigation pipeline (`setFocusedBuilding` → `CameraFocus`).
* Reused existing `SearchFeedback` states for errors and retries.
* Added an accessible `aria-label` to the search input.

### Benefits

* Faster navigation within large cities.
* Improved discoverability of developer profiles.
* Better user experience while exploring.
* No changes to existing camera or building-generation logic.

## Related issue

Fixes #493

## Screenshots

### Before

* Users could only search from the landing page.
* No username search available while in Explore Mode.

### After

* Users can search for a username directly from Explore Mode.
* Camera smoothly navigates to the selected developer's building.
* Existing feedback messages are displayed for invalid searches.

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
