### PR TITLE
fix(#486): guard arena leaderboard pagination against NaN inputs

### DIFF
--- a/src/app/api/arena/leaderboard/route.ts
+++ b/src/app/api/arena/leaderboard/route.ts
@@ -13,8 +13,10 @@ function getRankTitle(rating: number, index: number): { title: string; badge: st
 export async function GET(request: NextRequest) {
   const sb = getSupabaseAdmin();
   const { searchParams } = new URL(request.url);
-  const limit = Math.min(parseInt(searchParams.get("limit") || "100"), 100);
-  const offset = Math.max(parseInt(searchParams.get("offset") || "0"), 0);
+  const rawLimit = parseInt(searchParams.get("limit") ?? "", 10);
+  const rawOffset = parseInt(searchParams.get("offset") ?? "", 10);
+  const limit = Number.isNaN(rawLimit) ? 100 : Math.min(100, Math.max(1, rawLimit));
+  const offset = Number.isNaN(rawOffset) ? 0 : Math.max(0, rawOffset);
 
   // Query ratings table, ordering by ELO rating desc
   const { data: leaderboard, error } = await sb


### PR DESCRIPTION
## What does this PR do?

Fixes the arena leaderboard route accepting non-numeric pagination parameters.

`Math.min(parseInt(searchParams.get("limit") || "100"), 100)` passes NaN through when `limit` is non-numeric (e.g. `"abc"`, `"NaN"`). The resulting `NaN` propagates to Supabase `.range()`, causing a database error.

The fix adds explicit `Number.isNaN` guards with safe defaults before clamping, following the same pattern used in `src/lib/parse-pagination.ts`.

## Related issue

Fixes #486

## Screenshots

No visual UI changes — backend-only fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**