### PR TITLE
fix(visit): only credit daily missions on a unique building visit

### DIFF
--- a/src/app/api/interactions/visit/route.ts
+++ b/src/app/api/interactions/visit/route.ts
@@ -61,8 +61,6 @@ export async function POST(request: Request) {
 
   // Track activity
   await touchLastActive(visitor.id);
-  await trackDailyMission(visitor.id, "visit_building");
-  await trackDailyMission(visitor.id, "visit_3_buildings");
 
   // No self-visits
   if (visitor.id === building.id) {
@@ -95,6 +93,10 @@ export async function POST(request: Request) {
 
     // Grant XP for visiting a building
     await admin.rpc("grant_xp_atomic", { p_developer_id: visitor.id, p_source: "visit", p_amount: 2 });
+
+    // Only credit daily missions for genuine, unique visits
+    await trackDailyMission(visitor.id, "visit_building");
+    await trackDailyMission(visitor.id, "visit_3_buildings");
 
     // Check if building crossed visit milestone (>5 visits today)
     const { count: todayVisits } = await admin


### PR DESCRIPTION
## What does this PR do?

The `visit_building` / `visit_3_buildings` daily missions were credited on every POST to `/api/interactions/visit`, before the self-visit guard, the 50/day limit check and the deduplicated `building_visits` insert. That let you complete "Visit 3 buildings" by hitting the same building (or your own) three times.

Moved both `trackDailyMission` calls into the existing `if (!insertError)` block, right after the XP grant which already gates on a genuine, unique visit. `touchLastActive` stays where it is since presence isn't an exploit surface.

## Related issue

Fixes #624

## Screenshots

n/a (backend only)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
