### PR TITLE
fix(leetcode): remove setUTCHours mutation that shifted weekly submission window

### DIFF
--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -77,6 +77,7 @@ export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<
             yearsToFetch.push(sevenDaysAgoYear);
         }
 
+        const nowTs = Math.floor(now.getTime() / 1000);
         let totalWeeklyCount = 0;
 
         for (const year of yearsToFetch) {
@@ -107,8 +108,7 @@ export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<
             if (!calendarStr) continue;
 
             const calendar = JSON.parse(calendarStr);
-            now.setUTCHours(0, 0, 0, 0);
-            const sevenDaysAgoTs = Math.floor(now.getTime() / 1000) - 7 * 24 * 60 * 60;
+            const sevenDaysAgoTs = nowTs - 7 * 24 * 60 * 60;
 
             for (const [timestampStr, count] of Object.entries(calendar)) {
                 const timestamp = parseInt(timestampStr, 10);


### PR DESCRIPTION
## What does this PR do?

\`fetchLeetCodeWeeklySubmissions\` captured \`const now = new Date()\` at line 70, then called \`now.setUTCHours(0, 0, 0, 0)\` inside the fetch loop, mutating the object in place. After that mutation the 7-day cutoff was computed from midnight UTC instead of the actual call time — up to ~24 hours off.

The cron path in \`api/cron/lc-refresh/route.ts\` computes the cutoff correctly without mutating \`now\`. This discrepancy meant checkin-triggered updates and cron updates produced different \`current_week_contributions\` values for the same user on the same day, directly affecting raid attack scores.

Fix: pre-compute \`nowTs = Math.floor(now.getTime() / 1000)\` once before the loop and derive \`sevenDaysAgoTs\` from it, matching the cron path exactly.

## Related issue

Fixes #570

## Screenshots

N/A

## Checklist

- [x] \`npm run lint\` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)