### PR TITLE
fix(heartbeats): accumulate session counters atomically and per session

### DIFF
--- a/src/app/api/heartbeats/route.ts
+++ b/src/app/api/heartbeats/route.ts
@@ -106,15 +106,24 @@ export async function POST(request: NextRequest) {
 
   let accepted = 0;
 
-  for (const hb of heartbeats) {
-    // Server generates timestamp, never trust client
-    const now = new Date().toISOString();
-    const isOffline = hb.status === "offline";
+  // Aggregate active heartbeats per session so each session is persisted with
+  // a single atomic RPC (no SELECT-then-upsert per heartbeat). Offline signals
+  // end the session and are applied as direct updates.
+  interface SessionAgg {
+    count: number;
+    activeSeconds: number;
+    language?: string;
+    project?: string;
+    editorName: string;
+    os?: string;
+  }
+  const activeBySession = new Map<string, SessionAgg>();
 
-    if (isOffline) {
+  for (const hb of heartbeats) {
+    if (hb.status === "offline") {
       const { error } = await sb
         .from("developer_sessions")
-        .update({ status: "offline", ended_at: now })
+        .update({ status: "offline", ended_at: new Date().toISOString() })
         .eq("developer_id", dev.id)
         .eq("session_id", hb.sessionId);
 
@@ -122,37 +131,42 @@ export async function POST(request: NextRequest) {
         rejected++;
         continue;
       }
-    } else {
-      const { data: existing } = await sb
-        .from("developer_sessions")
-        .select("total_heartbeats, active_seconds")
-        .eq("developer_id", dev.id)
-        .eq("session_id", hb.sessionId)
-        .single();
-
-      const { error } = await sb.from("developer_sessions").upsert(
-        {
-          developer_id: dev.id,
-          session_id: hb.sessionId,
-          status: "active",
-          current_language: hb.language ?? null,
-          current_project: hb.project ?? null,
-          last_heartbeat_at: now,
-          editor_name: hb.editorName,
-          os: hb.os ?? null,
-          total_heartbeats: (existing?.total_heartbeats ?? 0) + 1,
-          active_seconds: (existing?.active_seconds ?? 0) + hb.activeSeconds,
-        },
-        { onConflict: "developer_id,session_id" },
-      );
-
-      if (error) {
-        rejected++;
-        continue;
-      }
+      accepted++;
+      continue;
     }
 
-    accepted++;
+    // Last writer wins for the descriptive fields; counters accumulate.
+    const agg = activeBySession.get(hb.sessionId) ?? {
+      count: 0,
+      activeSeconds: 0,
+      editorName: hb.editorName,
+    };
+    agg.count += 1;
+    agg.activeSeconds += hb.activeSeconds;
+    agg.language = hb.language;
+    agg.project = hb.project;
+    agg.editorName = hb.editorName;
+    agg.os = hb.os;
+    activeBySession.set(hb.sessionId, agg);
+  }
+
+  for (const [sessionId, agg] of activeBySession) {
+    const { error } = await sb.rpc("record_heartbeat", {
+      p_developer_id: dev.id,
+      p_session_id: sessionId,
+      p_heartbeats: agg.count,
+      p_active_seconds: agg.activeSeconds,
+      p_language: agg.language ?? null,
+      p_project: agg.project ?? null,
+      p_editor_name: agg.editorName,
+      p_os: agg.os ?? null,
+    });
+
+    if (error) {
+      rejected += agg.count;
+      continue;
+    }
+    accepted += agg.count;
   }
 
   // Broadcast to realtime (no internal IDs exposed)

--- a/supabase/migrations/20260621_heartbeat_atomic.sql
+++ b/supabase/migrations/20260621_heartbeat_atomic.sql
@@ -1,0 +1,47 @@
+-- Migration: Atomic heartbeat accumulation
+-- Issue #625
+--
+-- /api/heartbeats accumulated total_heartbeats / active_seconds with a
+-- read-modify-write at the app layer: SELECT the current counters, add the
+-- batch, UPSERT back. Two concurrent flushes for the same session both read
+-- the same base value and the second overwrites the first, losing increments.
+--
+-- record_heartbeat() folds a (pre-aggregated) batch for one session into a
+-- single atomic INSERT ... ON CONFLICT DO UPDATE. Postgres row-level locking
+-- on the UPDATE serializes concurrent calls for the same (developer, session),
+-- so increments can no longer be lost, and the route no longer needs a SELECT
+-- per heartbeat.
+CREATE OR REPLACE FUNCTION record_heartbeat(
+  p_developer_id   BIGINT,
+  p_session_id     TEXT,
+  p_heartbeats     INTEGER,
+  p_active_seconds INTEGER,
+  p_language       TEXT,
+  p_project        TEXT,
+  p_editor_name    TEXT,
+  p_os             TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO developer_sessions (
+    developer_id, session_id, status, current_language, current_project,
+    last_heartbeat_at, editor_name, os, total_heartbeats, active_seconds
+  )
+  VALUES (
+    p_developer_id, p_session_id, 'active', p_language, p_project,
+    NOW(), COALESCE(p_editor_name, 'vscode'), p_os,
+    GREATEST(p_heartbeats, 0), GREATEST(p_active_seconds, 0)
+  )
+  ON CONFLICT (developer_id, session_id) DO UPDATE SET
+    status            = 'active',
+    current_language  = EXCLUDED.current_language,
+    current_project   = EXCLUDED.current_project,
+    last_heartbeat_at = NOW(),
+    editor_name       = EXCLUDED.editor_name,
+    os                = EXCLUDED.os,
+    total_heartbeats  = developer_sessions.total_heartbeats + EXCLUDED.total_heartbeats,
+    active_seconds    = developer_sessions.active_seconds + EXCLUDED.active_seconds;
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

The active branch of `/api/heartbeats` read `total_heartbeats` / `active_seconds` and then wrote `value + 1` per heartbeat. Two flushes for the same session (two editor windows, or a retried batch) both read the same base and the second overwrites the first, so increments get lost. It also ran a SELECT plus an upsert for every heartbeat, so a full 25-item batch was up to 50 sequential round-trips.

Added a `record_heartbeat` RPC (migration `20260621_heartbeat_atomic.sql`) that folds a session's batch into one `INSERT ... ON CONFLICT DO UPDATE` with `total_heartbeats = ... + EXCLUDED.total_heartbeats`. Row-level locking on the update serializes concurrent calls for the same session, so no more lost counts.

In the route, active heartbeats are now aggregated per session (counters summed, descriptive fields last-writer-wins) and persisted with one RPC call per session instead of a query per heartbeat. Offline signals stay a direct update.

## Related issue

Fixes #625

## Screenshots

n/a (backend only)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
