### PR TITLE
fix(#490): make district population updates atomic via RPC

### DIFF
--- a/src/app/api/district/change/route.ts
+++ b/src/app/api/district/change/route.ts
@@ -86,59 +86,24 @@ export async function POST(request: Request) {
     }
   }
 
-  // Update developer
-  const { error: updateError } = await admin
-    .from("developers")
-    .update({
-      district: district_id,
-      district_chosen: true,
-      // Only count actual changes, not first choice
-      district_changes_count: isActualChange
-        ? (dev.district_changes_count ?? 0) + 1
-        : (dev.district_changes_count ?? 0),
-      district_changed_at: isActualChange
-        ? new Date().toISOString()
-        : dev.district_changed_at,
-    })
-    .eq("id", dev.id);
+  // Update developer + district populations atomically
+  const { data: rpcResult, error: rpcError } = await admin.rpc(
+    "change_district_atomic",
+    {
+      p_developer_id: dev.id,
+      p_old_district: oldDistrict,
+      p_new_district: district_id,
+      p_is_actual_change: isActualChange,
+      p_changes_count: dev.district_changes_count ?? 0,
+      p_changed_at: dev.district_changed_at,
+    },
+  );
 
-  if (updateError) {
-    return NextResponse.json({ error: "Failed to update district" }, { status: 500 });
-  }
-
-  // Log the change
-  await admin.from("district_changes").insert({
-    developer_id: dev.id,
-    from_district: oldDistrict,
-    to_district: district_id,
-    reason: "user_choice",
-  });
-
-  // Update district population counts
-  if (oldDistrict) {
-    const { data: oldDist } = await admin
-      .from("districts")
-      .select("population")
-      .eq("id", oldDistrict)
-      .single();
-    if (oldDist) {
-      await admin
-        .from("districts")
-        .update({ population: Math.max(0, (oldDist.population ?? 0) - 1) })
-        .eq("id", oldDistrict);
-    }
-  }
-
-  const { data: newDist } = await admin
-    .from("districts")
-    .select("population")
-    .eq("id", district_id)
-    .single();
-  if (newDist) {
-    await admin
-      .from("districts")
-      .update({ population: (newDist.population ?? 0) + 1 })
-      .eq("id", district_id);
+  if (rpcError || !rpcResult?.ok) {
+    return NextResponse.json(
+      { error: rpcResult?.error ?? "Failed to update district" },
+      { status: 500 },
+    );
   }
 
   return NextResponse.json({ ok: true, district: district_id });

--- a/supabase/migrations/064_change_district_atomic.sql
+++ b/supabase/migrations/064_change_district_atomic.sql
@@ -1,0 +1,49 @@
+CREATE OR REPLACE FUNCTION public.change_district_atomic(
+  p_developer_id        BIGINT,
+  p_old_district        TEXT,
+  p_new_district        TEXT,
+  p_is_actual_change    BOOLEAN,
+  p_changes_count       INT,
+  p_changed_at          TIMESTAMPTZ
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  UPDATE public.developers
+  SET
+    district            = p_new_district,
+    district_chosen     = true,
+    district_changes_count = CASE WHEN p_is_actual_change
+                               THEN p_changes_count + 1
+                               ELSE p_changes_count
+                            END,
+    district_changed_at = CASE WHEN p_is_actual_change
+                            THEN COALESCE(p_changed_at, now())
+                            ELSE district_changed_at
+                         END
+  WHERE id = p_developer_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'Developer not found');
+  END IF;
+
+  INSERT INTO public.district_changes (developer_id, from_district, to_district, reason)
+  VALUES (p_developer_id, p_old_district, p_new_district, 'user_choice');
+
+  IF p_old_district IS NOT NULL AND p_old_district != p_new_district THEN
+    UPDATE public.districts
+    SET population = GREATEST(0, population - 1)
+    WHERE id = p_old_district;
+  END IF;
+
+  UPDATE public.districts
+  SET population = population + 1
+  WHERE id = p_new_district;
+
+  RETURN jsonb_build_object('ok', true, 'district', p_new_district);
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where concurrent district changes could corrupt population counters.

The old code used a read-modify-write pattern (SELECT population, compute +/-1, UPDATE) outside a transaction. Two simultaneous district changes to the same district could read the same population value and overwrite each other's increments/decrements, causing counters to drift.

The fix replaces the three separate operations (developer update, log insert, population update) with a single PL/pgSQL RPC function `change_district_atomic` that executes all writes atomically inside PostgreSQL using direct SQL increments (`population = population + 1`) instead of read-modify-write.

## Related issue

Fixes #490

## Screenshots

No visual UI changes — backend-only fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**