### PR TITLE
fix(dailies): credit missions assigned on either device profile

### DIFF
--- a/src/lib/__tests__/dailies-mobile-flag.test.ts
+++ b/src/lib/__tests__/dailies-mobile-flag.test.ts
@@ -115,6 +115,30 @@ describe("trackDailyMission", () => {
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
+  it("credits a mobile-only assigned mission even when it is absent from the desktop set", async () => {
+    // Find a seed where a non-desktopOnly mission appears in the mobile set
+    // but NOT in the desktop set (happens when desktopOnly missions occupy the
+    // desktop secondary slots). Such a mission must still be credited.
+    let targetId: number | null = null;
+    let missionId: string | null = null;
+    for (let id = 1; id <= 1000; id++) {
+      const mobile = getDailyMissions(id, DATE, true).slice(1);
+      const desktopIds = new Set(getDailyMissions(id, DATE, false).map((m) => m.id));
+      const mobileOnly = mobile.find((m) => !desktopIds.has(m.id));
+      if (mobileOnly) {
+        targetId = id;
+        missionId = mobileOnly.id;
+        break;
+      }
+    }
+    if (!targetId || !missionId) return; // skip if not found in range
+
+    await trackDailyMission(targetId, missionId);
+    expect(mockRpc).toHaveBeenCalledWith("record_mission_progress", expect.objectContaining({
+      p_mission_id: missionId,
+    }));
+  });
+
   it("may record fly_score_50 when isMobile=false and mission is assigned", async () => {
     let targetId: number | null = null;
     for (let id = 1; id <= 500; id++) {

--- a/src/lib/dailies.ts
+++ b/src/lib/dailies.ts
@@ -96,12 +96,18 @@ export function getTodayStr(): string {
 export async function trackDailyMission(
   developerId: number,
   missionId: string,
-  extra?: { score?: number; isMobile?: boolean },  // ← add isMobile here
+  extra?: { score?: number; isMobile?: boolean },
 ): Promise<void> {
   try {
     const today = getTodayStr();
-    const missions = getDailyMissions(developerId, today, extra?.isMobile ?? false);  // ← forward flag
-    const mission = missions.find((m) => m.id === missionId);
+    // A user's assigned missions can differ between mobile and desktop
+    // (desktopOnly missions shift the selection), and the device making the
+    // request isn't known here. Credit the mission if it belongs to either
+    // set so mobile users aren't silently denied progress; desktopOnly
+    // missions stay gated by the score checks below.
+    const mission =
+      getDailyMissions(developerId, today, false).find((m) => m.id === missionId) ??
+      getDailyMissions(developerId, today, true).find((m) => m.id === missionId);
     if (!mission) return;
 
     if (missionId === "fly_score_50"  && (extra?.score ?? 0) < 50)  return;


### PR DESCRIPTION
## What does this PR do?

`trackDailyMission` resolved today's missions with `isMobile` defaulting to `false`, and every caller except `/api/dailies` (visit, kudos, raid, fly) omits the flag. Because `getDailyMissions` filters `desktopOnly` missions after the shuffle, a mobile user's two secondary slots can be missions that never appear in the desktop set. In that case tracking looked up the desktop set, didn't find the mission, and silently no-oped, so mobile users got no credit for completing them.

Instead of threading device state through every mutating endpoint, resolve the mission against both the desktop and mobile sets and credit it if it belongs to either. The `desktopOnly` fly missions are still gated by the existing score checks, so this can't over-credit them.

Added a regression test that finds a seed where a mobile mission is absent from the desktop set and asserts it still records progress. Verified it fails on the previous logic.

## Related issue

Fixes #623

## Screenshots

n/a (backend only)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
