### PR TITLE
fix: align activity ticker with leetcode terms

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -149,7 +149,7 @@ export async function GET(request: Request) {
 async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, count: number) {
   const { data: devs } = await sb
     .from("developers")
-    .select("id, github_login, contributions, total_stars, rank, contributions_total, current_streak, primary_language, public_repos")
+    .select("id, github_login, contributions, contributions_total, total_stars, rank, lc_streak")
     .order("contributions", { ascending: false })
     .limit(50);
 
@@ -173,7 +173,12 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
     // Pick a random synthetic event type for each dev
     const roll = Math.random();
 
-    if (roll < 0.25 && dev.contributions > 0) {
+    const solvedCount =
+      dev.contributions_total && dev.contributions_total > 0
+        ? dev.contributions_total
+        : dev.contributions ?? 0;
+
+    if (roll < 0.25 && solvedCount > 0) {
       events.push({
         id: `syn-contrib-${dev.id}`,
         event_type: "dev_highlight",
@@ -182,7 +187,7 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
         metadata: {
           login: dev.github_login,
           highlight: "contributions",
-          value: dev.contributions,
+          value: solvedCount,
         },
         created_at: new Date().toISOString(),
       });
@@ -212,7 +217,7 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
         },
         created_at: new Date().toISOString(),
       });
-    } else if (roll < 0.75 && dev.current_streak && dev.current_streak > 0) {
+    } else if (roll < 0.75 && dev.lc_streak && dev.lc_streak > 0) {
       events.push({
         id: `syn-streak-${dev.id}`,
         event_type: "dev_highlight",
@@ -221,33 +226,7 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
         metadata: {
           login: dev.github_login,
           highlight: "streak",
-          value: dev.current_streak,
-        },
-        created_at: new Date().toISOString(),
-      });
-    } else if (dev.primary_language) {
-      events.push({
-        id: `syn-lang-${dev.id}`,
-        event_type: "dev_highlight",
-        actor_id: dev.id,
-        target_id: null,
-        metadata: {
-          login: dev.github_login,
-          highlight: "language",
-          value: dev.primary_language,
-        },
-        created_at: new Date().toISOString(),
-      });
-    } else if (dev.public_repos > 0) {
-      events.push({
-        id: `syn-repos-${dev.id}`,
-        event_type: "dev_highlight",
-        actor_id: dev.id,
-        target_id: null,
-        metadata: {
-          login: dev.github_login,
-          highlight: "repos",
-          value: dev.public_repos,
+          value: dev.lc_streak,
         },
         created_at: new Date().toISOString(),
       });

--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -55,17 +55,13 @@ function formatEvent(e: FeedEvent): string {
       const login = meta.login ? `@${meta.login}` : actor;
       switch (meta.highlight) {
         case "contributions":
-          return `#  ${login}'s building has ${Number(meta.value).toLocaleString()} contributions`;
+          return `#  ${login} has ${Number(meta.value).toLocaleString()} solved LeetCode problems`;
         case "stars":
-          return `*  ${login} has ${Number(meta.value).toLocaleString()} stars across their repos`;
+          return `*  ${login} has ${Number(meta.value).toLocaleString()} reputation points on LeetCode`;
         case "rank":
           return `>>  ${login} is ranked #${meta.value} in the city`;
         case "streak":
-          return `~  ${login} is on a ${meta.value}-day commit streak`;
-        case "language":
-          return `<>  ${login} builds with ${meta.value}`;
-        case "repos":
-          return `{}  ${login} has ${meta.value} public repos`;
+          return `~  ${login} is on a ${meta.value}-day LeetCode active streak`;
         default:
           return `${login} is in the city`;
       }


### PR DESCRIPTION
## What changed
- Updated synthetic feed generation to use LeetCode-oriented data for highlights.
- Removed GitHub-flavored synthetic highlights for language and public repo metrics.
- Reworded the activity ticker copy to speak in LeetCode terms for solved problems, reputation points, and active streaks.

## Why
- The ticker was surfacing GitHub terminology in a LeetCode product.
- This keeps the feed language aligned with the app and the issue request.

## Validation
- `git diff --check`
- `npm run lint -- src/app/api/feed/route.ts src/components/ActivityTicker.tsx`
- Captured a local screenshot proof of the updated wording at `/tmp/leetcode-city-ticker-proof.png`

Closes #619