### PR TITLE
fix(relics): replace read-modify-write with atomic increment_relic_progress RPC

### DIFF
--- a/src/app/api/arena/submit/route.ts
+++ b/src/app/api/arena/submit/route.ts
@@ -222,34 +222,14 @@ export async function POST(request: NextRequest) {
 
       droppedItems = await rollItemDrops(sb, difficulty, dev.id);
 
-      // Track arena solve to update relic progress
+      // Track arena solve to update relic progress atomically
       try {
-        const { data: custom } = await sb
-          .from("developer_customizations")
-          .select("config")
-          .eq("developer_id", dev.id)
-          .eq("item_id", "relic_progress")
-          .maybeSingle();
+        const { data: newSolves } = await sb.rpc("increment_relic_progress", {
+          p_developer_id: dev.id,
+          p_field: "arena_solves",
+        });
 
-        const progress = custom?.config ?? {
-          docks_visits: 0,
-          arena_solves: 0,
-          raid_wins: 0,
-        };
-
-        progress.arena_solves = (progress.arena_solves ?? 0) + 1;
-
-        await sb.from("developer_customizations").upsert(
-          {
-            developer_id: dev.id,
-            item_id: "relic_progress",
-            config: progress,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "developer_id,item_id" }
-        );
-
-        if (progress.arena_solves >= 20) {
+        if ((newSolves ?? 0) >= 20) {
           await sb.from("developer_relics").upsert(
             {
               developer_id: dev.id,

--- a/src/app/api/arena/submit/route.ts
+++ b/src/app/api/arena/submit/route.ts
@@ -224,12 +224,14 @@ export async function POST(request: NextRequest) {
 
       // Track arena solve to update relic progress atomically
       try {
-        const { data: newSolves } = await sb.rpc("increment_relic_progress", {
+        const { data: newSolves, error: relicErr } = await sb.rpc("increment_relic_progress", {
           p_developer_id: dev.id,
           p_field: "arena_solves",
         });
 
-        if ((newSolves ?? 0) >= 20) {
+        if (relicErr) {
+          console.error("[arena/submit] increment_relic_progress error:", relicErr.message);
+        } else if ((newSolves ?? 0) >= 20) {
           await sb.from("developer_relics").upsert(
             {
               developer_id: dev.id,

--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -345,34 +345,14 @@ export async function POST(request: Request) {
     await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
     await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
 
-    // Track raid win to update relic progress
+    // Track raid win to update relic progress atomically
     try {
-      const { data: custom } = await admin
-        .from("developer_customizations")
-        .select("config")
-        .eq("developer_id", attacker.id)
-        .eq("item_id", "relic_progress")
-        .maybeSingle();
+      const { data: newWins } = await admin.rpc("increment_relic_progress", {
+        p_developer_id: attacker.id,
+        p_field: "raid_wins",
+      });
 
-      const progress = custom?.config ?? {
-        docks_visits: 0,
-        arena_solves: 0,
-        raid_wins: 0,
-      };
-
-      progress.raid_wins = (progress.raid_wins ?? 0) + 1;
-
-      await admin.from("developer_customizations").upsert(
-        {
-          developer_id: attacker.id,
-          item_id: "relic_progress",
-          config: progress,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: "developer_id,item_id" }
-      );
-
-      if (progress.raid_wins >= 1) {
+      if ((newWins ?? 0) >= 1) {
         await admin.from("developer_relics").upsert(
           {
             developer_id: attacker.id,

--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -347,12 +347,14 @@ export async function POST(request: Request) {
 
     // Track raid win to update relic progress atomically
     try {
-      const { data: newWins } = await admin.rpc("increment_relic_progress", {
+      const { data: newWins, error: relicErr } = await admin.rpc("increment_relic_progress", {
         p_developer_id: attacker.id,
         p_field: "raid_wins",
       });
 
-      if ((newWins ?? 0) >= 1) {
+      if (relicErr) {
+        console.error("[raid/execute] increment_relic_progress error:", relicErr.message);
+      } else if ((newWins ?? 0) >= 1) {
         await admin.from("developer_relics").upsert(
           {
             developer_id: attacker.id,

--- a/supabase/migrations/20260617_relic_progress_atomic.sql
+++ b/supabase/migrations/20260617_relic_progress_atomic.sql
@@ -1,0 +1,45 @@
+-- Migration: Atomic relic progress increment
+-- Issue #571
+--
+-- Both arena/submit and raid/execute tracked relic progress with a
+-- read-modify-write at the app layer: SELECT config, mutate in memory,
+-- UPSERT back. Two concurrent accepted submissions could both read the
+-- same counter value and write back the same incremented value, leaving
+-- the counter one step behind. Users could get stuck below an unlock
+-- threshold they legitimately crossed.
+--
+-- increment_relic_progress() replaces this with a single atomic UPDATE
+-- using jsonb_set on the config JSONB column. Postgres row-level locking
+-- on UPDATE serializes concurrent calls for the same developer, so no
+-- two calls can read-then-write the same value.
+CREATE OR REPLACE FUNCTION increment_relic_progress(
+  p_developer_id BIGINT,
+  p_field        TEXT
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_new_value INTEGER;
+BEGIN
+  INSERT INTO developer_customizations (developer_id, item_id, config, updated_at)
+  VALUES (
+    p_developer_id,
+    'relic_progress',
+    jsonb_build_object(p_field, 1),
+    NOW()
+  )
+  ON CONFLICT (developer_id, item_id) DO UPDATE
+    SET config = jsonb_set(
+          developer_customizations.config,
+          ARRAY[p_field],
+          to_jsonb(
+            COALESCE((developer_customizations.config ->> p_field)::int, 0) + 1
+          )
+        ),
+        updated_at = NOW()
+  RETURNING (config ->> p_field)::int INTO v_new_value;
+
+  RETURN v_new_value;
+END;
+$$;

--- a/supabase/migrations/20260617_relic_progress_atomic.sql
+++ b/supabase/migrations/20260617_relic_progress_atomic.sql
@@ -22,6 +22,13 @@ AS $$
 DECLARE
   v_new_value INTEGER;
 BEGIN
+  -- Allowlist p_field to prevent arbitrary JSON key injection.
+  -- This function is called via the service-role client (server-side only),
+  -- but defence-in-depth: reject any field not in the known relic counter set.
+  IF p_field NOT IN ('arena_solves', 'raid_wins', 'docks_visits') THEN
+    RAISE EXCEPTION 'increment_relic_progress: invalid field %', p_field;
+  END IF;
+
   INSERT INTO developer_customizations (developer_id, item_id, config, updated_at)
   VALUES (
     p_developer_id,


### PR DESCRIPTION
## What does this PR do?

Both \`arena/submit\` and \`raid/execute\` tracked relic progress with a SELECT-then-UPSERT at the app layer. Two concurrent accepted submissions could both read \`arena_solves: 19\`, both write back \`arena_solves: 20\`, and the counter would get stuck permanently one step behind. Users could cross an unlock threshold and never get the relic.

This adds \`increment_relic_progress(p_developer_id, p_field)\` — a Postgres function that does the increment atomically using \`INSERT ... ON CONFLICT DO UPDATE jsonb_set\`. \`p_field\` is validated against an explicit allowlist inside the function to prevent arbitrary JSON key injection. Both routes now call this RPC instead of doing the read-modify-write themselves, and explicitly handle the returned \`error\` value before checking the new count.

Same fix class as #497 (kudos streak) and #496 (XP overwrite).

## Related issue

Fixes #571

## Screenshots

N/A

## Checklist

- [x] \`npm run lint\` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)