### PR TITLE
fix: eliminate shadow acne and canvas z-fighting artifacts (#568)

### DIFF
--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -1795,7 +1795,7 @@ export default function AtmosphereCycleManager({
       <SceneBackground color={theme.fogColor} />
 
       <ambientLight ref={ambientLightRef} intensity={theme.ambientIntensity * 3} color={theme.ambientColor} />
-      <directionalLight ref={sunLightRef} position={theme.sunPos} intensity={theme.sunIntensity * 3.5} color={theme.sunColor} />
+      <directionalLight ref={sunLightRef} position={theme.sunPos} intensity={theme.sunIntensity * 3.5} color={theme.sunColor} shadow-bias={-0.0005} shadow-normalBias={0.04} />
       <directionalLight ref={fillLightRef} position={theme.fillPos} intensity={theme.fillIntensity * 3} color={theme.fillColor} />
       <hemisphereLight ref={hemiLightRef} args={[theme.hemiSky, theme.hemiGround, theme.hemiIntensity * 3.5]} />
 

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -2256,7 +2256,7 @@ export default function CityCanvas({
           console.warn("CityCanvas: failed to enforce nearest filtering", e);
         }
       }}
-      gl={{ antialias: true, logarithmicDepthBuffer: true, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.3 }}
+      gl={{ antialias: true, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.3 }}
       style={{ position: "fixed", inset: 0, width: "100vw", height: "100vh" }}
     >
       {showPerf && <Stats />}

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -2211,8 +2211,8 @@ export default function CityCanvas({
 
   return (
     <Canvas
-      camera={{ position: [400, 450, 600], fov: 55, near: 0.5, far: 4000 }}
-      dpr={1}
+      camera={{ position: [400, 450, 600], fov: 55, near: 1.0, far: 4000 }}
+      dpr={[1, 2]}
       onCreated={({ gl, scene }) => {
         try {
           // Keep the canvas pixelated via CSS; don't override the Canvas `dpr` prop here
@@ -2256,7 +2256,7 @@ export default function CityCanvas({
           console.warn("CityCanvas: failed to enforce nearest filtering", e);
         }
       }}
-      gl={{ antialias: false, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.3 }}
+      gl={{ antialias: true, logarithmicDepthBuffer: true, powerPreference: "high-performance", toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.3 }}
       style={{ position: "fixed", inset: 0, width: "100vw", height: "100vh" }}
     >
       {showPerf && <Stats />}

--- a/src/components/DarkContinentCanvas.tsx
+++ b/src/components/DarkContinentCanvas.tsx
@@ -1209,6 +1209,7 @@ export default function DarkContinentCanvas() {
         camera={{ position: [0, 300, 800], fov: 65, near: 1, far: 12000 }}
         gl={{
           antialias: true,
+          logarithmicDepthBuffer: true,
           powerPreference: "high-performance",
           toneMapping: THREE.ACESFilmicToneMapping,
           toneMappingExposure: 1.2,

--- a/src/components/DarkContinentCanvas.tsx
+++ b/src/components/DarkContinentCanvas.tsx
@@ -1209,7 +1209,6 @@ export default function DarkContinentCanvas() {
         camera={{ position: [0, 300, 800], fov: 65, near: 1, far: 12000 }}
         gl={{
           antialias: true,
-          logarithmicDepthBuffer: true,
           powerPreference: "high-performance",
           toneMapping: THREE.ACESFilmicToneMapping,
           toneMappingExposure: 1.2,

--- a/src/components/SunnyWeather.tsx
+++ b/src/components/SunnyWeather.tsx
@@ -213,7 +213,8 @@ export const SunnyWeather = ({
         shadow-camera-right={1500}
         shadow-camera-top={1500}
         shadow-camera-bottom={-1500}
-        shadow-bias={-0.0002}
+        shadow-bias={-0.0005}
+        shadow-normalBias={0.04}
       />
 
       {/* Warm Ambient Reflection Secondary Bounce */}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the visual rendering artifacts reported in the scene when interacting with the 3D city map. Specifically, it resolves two major graphics issues:

1. **Shadow Map Acne:** Added `shadow-bias` and `shadow-normalBias` to the main directional light source. This eliminates the jagged, dark moiré patterns and shadow lines that appeared across flat building roofs and terrain.
2. **Z-Fighting & Depth Precision Loss:** Enabled `logarithmicDepthBuffer` on the Canvas and optimized the camera's `near` clipping plane. This prevents textures and co-planar elements (like the grid lines and building bases) from violently flickering and fighting for depth depth priority when the camera zooms out.
3. **Line Aliasing:** Ensured robust hardware antialiasing and proper device pixel ratio (`dpr`) scaling for smoother high-frequency line rendering.

## Related issue

Fixes #568

<!-- Before/after if visual changes -->
| Before | After |
|--------|-------|
| *<img width="1918" height="983" alt="Screenshot 2026-06-17 122351" src="https://github.com/user-attachments/assets/322e9080-3ceb-4bbb-8b5b-1f53cca65311" />* | *<img width="1918" height="985" alt="Screenshot 2026-06-18 202009" src="https://github.com/user-attachments/assets/52544085-4e89-4f2c-8c2e-197cd16fda3f" />* |

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)