### PR TITLE
fix: replace GitHub terminology with LeetCode metrics in Activity Ticker

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -149,7 +149,7 @@ export async function GET(request: Request) {
 async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, count: number) {
   const { data: devs } = await sb
     .from("developers")
-    .select("id, github_login, contributions, total_stars, rank, contributions_total, current_streak, primary_language, public_repos")
+    .select("id, github_login, contributions, total_stars, rank, lc_streak")
     .order("contributions", { ascending: false })
     .limit(50);
 
@@ -188,13 +188,13 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
       });
     } else if (roll < 0.45 && dev.total_stars > 0) {
       events.push({
-        id: `syn-stars-${dev.id}`,
+        id: `syn-rep-${dev.id}`,
         event_type: "dev_highlight",
         actor_id: dev.id,
         target_id: null,
         metadata: {
           login: dev.github_login,
-          highlight: "stars",
+          highlight: "reputation",   // renamed from "stars"
           value: dev.total_stars,
         },
         created_at: new Date().toISOString(),
@@ -212,42 +212,16 @@ async function generateSyntheticEvents(sb: ReturnType<typeof getSupabaseAdmin>, 
         },
         created_at: new Date().toISOString(),
       });
-    } else if (roll < 0.75 && dev.current_streak && dev.current_streak > 0) {
+    } else if (roll < 0.75 && dev.lc_streak && dev.lc_streak > 0) {
       events.push({
-        id: `syn-streak-${dev.id}`,
+        id: `syn-lcstreak-${dev.id}`,
         event_type: "dev_highlight",
         actor_id: dev.id,
         target_id: null,
         metadata: {
           login: dev.github_login,
-          highlight: "streak",
-          value: dev.current_streak,
-        },
-        created_at: new Date().toISOString(),
-      });
-    } else if (dev.primary_language) {
-      events.push({
-        id: `syn-lang-${dev.id}`,
-        event_type: "dev_highlight",
-        actor_id: dev.id,
-        target_id: null,
-        metadata: {
-          login: dev.github_login,
-          highlight: "language",
-          value: dev.primary_language,
-        },
-        created_at: new Date().toISOString(),
-      });
-    } else if (dev.public_repos > 0) {
-      events.push({
-        id: `syn-repos-${dev.id}`,
-        event_type: "dev_highlight",
-        actor_id: dev.id,
-        target_id: null,
-        metadata: {
-          login: dev.github_login,
-          highlight: "repos",
-          value: dev.public_repos,
+          highlight: "lc_streak",    // renamed from "streak"
+          value: dev.lc_streak,
         },
         created_at: new Date().toISOString(),
       });

--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -56,16 +56,12 @@ function formatEvent(e: FeedEvent): string {
       switch (meta.highlight) {
         case "contributions":
           return `#  ${login}'s building has ${Number(meta.value).toLocaleString()} contributions`;
-        case "stars":
-          return `*  ${login} has ${Number(meta.value).toLocaleString()} stars across their repos`;
         case "rank":
           return `>>  ${login} is ranked #${meta.value} in the city`;
-        case "streak":
-          return `~  ${login} is on a ${meta.value}-day commit streak`;
-        case "language":
-          return `<>  ${login} builds with ${meta.value}`;
-        case "repos":
-          return `{}  ${login} has ${meta.value} public repos`;
+        case "reputation":
+          return `⭐ ${login} has ${Number(meta.value).toLocaleString()} reputation points on LeetCode`;
+        case "lc_streak":
+          return `🔥 ${login} is on a ${meta.value}-day LeetCode active streak`;
         default:
           return `${login} is in the city`;
       }


### PR DESCRIPTION
## What does this PR do?

Fixes the Activity Ticker displaying GitHub-specific terminology instead of LeetCode metrics.

The synthetic event generator in `feed/route.ts` was querying GitHub columns (`current_streak`, `public_repos`, `primary_language`, `total_stars`) and the formatter in `ActivityTicker.tsx` was displaying strings like:
- `"stars across their repos"`
- `"commit streak"`
- `"public repos"`
- `"builds with [Language]"`

**Changes made:**

**`route.ts`**
- Updated `generateSyntheticEvents` to query `lc_streak` instead of GitHub columns
- Replaced `"stars"` highlight key with `"reputation"` pointing to `total_stars` (LeetCode reputation)
- Replaced `"streak"` highlight key with `"lc_streak"` pointing to `lc_streak` column
- Removed `language` and `repos` event blocks entirely
- Fixed probability range ordering so `reputation` block is no longer dead code

**`ActivityTicker.tsx`**
- Updated `formatEvent` to show `⭐ has X reputation points on LeetCode` for `"reputation"`
- Updated `formatEvent` to show `🔥 is on a X-day LeetCode active streak` for `"lc_streak"`
- Removed GitHub-specific `"stars"`, `"streak"`, `"language"`, `"repos"` cases

## Related issue
Fixes #619

## Screenshots

| Before | After |
|--------|-------|
| <img width="1258" alt="before" src="https://github.com/user-attachments/assets/f29f700c-b842-47dd-87d9-17b15104eba3" /> | <img width="1249" alt="after" src="https://github.com/user-attachments/assets/807f280e-4c80-45dc-a29a-48d88b5e741b" /> |

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**