### PR TITLE
fix(checkout): apply bungalow override in calcBuildingDims and fetch building_style for billboard slot limits

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -192,7 +192,7 @@ export async function POST(request: Request) {
     // Fetch building dimensions to calculate max slots
     const { data: devFull } = await sb
       .from("developers")
-      .select("github_login, contributions, public_repos, total_stars, rank, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, longest_streak, active_days_last_year, language_diversity, top_repos")
+      .select("github_login, contributions, public_repos, total_stars, rank, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, longest_streak, active_days_last_year, language_diversity, top_repos, building_style")
       .eq("id", dev.id)
       .single();
 
@@ -206,6 +206,7 @@ export async function POST(request: Request) {
         20_000, // maxContrib estimate
         200_000, // maxStars estimate
         (devFull.contributions_total ?? 0) > 0 ? devFull : undefined,
+        devFull.building_style ?? undefined,
       );
       const w = dims.width;
       const d = dims.depth;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1020,7 +1020,13 @@ export function calcBuildingDims(
   maxContrib: number,
   maxStars: number,
   v2Data?: Partial<DeveloperRecord>,
+  buildingStyle?: string,
 ): { width: number; height: number; depth: number } {
+  // BUNGALOW OVERRIDE — must match generateCityLayout
+  if (buildingStyle === "bungalow") {
+    return { width: 80, height: 25, depth: 60 };
+  }
+
   // V2 path when expanded data is available
   if (v2Data && (v2Data.contributions_total ?? 0) > 0) {
     const dev: DeveloperRecord = {


### PR DESCRIPTION
## What does this PR do?

Fixes a two-part bug where bungalow-style buildings were assigned incorrect billboard slot limits at checkout.
- calcBuildingDims in github.ts had no bungalow override, so it computed slots based on full tower dimensions instead of the actual 80×25×60 bungalow footprint. 
- Compounding this, checkout/route.ts never fetched building_style from the developers table, meaning even after fixing calcBuildingDims the field would have arrived as undefined. Both gaps are fixed together.
- The field is now selected and forwarded and calcBuildingDims returns early with the correct bungalow dimensions when buildingStyle === "bungalow".

## Related issue

Fixes #537

## Screenshots

No visual changes, this is a server-side calculation fix.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)