### PR TITLE
fix(#487): validate feed cursor UUID and reject missing cursors

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
 const MIN_EVENTS = 8;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -19,6 +20,13 @@ export async function GET(request: Request) {
 
   const limit = Math.min(50, Math.max(1, rawLimit));
   const before = searchParams.get("before"); // UUID cursor
+
+  if (before && !UUID_RE.test(before)) {
+    return NextResponse.json(
+      { error: "Invalid cursor: must be a valid UUID." },
+      { status: 400 }
+    );
+  }
 
   const todayOnly = searchParams.get("today") === "1";
 
@@ -49,16 +57,20 @@ export async function GET(request: Request) {
   }
 
   if (before) {
-    // Get the created_at of the cursor event to page from there
     const { data: cursor } = await sb
       .from("activity_feed")
       .select("created_at")
       .eq("id", before)
-      .single();
+      .maybeSingle();
 
-    if (cursor) {
-      query = query.lt("created_at", cursor.created_at);
+    if (!cursor) {
+      return NextResponse.json(
+        { error: "Cursor not found." },
+        { status: 404 }
+      );
     }
+
+    query = query.lt("created_at", cursor.created_at);
   }
 
   let events = (await query).data ?? [];


### PR DESCRIPTION
## What does this PR do?

Fixes the activity feed endpoint accepting invalid pagination cursors.

Previously:
- Malformed UUIDs (e.g. `"abc"`, `"not-a-uuid"`) were silently ignored, returning the first page
- Non-existent cursors were also silently ignored, returning incorrect results

Now:
- UUID format is validated with a regex before querying
- Invalid UUIDs return `400 Invalid cursor`
- Valid UUIDs that don't exist in activity_feed return `404 Cursor not found`

## Related issue

Fixes #487

## Screenshots

No visual UI changes — backend-only fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**