### PR TITLE
fix: improve accessibility for live status indicators

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -346,6 +346,19 @@ body {
   animation: live-pulse 2s ease-in-out infinite;
 }
 
+/* Visually hidden utility for screen readers */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 /* ─── District fly-by announcement ─── */
 @keyframes district-in {
   0% {

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -53,7 +53,7 @@ export default function LivePage() {
             &larr; Back to city
           </Link>
           <div className="flex items-center gap-3">
-            <span className="live-dot h-3 w-3 rounded-full bg-[#4ade80]" />
+            <span className="live-dot h-3 w-3 rounded-full bg-[#4ade80]" aria-hidden="true" />
             <h1 className="text-2xl text-cream">Live Now</h1>
             <span className="text-xs text-muted">
               {developers.length} developer{developers.length !== 1 ? "s" : ""} coding
@@ -96,7 +96,9 @@ export default function LivePage() {
                     />
                     <span
                       className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-bg ${isCreator ? "bg-[#fbbf24]" : "bg-[#4ade80]"}`}
+                      aria-hidden="true"
                     />
+                    <span className="sr-only">live</span>
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3637,8 +3637,11 @@ function HomeContent() {
             )}
           </a>
           {liveStatus !== "error" && (
-            <div className="flex items-center gap-1.5 border-[3px] border-border bg-bg/70 px-2.5 py-1 text-[10px] backdrop-blur-sm">
-              <span className="live-dot h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#4ade80]" />
+            <div
+              className="flex items-center gap-1.5 border-[3px] border-border bg-bg/70 px-2.5 py-1 text-[10px] backdrop-blur-sm"
+              aria-label={`${liveUsers.toLocaleString()} live users`}
+            >
+              <span className="live-dot h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#4ade80]" aria-hidden="true" />
               <span className="text-cream">{liveUsers.toLocaleString()}</span>
               <span className="hidden sm:inline text-muted">live</span>
             </div>
@@ -3674,6 +3677,7 @@ function HomeContent() {
                 >
                   <span
                     className={`${energyDotAnim} h-1.5 w-1.5 flex-shrink-0 rounded-full ${energyDotColor}`}
+                    aria-hidden="true"
                   />
                   {codingCount > 0 ? (
                     <>
@@ -3761,7 +3765,9 @@ function HomeContent() {
                                 </div>
                                 <span
                                   className={`live-dot h-2 w-2 flex-shrink-0 rounded-full ${isCreator ? "bg-[#fbbf24]" : "bg-[#4ade80]"}`}
+                                  aria-hidden="true"
                                 />
+                                <span className="sr-only">live</span>
                               </button>
                             );
                           })}

--- a/src/app/roadmap/RoadmapClient.tsx
+++ b/src/app/roadmap/RoadmapClient.tsx
@@ -289,9 +289,15 @@ function ItemRow({
       {/* Checkbox */}
       <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border-[2px] border-border text-[8px]">
         {isDone ? (
-          <span style={{ color: "#4ade80" }}>&#10003;</span>
+          <>
+            <span style={{ color: "#4ade80" }} aria-hidden="true">&#10003;</span>
+            <span className="sr-only">Completed</span>
+          </>
         ) : item.status === "building" ? (
-          <span className="blink-dot block h-1.5 w-1.5" style={{ backgroundColor: ACCENT }} />
+          <>
+            <span className="blink-dot block h-1.5 w-1.5" style={{ backgroundColor: ACCENT }} aria-hidden="true" />
+            <span className="sr-only">Building</span>
+          </>
         ) : null}
       </span>
 


### PR DESCRIPTION
## What does this PR do?

Improves accessibility for user status indicators that were previously communicated through visual-only cues such as animated live dots, avatar status indicators, and roadmap progress indicators.

This PR adds accessible status descriptions for assistive technologies while preserving the existing visual design and functionality.

### Accessibility Improvements

* Added a reusable `sr-only` utility for visually hidden screen-reader text.
* Added accessible descriptions for live/active status indicators.
* Exposed roadmap states such as **Building** and **Completed** to assistive technologies.
* Marked decorative status indicators as `aria-hidden="true"` to prevent redundant announcements.
* Added accessible labeling for live user counts.

No production behavior or visual design was changed.

## Related issue

Fixes #547

## Screenshots

Not applicable. This PR improves accessibility and screen-reader support without introducing visual UI changes.

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
