### PR TITLE
fix(#489): return actual DB score and rank on duplicate fly-score submission

### DIFF
--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -130,12 +130,39 @@ export async function POST(request: Request) {
   if (insertError?.code === "23505") {
     const { data: existing } = await admin
       .from("fly_scores")
-      .select("id")
+      .select("id, score, flight_ms")
       .eq("developer_id", dev.id)
       .eq("seed", seed)
       .single();
 
-    return NextResponse.json({ id: existing?.id, score, rank_today: null, total: 0 });
+    if (!existing) {
+      return NextResponse.json({ error: "Existing score not found" }, { status: 500 });
+    }
+
+    const { data: higherDevs } = await admin
+      .from("fly_scores")
+      .select("developer_id")
+      .eq("seed", seed)
+      .gt("score", existing.score);
+
+    const { data: tiedFasterDevs } = await admin
+      .from("fly_scores")
+      .select("developer_id")
+      .eq("seed", seed)
+      .eq("score", existing.score)
+      .lt("flight_ms", existing.flight_ms);
+
+    const uniqueHigher = new Set([
+      ...(higherDevs ?? []).map((r: FlyScoreDev) => r.developer_id),
+      ...(tiedFasterDevs ?? []).map((r: FlyScoreDev) => r.developer_id),
+    ]);
+    uniqueHigher.delete(dev.id);
+    const rankToday = uniqueHigher.size + 1;
+
+    const { data: allDevs } = await admin.from("fly_scores").select("developer_id").eq("seed", seed);
+    const totalDevs = new Set((allDevs ?? []).map((r: FlyScoreDev) => r.developer_id)).size;
+
+    return NextResponse.json({ id: existing.id, score: existing.score, rank_today: rankToday, total: totalDevs });
   }
 
   const flyXp = Math.floor(score * 0.1);


### PR DESCRIPTION
## What does this PR do?

Fixes the fly-score endpoint returning unsaved request data when a duplicate submission is detected.

When POST /api/fly-scores hits the unique `(developer_id, seed)` constraint (code 23505), the old code:
- Only selected `id` from the existing row
- Returned `score` from the request body (which was NOT saved)
- Returned `rank_today: null, total: 0`

Now it fetches the actual saved `score` and `flight_ms`, computes the real rank and total participant count for that saved score, and returns the correct values.

## Related issue

Fixes #489

## Screenshots

No visual UI changes — backend-only fix.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have stared this repository!**