### PR TITLE
fix: translate share card taunts to english

### DIFF
--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -559,23 +559,23 @@ const TAUNTS: Record<Lang, { rank: [number, string][]; contribs: [number, string
   },
   pt: {
     rank: [
-      [5, "EU SOU O HORIZONTE"],
-      [15, "A VISTA DAQUI DE CIMA E INSANA"],
-      [50, "DA PRA VER SEU PRÉDIO DAQUI"],
-      [100, "MEU ELEVADOR NAO DESCE ATE AI"],
-      [250, "SÓ COBERTURA"],
-      [500, "MEU PRÉDIO TEM PISCINA NO TOPO"],
-      [1000, "NADA MAL PRA QUEM DORME"],
+      [5, "I AM THE SKYLINE"],
+      [15, "THE VIEW FROM UP HERE IS INSANE"],
+      [50, "I CAN SEE YOUR BUILDING FROM HERE"],
+      [100, "MY ELEVATOR DOESN'T GO THAT LOW"],
+      [250, "PENTHOUSE VIBES ONLY"],
+      [500, "MY BUILDING HAS A ROOFTOP POOL"],
+      [1000, "NOT BAD FOR SOMEONE WHO SLEEPS"],
     ],
     contribs: [
-      [5000, "EU NAO TOCO GRAMA. EU FAÇO PUSH."],
-      [2000, "SEU PRÉDIO CABE NO MEU LOBBY"],
-      [1000, "MEUS COMMITS TEM COMMITS"],
-      [500, "MAIS ALTO QUE SUA PACIÊNCIA"],
-      [200, "PRÉDIO PEQUENO, ENERGIA GRANDE"],
-      [50, "TODO ARRANHA-CEU COMEÇA EM ALGUM LUGAR"],
+      [5000, "I DON'T TOUCH GRASS. I PUSH CODE."],
+      [2000, "YOUR BUILDING FITS IN MY LOBBY"],
+      [1000, "MY COMMITS HAVE COMMITS"],
+      [500, "TALLER THAN YOUR ATTENTION SPAN"],
+      [200, "SMALL BUILDING, BIG ENERGY"],
+      [50, "EVERY SKYSCRAPER STARTS SOMEWHERE"],
     ],
-    fallback: "ACABEI DE CHEGAR. ME OBSERVE.",
+    fallback: "JUST MOVED IN. WATCH ME GROW.",
   }
 };
 


### PR DESCRIPTION
## What changed
- Translated the remaining Portuguese taunts in the share card API to English.
- Kept the ranking and contribution thresholds intact while making the copy consistent.

## Why
- The issue requested removing hardcoded Portuguese strings from the share card payload.
- This keeps the generated card text readable for the wider audience.

## Validation
- `git diff --check`
- `rg -n "ARRANHA|PRÉDIO|PRÉDIO|COMEÇA|ACABEI|FAÇO|NAO|PRA|LUGAR|TODO" src/app/api/share-card/[username]/route.tsx`

Closes #613