### PR TITLE
fix(ticker): replace flex with inline-flex to fix marquee stutter on loop #618

### DIFF
--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -98,15 +98,15 @@ export default function ActivityTicker({
 
   return (
     <div
-      className={`fixed ${hasBottomBar ? "bottom-[46px]" : "bottom-0"} sm:bottom-0 left-0 right-0 z-30 flex h-7 items-center border-t border-border/30 bg-bg/90 backdrop-blur-sm`}
+      className={`fixed ${hasBottomBar ? "bottom-11.5" : "bottom-0"} sm:bottom-0 left-0 right-0 z-30 flex h-7 items-center border-t border-border/30 bg-bg/90 backdrop-blur-sm`}
     >
       <div
         className="min-w-0 flex-1 overflow-hidden cursor-pointer"
         onClick={onOpenPanel}
       >
         <div
-          className="ticker-scroll flex whitespace-nowrap"
-          style={{ "--ticker-duration": `${Math.max(20, tickerText.length)}s` } as React.CSSProperties}
+          className="ticker-scroll inline-flex whitespace-nowrap"
+          style={{ "--ticker-duration": `${Math.max(20, tickerText.length * 8)}s` } as React.CSSProperties}
         >
           {[...tickerText, ...tickerText].map((item, i) => (
             <span


### PR DESCRIPTION
## What does this PR do?

Fixes the activity ticker marquee stuttering and jumping during its loop by changing `display: flex` to `display: inline-flex` on the `.ticker-scroll` container.

- With `flex`, the container stretches to 100% of the viewport width, so `translateX(-50%)` translates by half the viewport, not half the content which was causing a visible jump on each loop reset. 
- Switching to `inline-flex` makes the container shrink-wrap to `max-content` width, so `-50%` translates exactly one copy of the duplicated content, producing a seamless infinite loop.

## Related issue

Fixes #618

## Screenshots / Videos

### ❌ Before — Ticker stutters and jumps on loop

https://github.com/user-attachments/assets/afe5093e-9f49-43ec-aff6-0b413ebd568f

### ✅ After — Ticker loops smoothly with no jump 

https://github.com/user-attachments/assets/0ba58a34-b21c-490e-9179-1767d4ae8c82

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**