### PR TITLE
fix(arena): eliminate TOCTOU race in rotateDailyChallenges with upsert + UNIQUE constraint

### DIFF
--- a/src/lib/__tests__/arena-first-solve.test.ts
+++ b/src/lib/__tests__/arena-first-solve.test.ts
@@ -167,3 +167,133 @@ describe("Arena first-solve idempotency — application layer", () => {
     expect(claimResult).toBeNull();
   });
 });
+
+describe("rotateDailyChallenges — concurrent-rotation idempotency", () => {  type ChallengeRow = {
+    challenge_date: string;
+    type: string;
+    difficulty: string;
+    problem_id: string;
+  };
+
+  function makeStore() {
+    // Keyed by "date|type|difficulty" to simulate UNIQUE constraint
+    const committed = new Map<string, ChallengeRow>();
+
+    return {
+      insert(rows: ChallengeRow[]) {
+        // No ON CONFLICT guard — always inserts, producing duplicates
+        rows.forEach((r) => {
+          const key = `${r.challenge_date}|${r.type}|${r.difficulty}`;
+          committed.set(`${key}|${Math.random()}`, r); // unique synthetic pk
+        });
+      },
+      upsert(rows: ChallengeRow[], ignoreDuplicates: boolean) {
+        rows.forEach((r) => {
+          const key = `${r.challenge_date}|${r.type}|${r.difficulty}`;
+          if (ignoreDuplicates && committed.has(key)) return; // ON CONFLICT DO NOTHING
+          committed.set(key, r);
+        });
+      },
+      count() {
+        return committed.size;
+      },
+      rows() {
+        return [...committed.values()];
+      },
+    };
+  }
+
+  const DATE = "2026-06-16";
+
+  const CHALLENGES: ChallengeRow[] = [
+    { challenge_date: DATE, type: "daily", difficulty: "easy",   problem_id: "P1" },
+    { challenge_date: DATE, type: "daily", difficulty: "medium", problem_id: "P2" },
+    { challenge_date: DATE, type: "daily", difficulty: "hard",   problem_id: "P3" },
+  ];
+
+  it("OLD behaviour (plain insert): two concurrent invocations produce 6 rows — demonstrating the bug", () => {
+    const store = makeStore();
+
+    // Both invocations pass the guard (store is empty at read time)
+    // and both insert — TOCTOU race
+    store.insert(CHALLENGES); // invocation A
+    store.insert(CHALLENGES); // invocation B (concurrent)
+
+    expect(store.count()).toBe(6); // BUG: 6 rows for one date
+  });
+
+  it("NEW behaviour (upsert + ignoreDuplicates): two concurrent invocations produce exactly 3 rows", () => {
+    const store = makeStore();
+
+    store.upsert(CHALLENGES, true); // invocation A — commits all 3
+    store.upsert(CHALLENGES, true); // invocation B — all 3 conflict → no-op
+
+    expect(store.count()).toBe(3); // FIXED: exactly 3 rows
+  });
+
+  it("each difficulty appears exactly once after concurrent rotation", () => {
+    const store = makeStore();
+
+    store.upsert(CHALLENGES, true);
+    store.upsert(CHALLENGES, true); // concurrent duplicate
+
+    const difficulties = store.rows().map((r) => r.difficulty).sort();
+    expect(difficulties).toEqual(["easy", "hard", "medium"]);
+  });
+
+  it("upsert is idempotent across N invocations", () => {
+    const store = makeStore();
+
+    for (let i = 0; i < 10; i++) {
+      store.upsert(CHALLENGES, true);
+    }
+
+    expect(store.count()).toBe(3);
+  });
+
+  it("different dates do not conflict with each other", () => {
+    const store = makeStore();
+
+    const tomorrow: ChallengeRow[] = CHALLENGES.map((r) => ({
+      ...r,
+      challenge_date: "2026-06-17",
+    }));
+
+    store.upsert(CHALLENGES, true); // today
+    store.upsert(tomorrow, true);   // tomorrow
+
+    expect(store.count()).toBe(6); // 3 per date — correct
+  });
+
+  it("the JS-level guard (existingChallenges.length >= 3) remains a valid fast-path check", () => {
+    // Verifies the guard logic independently — it's still useful as a
+    // fast-path to avoid unnecessary DB round-trips even though it's no
+    // longer safety-critical after the upsert fix.
+    const existingChallenges = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const shouldSkip = existingChallenges.length >= 3;
+    expect(shouldSkip).toBe(true);
+  });
+
+  it("guard does NOT skip when fewer than 3 challenges exist (partial rotation)", () => {
+    const existingChallenges = [{ id: 1 }];
+    const shouldSkip = existingChallenges.length >= 3;
+    expect(shouldSkip).toBe(false);
+  });
+
+  it("upsert preserves the problem_id from the first writer under a conflict", () => {
+    const store = makeStore();
+
+    const firstWriterChallenges: ChallengeRow[] = [
+      { challenge_date: DATE, type: "daily", difficulty: "easy", problem_id: "FIRST" },
+    ];
+    const secondWriterChallenges: ChallengeRow[] = [
+      { challenge_date: DATE, type: "daily", difficulty: "easy", problem_id: "SECOND" },
+    ];
+
+    store.upsert(firstWriterChallenges, true);
+    store.upsert(secondWriterChallenges, true); // ignored — first writer wins
+
+    const row = store.rows().find((r) => r.difficulty === "easy");
+    expect(row?.problem_id).toBe("FIRST");
+  });
+});

--- a/src/lib/arena.ts
+++ b/src/lib/arena.ts
@@ -457,9 +457,14 @@ export async function rotateDailyChallenges(dateStr: string): Promise<boolean> {
       }
     ];
 
-    const { error } = await sb.from("arena_challenges").insert(challengesToInsert);
+    const { error } = await sb
+      .from("arena_challenges")
+      .upsert(challengesToInsert, {
+        onConflict: "challenge_date,type,difficulty",
+        ignoreDuplicates: true,
+      });
     if (error) {
-      console.error(`Error inserting daily challenges:`, error.message);
+      console.error(`Error upserting daily challenges:`, error.message);
       return false;
     }
 

--- a/supabase/migrations/20260616_arena_challenges_unique_constraint.sql
+++ b/supabase/migrations/20260616_arena_challenges_unique_constraint.sql
@@ -1,0 +1,14 @@
+-- Migration: add UNIQUE(challenge_date, type, difficulty) to arena_challenges
+-- Fixes the TOCTOU race in rotateDailyChallenges.
+--
+-- Two overlapping cron invocations both pass the JS-level guard (SELECT count)
+-- and then both INSERT, producing duplicate daily challenges for the same date.
+-- This constraint makes the second insert a safe no-op when combined with the
+-- upsert change in arena.ts.
+--
+-- ON CONFLICT DO NOTHING is safe here: the first writer wins and sets the
+-- canonical challenge; any concurrent or retry invocation is silently ignored.
+
+ALTER TABLE arena_challenges
+  ADD CONSTRAINT arena_challenges_date_type_difficulty_unique
+  UNIQUE (challenge_date, type, difficulty);


### PR DESCRIPTION
## What does this PR do?

Fixes a TOCTOU (time-of-check / time-of-use) race in `rotateDailyChallenges` where the guard against duplicate rotation used a read-then-write pattern with no database-level uniqueness enforcement. The function read existing challenge count with `SELECT`, decided whether to proceed, then `INSERT`ed three rows — but with no atomicity between those two steps. Two overlapping Vercel cron invocations (common at minute boundaries on Pro tier, or when a cron is manually triggered during an already-running invocation) both passed the guard simultaneously (both read 0 rows before either had written) and both inserted their three challenges, producing 6 or more `arena_challenges` rows for the same date. The `/api/arena/challenge/today` endpoint then returned an arbitrary duplicate non-deterministically.

The `arena_challenges` table had no `UNIQUE(challenge_date, type, difficulty)` constraint, so both inserts succeeded silently. Every other concurrent-write path in the codebase (`grant_xp_atomic`, `perform_checkin`, `insert_kudos_atomic`, `claim_first_solve`) already uses DB-level guards; this was the one remaining case computing its result in application code with a bare insert.

Fix — three files:

`supabase/migrations/20260616_arena_challenges_unique_constraint.sql` — adds `UNIQUE(challenge_date, type, difficulty)` on `arena_challenges`. This is the authoritative, DB-level guard. Postgres' constraint enforcement serializes concurrent writes to the same slot: the first writer commits, and any subsequent writer for the same `(challenge_date, type, difficulty)` receives a conflict signal rather than silently inserting a duplicate row. No data migration is needed — the constraint is additive and existing rows are assumed to be correct (one set per date from prior single-instance deployments).

`src/lib/arena.ts` — replaces the bare `.insert(challengesToInsert)` with `.upsert(challengesToInsert, { onConflict: "challenge_date,type,difficulty", ignoreDuplicates: true })`. This is the matching application-layer complement to the DB constraint: when the constraint fires, Supabase's `ON CONFLICT DO NOTHING` means the second invocation returns no error and no rows written — a safe no-op. The existing JS-level guard (`existingChallenges.length >= 3`) is intentionally retained as a fast-path to skip the three subsequent problem-fetch round-trips when challenges already exist; it is no longer safety-critical but remains a useful latency optimisation.

`src/lib/__tests__/arena-first-solve.test.ts` — new `describe` block appended to the existing file. Reproduces the original bug (plain insert from two concurrent invocations → 6 rows) using an in-memory store modelling the DB constraint, verifies the fix (upsert + ignoreDuplicates → exactly 3 rows), asserts each difficulty appears exactly once, confirms idempotency across N invocations, verifies different dates don't conflict with each other, and checks that the first writer's `problem_id` is preserved under a conflict (first writer wins).

No other files change. The cron route (`src/app/api/cron/rotate-daily-challenge/route.ts`) is untouched — it calls `rotateDailyChallenges` unchanged and the fix is entirely within that function.

## Related issue

Fixes #499

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have linked the related issue above