### PR TITLE
fix: replace stale-read XP overwrite with atomic grant_xp_atomic RPC 

### DIFF
--- a/src/app/api/shop/redeem-xp/route.ts
+++ b/src/app/api/shop/redeem-xp/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
-import { levelFromXp } from "@/lib/xp";
 
 /**
  * @param {import('next/server').NextRequest} req
@@ -106,23 +105,37 @@ export async function POST(req: Request) {
 
     // ── Apply XP — only reached if RPC won the race ───────────────────
     const xpAmount = result.xp_amount;
-    const newXpTotal = (dev.xp_total ?? 0) + xpAmount;
-    const newLevel = levelFromXp(newXpTotal);
-
-    const { error: xpError } = await sb
-      .from("developers")
-      .update({ xp_total: newXpTotal, xp_level: newLevel })
-      .eq("id", dev.id);
+    const { data: xpResult, error: xpError } = await sb.rpc("grant_xp_atomic", {
+      p_developer_id: dev.id,
+      p_source: `xp_code:${redeemCode.id}`,
+      p_amount: xpAmount,
+    });
 
     if (xpError) {
-      // RPC already committed usage + incremented used_count.
-      // Log the failure but do not return an error that would let the
-      // user retry — the code slot has been consumed.
-      console.error("[redeem-xp] XP update failed after successful RPC:", xpError.message);
+      console.error("[redeem-xp] grant_xp_atomic failed after successful redemption:", xpError.message);
       return NextResponse.json(
         { error: "Code was redeemed but XP could not be applied. Contact support." },
         { status: 500 }
       );
+    }
+
+    let newXpTotal: number;
+    let newLevel: number;
+    if (xpResult) {
+     const grant = xpResult as { granted: number; new_total: number; new_level: number };
+      newXpTotal = grant.new_total;
+      newLevel = grant.new_level;
+    } else {
+      console.warn(
+        `[redeem-xp] grant_xp_atomic returned null (duplicate source key) for dev ${dev.id}, code ${redeemCode.id}`
+      );
+      const { data: refreshed } = await sb
+        .from("developers")
+        .select("xp_total, xp_level")
+        .eq("id", dev.id)
+        .single();
+      newXpTotal = refreshed?.xp_total ?? dev.xp_total ?? 0;
+      newLevel = refreshed?.xp_level ?? 1;
     }
 
     return NextResponse.json({

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -29,7 +29,8 @@ export type XpSourceType =
   | "kudos_received"
   | "referral"
   | "gift_sent"
-  | "github";
+  | "github"
+  | "xp_code";
 
 // ─── Constants ──────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes the stale-read XP overwrite race in `/api/shop/redeem-xp` where two concurrent operations touching the same developer's `xp_total` (a checkin, a raid win, completing dailies, or a second simultaneous redemption) could cause one XP grant to be silently lost.

Root cause: the handler read `dev.xp_total` once at the top of the request, then — after the `redeem_xp_code` RPC resolved (100–500ms later) — wrote `xp_total = staleSnapshot + xpAmount` back with a plain `.update()`. There was no optimistic lock and no `WHERE xp_total = $snapshot` guard, so any write to `xp_total` that landed inside that window was overwritten rather than summed. Every other XP-granting path (`checkin`, `dailies`, `raid`, `kudos`, `visit`) already avoided this by going through `grant_xp_atomic`, which increments in SQL directly — `redeem-xp` was the one path still computing the new total in application code.

Fix — two-file change:

`src/app/api/shop/redeem-xp/route.ts` — replaced the stale-read `.update({ xp_total: newXpTotal, xp_level: newLevel })` with a call to the existing `grant_xp_atomic` RPC, passing `p_source: "xp_code:${redeemCode.id}"` and `p_amount: xpAmount`. The response's `new_xp_total` / `new_xp_level` now come directly from the RPC's return value instead of being recomputed from a snapshot. Removed the now-unused `levelFromXp` import.

`src/lib/xp.ts` — added `"xp_code"` to the `XpSourceType` union for parity with the other source names (`"checkin"`, `"dailies"`, etc.) already enumerated there.

One detail worth calling out: `grant_xp_atomic`'s own idempotency key is `(developer_id, source, source_date)`. Passing a flat `p_source: "xp_code"` would have traded the original race for a different bug — a second, different code redeemed by the same developer later the same day would collide on that key and silently grant 0 XP, even though `redeem_xp_code` had already validated it as a fresh redemption. Namespacing the source per code id (`xp_code:${redeemCode.id}`) keeps each code's grant on its own key while still letting `grant_xp_atomic` correctly dedupe a genuine retried call for the *same* code.

`redeem_xp_code` (the RPC that records usage and increments `used_count`) is unchanged — it was already correctly atomic; only the XP-application step after it needed fixing.

No migration needed. `grant_xp_atomic` and its backing `xp_grant_log` table already exist (`060_xp_grant_idempotency.sql`) and are reused as-is.

## Related issue

Fixes #496

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above