### PR TITLE
fix(#488): guard billboard slot_index against File/NaN values

### DIFF
--- a/src/app/api/customizations/upload/route.ts
+++ b/src/app/api/customizations/upload/route.ts
@@ -68,9 +68,16 @@ export async function POST(request: Request) {
    }
   const file = formData.get("file") as File | null;
   const slotIndexRaw = formData.get("slot_index");
-  const slotIndex = slotIndexRaw !== null ? parseInt(slotIndexRaw as string, 10) : 0;
 
-  if (isNaN(slotIndex) || slotIndex < 0) {
+  if (slotIndexRaw === null || slotIndexRaw instanceof File) {
+    return NextResponse.json(
+      { error: "Invalid slot_index" },
+      { status: 400 }
+    );
+  }
+
+  const slotIndex = parseInt(slotIndexRaw, 10);
+  if (!Number.isFinite(slotIndex) || slotIndex < 0) {
     return NextResponse.json(
       { error: "Invalid slot_index" },
       { status: 400 }


### PR DESCRIPTION
## What does this PR do?

Fixes the billboard upload endpoint accepting malformed `slot_index` values from FormData.

`formData.get('slot_index')` returns `FormDataEntryValue` which can be either a `string` or a `File`. If the field accidentally contains a `File` object, `parseInt([object File])` silently returns `NaN`. The existing `isNaN` check catches NaN but doesn't reject File inputs before parsing.

Fix: explicitly reject `null` and `File` inputs, then use `Number.isFinite` guard after parsing.

## Related issue

Fixes #488

## Screenshots

No visual UI changes — backend-only fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**