### PR TITLE
fix(upload): validate file magic bytes instead of trusting client Content-Type

### DIFF
--- a/src/app/api/customizations/upload/route.ts
+++ b/src/app/api/customizations/upload/route.ts
@@ -10,6 +10,29 @@ const ALLOWED_TYPES = new Set([
   "image/gif",
 ]);
 
+function detectMimeFromBytes(bytes: Uint8Array): string | null {
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+    return "image/png";
+  }
+  // JPEG: FF D8 FF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  // GIF: 47 49 46 38 (GIF8)
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) {
+    return "image/gif";
+  }
+  // WebP: 52 49 46 46 ?? ?? ?? ?? 57 45 42 50 (RIFF....WEBP)
+  if (
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
 /**
  * @param {import('next/server').NextRequest} request
  */
@@ -116,6 +139,17 @@ export async function POST(request: Request) {
   const ext = file.type.split("/")[1] === "jpeg" ? "jpg" : file.type.split("/")[1];
   const filePath = `${dev.id}_${slotIndex}.${ext}`;
   const fileBuffer = await file.arrayBuffer();
+
+  // Validate actual file content against magic bytes to prevent MIME spoofing.
+  // file.type comes from the client-controlled Content-Type header and cannot
+  // be trusted on its own — this check ensures the bytes match the declared type.
+  const detectedType = detectMimeFromBytes(new Uint8Array(fileBuffer.slice(0, 12)));
+  if (!detectedType || detectedType !== file.type) {
+    return NextResponse.json(
+      { error: "File content does not match declared type" },
+      { status: 400 }
+    );
+  }
 
   const { error: uploadError } = await sb.storage
     .from("billboards")

--- a/src/app/api/customizations/upload/route.ts
+++ b/src/app/api/customizations/upload/route.ts
@@ -10,9 +10,15 @@ const ALLOWED_TYPES = new Set([
   "image/gif",
 ]);
 
+const MAGIC_BYTES_TO_READ = 12;
+
 function detectMimeFromBytes(bytes: Uint8Array): string | null {
-  // PNG: 89 50 4E 47 0D 0A 1A 0A
-  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+  if (bytes.length < MAGIC_BYTES_TO_READ) return null;
+  // PNG: 89 50 4E 47 0D 0A 1A 0A (full 8-byte signature)
+  if (
+    bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 &&
+    bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a
+  ) {
     return "image/png";
   }
   // JPEG: FF D8 FF
@@ -136,25 +142,26 @@ export async function POST(request: Request) {
   }
 
   // Upload file (overwrite on re-upload)
-  const ext = file.type.split("/")[1] === "jpeg" ? "jpg" : file.type.split("/")[1];
-  const filePath = `${dev.id}_${slotIndex}.${ext}`;
   const fileBuffer = await file.arrayBuffer();
 
-  // Validate actual file content against magic bytes to prevent MIME spoofing.
-  // file.type comes from the client-controlled Content-Type header and cannot
-  // be trusted on its own — this check ensures the bytes match the declared type.
-  const detectedType = detectMimeFromBytes(new Uint8Array(fileBuffer.slice(0, 12)));
-  if (!detectedType || detectedType !== file.type) {
+  // Detect MIME type from magic bytes — file.type comes from the client-controlled
+  // Content-Type part header and cannot be trusted. Use the detected type as the
+  // source of truth: reject if unknown, reject if not in ALLOWED_TYPES.
+  const detectedType = detectMimeFromBytes(new Uint8Array(fileBuffer.slice(0, MAGIC_BYTES_TO_READ)));
+  if (!detectedType || !ALLOWED_TYPES.has(detectedType)) {
     return NextResponse.json(
-      { error: "File content does not match declared type" },
+      { error: "File content does not match an allowed image type" },
       { status: 400 }
     );
   }
 
+  const ext = detectedType.split("/")[1] === "jpeg" ? "jpg" : detectedType.split("/")[1];
+  const filePath = `${dev.id}_${slotIndex}.${ext}`;
+
   const { error: uploadError } = await sb.storage
     .from("billboards")
     .upload(filePath, fileBuffer, {
-      contentType: file.type,
+      contentType: detectedType,
       upsert: true,
     });
 


### PR DESCRIPTION
## What does this PR do?

\`POST /api/customizations/upload\` was validating MIME type via \`file.type\`, which comes directly from the \`Content-Type\` field in the multipart form body — fully client-controlled. The SVG exclusion (to prevent XSS) was trivially bypassed by sending SVG content with \`Content-Type: image/webp\`. A GIF89a polyglot could also be uploaded and served from the public \`billboards\` bucket to all city visitors.

Add \`detectMimeFromBytes()\` that inspects the first 12 bytes of the actual file buffer against known magic signatures for PNG, JPEG, GIF, and WebP. The check runs after \`file.arrayBuffer()\` is already called (no extra read). If the detected type is missing or doesn't match \`file.type\`, the upload is rejected with 400.

No behavior change for legitimate uploads — magic bytes always match for real image files.

## Related issue

Fixes #572

## Screenshots

N/A

## Checklist

- [x] \`npm run lint\` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)