### PR TITLE
fix(SkyCollectibles): spawn coins outside central landmark clearance zone

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1015,16 +1015,22 @@ function SkyCollectibles({ playerPosRef, accentColor, onCollect, cityRadius }: {
       }
     };
 
-    // Altitudes are absolute — player flies between MIN_ALT(25) and MAX_ALT(900)
-    // Inner ring: 10 commons between buildings, low altitude
-    placeInZone(10, spread * 0.2, spread * 0.4, 80, 250, "common", 1, 6);
-    // Mid ring: 12 commons + 4 rares, medium altitude
-    placeInZone(12, spread * 0.4, spread * 0.7, 200, 500, "common", 1, 6);
-    placeInZone(4, spread * 0.4, spread * 0.7, 300, 600, "rare", 5, 9);
-    // Outer ring: 8 commons + 4 rares + 2 epics, high altitude
-    placeInZone(8, spread * 0.7, spread, 250, 550, "common", 1, 6);
-    placeInZone(4, spread * 0.7, spread, 400, 700, "rare", 5, 9);
-    placeInZone(2, spread * 0.7, spread, 650, 850, "epic", 25, 14);
+    // Altitudes are absolute — player flies between MIN_ALT(25) and MAX_ALT(900).
+    // All rings start at CENTER_CLEARANCE (700) so coins never spawn inside the
+    // central landmark zone where the Colosseum sits at radius ~461 units.
+    const CENTER_CLEARANCE = 700;
+    const outerEdge = Math.max(spread, CENTER_CLEARANCE + 200);
+    const band = outerEdge - CENTER_CLEARANCE;
+
+    // Inner band: just outside the clearance zone, low altitude
+    placeInZone(10, CENTER_CLEARANCE, CENTER_CLEARANCE + band * 0.35, 80, 250, "common", 1, 6);
+    // Mid band: medium altitude
+    placeInZone(12, CENTER_CLEARANCE + band * 0.2, CENTER_CLEARANCE + band * 0.65, 200, 500, "common", 1, 6);
+    placeInZone(4,  CENTER_CLEARANCE + band * 0.2, CENTER_CLEARANCE + band * 0.65, 300, 600, "rare", 5, 9);
+    // Outer band: high altitude
+    placeInZone(8,  CENTER_CLEARANCE + band * 0.5, outerEdge, 250, 550, "common", 1, 6);
+    placeInZone(4,  CENTER_CLEARANCE + band * 0.5, outerEdge, 400, 700, "rare", 5, 9);
+    placeInZone(2,  CENTER_CLEARANCE + band * 0.5, outerEdge, 650, 850, "epic", 25, 14);
 
     return result;
   }, [cityRadius]);


### PR DESCRIPTION
## What does this PR do?

Fixes `SkyCollectibles` in `CityCanvas.tsx` so flight-mode coins never spawn inside the 700-unit central clearance zone where the Colosseum sits. Previously, the inner ring used `spread * 0.2`–`spread * 0.4` as radii (~132–264 units), placing coins inside the landmark area where they would clip through the Colosseum mesh and become unreachable. This PR introduces a `CENTER_CLEARANCE = 700` constant and a `band` variable so all three coin tiers (inner/mid/outer) spawn from radius 700 outward, aligned with the actual developer building zone.

## Related issue

Fixes #538

## Screenshots

No visual before/after needed. The change is positional. Coins that previously clipped inside the Colosseum no longer appear there. All 40 collectibles now spawn in the building ring where the player can reach them.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)