### PR TITLE
feat: Implement Web Push Notifications System (#615)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,4 +89,17 @@ ARENA_CRYPTO_KEY=
 # Comma-separated list of GitHub usernames permitted to edit maps/portals.
 ADMIN_GITHUB_LOGINS=
 # Secure random string/key for auth.
-ARCADE_ADMIN_KEY=
+ARCADE_ADMIN_KEY=
+
+# ── Web Push / VAPID (push notifications) ───────────────────
+# Required to send browser push notifications via the web-push library.
+# Generate once with: npx web-push generate-vapid-keys
+#
+# ⚠️ Changing these keys invalidates ALL existing push subscriptions and every user will need to re-subscribe. 
+# ⚠️ Only rotate if compromised.
+#
+# NEXT_PUBLIC_VAPID_PUBLIC_KEY is exposed to the browser (safe to share).
+# VAPID_PRIVATE_KEY is server-only and never commit a real value here.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_EMAIL=

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,57 @@
-self.addEventListener("push", function (event) {
-  const data = event.data ? event.data.json() : {};
+// ── Push event ──────────────────────────────────────────────────────────────
+// Fired when the server sends a push message via web-push (dispatchPush in
+// notifications.ts). The payload matches the JSON built in that function.
 
-  const title = data.title || "Notification";
-  const options = {
-    body: data.body || "You have a new update",
-    icon: "/icon-192.png",
-  };
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
 
-  event.waitUntil(self.registration.showNotification(title, options));
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    // Fallback if the push body is plain text instead of JSON
+    payload = { title: "New notification", body: event.data.text(), data: {} };
+  }
+
+  const { title, body, icon, badge, data } = payload;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: icon || "/icons/icon-192x192.png",
+      badge: badge || "/icons/badge-72x72.png",
+      data: data || {},
+      // `tag` collapses duplicate notifications (same tag = replace, not stack)
+      tag: data?.tag || "default",
+      renotify: true, // vibrate/sound even when replacing a same-tag notification
+    })
+  );
+});
+
+// ── Notification click event ─────────────────────────────────────────────────
+// Fired when the user taps/clicks a notification in the OS notification tray.
+// We close the notification and navigate to the action URL.
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  // `data.url` is set by dispatchPush() via payload.actionUrl
+  const url = event.notification.data?.url || "/";
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((windowClients) => {
+        // If the target URL is already open in a tab, just focus it
+        for (const client of windowClients) {
+          if (client.url === url && "focus" in client) {
+            return client.focus();
+          }
+        }
+        // Otherwise open a new tab
+        if (clients.openWindow) {
+          return clients.openWindow(url);
+        }
+      })
+  );
 });

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+// ── POST /api/push/subscribe ─────────────────────────────────────────────────
+// Body: { developerId: number, subscription: PushSubscriptionJSON, platform: string }
+//
+// PushSubscriptionJSON looks like:
+//   { endpoint: string, keys: { p256dh: string, auth: string } }
+//
+// We store the entire object as JSON text in the `token` column so
+// dispatchPush() can JSON.parse() it and pass it straight to web-push.
+// Upsert on `token` (unique) so re-subscribing the same device doesn't
+// duplicate rows, and re-activates a previously deactivated subscription.
+
+export async function POST(req: Request) {
+  try {
+    const { developerId, subscription, platform } = await req.json();
+
+    if (!developerId || !subscription?.endpoint) {
+      return NextResponse.json(
+        { error: "Missing required fields: developerId and subscription.endpoint" },
+        { status: 400 }
+      );
+    }
+
+    const sb = getSupabaseAdmin();
+
+    const { error } = await sb.from("push_subscriptions").upsert(
+      {
+        developer_id: developerId,
+        token: JSON.stringify(subscription), // store full PushSubscription JSON
+        platform: platform || "web",
+        active: true,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "token" } // unique index on token prevents duplicates
+    );
+
+    if (error) {
+      console.error("[api/push/subscribe] DB upsert error:", error);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[api/push/subscribe] POST error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── DELETE /api/push/subscribe ───────────────────────────────────────────────
+// Body: { developerId: number, endpoint: string }
+//
+// We mark the row inactive rather than hard-deleting it so we retain audit
+// history and dispatchPush() can see that the subscription was voluntarily
+// removed (vs. expired — those are marked inactive by 404/410 error handling).
+//
+// NOTE: The endpoint is stored inside the JSON `token` column. We filter by
+// developer_id + LIKE to locate it. For a high-scale app, add a separate
+// indexed `endpoint text unique` column (see docs/web-push-setup.md).
+
+export async function DELETE(req: Request) {
+  try {
+    const { developerId, endpoint } = await req.json();
+
+    if (!developerId || !endpoint) {
+      return NextResponse.json(
+        { error: "Missing required fields: developerId and endpoint" },
+        { status: 400 }
+      );
+    }
+
+    const sb = getSupabaseAdmin();
+
+    const { error } = await sb
+      .from("push_subscriptions")
+      .update({ active: false, updated_at: new Date().toISOString() })
+      .eq("developer_id", developerId)
+      .like("token", `%${endpoint}%`); // endpoint is inside the stored JSON
+
+    if (error) {
+      console.error("[api/push/subscribe] DB update error:", error);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[api/push/subscribe] DELETE error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -20,11 +20,11 @@ interface UsePushNotificationsReturn {
 
 // The VAPID public key is stored as URL-safe base64; the browser's
 // pushManager.subscribe() needs it as a Uint8Array (applicationServerKey).
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
+function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const rawData = atob(base64);
-  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0))).buffer as ArrayBuffer;
 }
 
 // Best-effort platform label stored alongside the subscription so the server

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export type SubscriptionState =
+  | "loading"
+  | "unsupported"
+  | "denied"
+  | "unsubscribed"
+  | "subscribed";
+
+interface UsePushNotificationsReturn {
+  state: SubscriptionState;
+  subscribe: () => Promise<void>;
+  unsubscribe: () => Promise<void>;
+  error: string | null;
+}
+
+// ── Utility ──────────────────────────────────────────────────────────────────
+
+// The VAPID public key is stored as URL-safe base64; the browser's
+// pushManager.subscribe() needs it as a Uint8Array (applicationServerKey).
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}
+
+// Best-effort platform label stored alongside the subscription so the server
+// can log which devices a push was delivered to.
+function getPlatform(): string {
+  const ua = navigator.userAgent;
+  if (/android/i.test(ua)) return "android";
+  if (/iphone|ipad|ipod/i.test(ua)) return "ios";
+  return "web";
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function usePushNotifications(developerId: number): UsePushNotificationsReturn {
+  const [state, setState] = useState<SubscriptionState>("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  // On mount: detect support + check if already subscribed
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      !("PushManager" in window)
+    ) {
+      setState("unsupported");
+      return;
+    }
+
+    if (Notification.permission === "denied") {
+      setState("denied");
+      return;
+    }
+
+    // Check if there's an existing active subscription
+    navigator.serviceWorker.ready.then(async (reg) => {
+      const existing = await reg.pushManager.getSubscription();
+      setState(existing ? "subscribed" : "unsubscribed");
+    });
+  }, []);
+
+  // ── Subscribe ──────────────────────────────────────────────────────────────
+
+  const subscribe = useCallback(async () => {
+    setError(null);
+    setState("loading");
+
+    try {
+      // Register the service worker if not already registered.
+      // navigator.serviceWorker.register() is idempotent — safe to call repeatedly.
+      await navigator.serviceWorker.register("/sw.js");
+      const reg = await navigator.serviceWorker.ready;
+
+      // Ask the browser for notification permission
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setState("denied");
+        return;
+      }
+
+      // NEXT_PUBLIC_VAPID_PUBLIC_KEY must be set in .env.local
+      const vapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+      if (!vapidKey) {
+        throw new Error(
+          "NEXT_PUBLIC_VAPID_PUBLIC_KEY is not set. " +
+          "Run `npx web-push generate-vapid-keys` and add it to .env.local"
+        );
+      }
+
+      // Create the push subscription in the browser
+      const subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true, // required — browser will always show a notification
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+
+      // Persist the subscription in the database via our API route
+      const res = await fetch("/api/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          developerId,
+          subscription: subscription.toJSON(), // { endpoint, keys: { p256dh, auth } }
+          platform: getPlatform(),
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Failed to save subscription: ${text}`);
+      }
+
+      setState("subscribed");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to subscribe";
+      setError(msg);
+      setState("unsubscribed");
+      console.error("[usePushNotifications] subscribe error:", err);
+    }
+  }, [developerId]);
+
+  // ── Unsubscribe ────────────────────────────────────────────────────────────
+
+  const unsubscribe = useCallback(async () => {
+    setError(null);
+    setState("loading");
+
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const subscription = await reg.pushManager.getSubscription();
+
+      if (subscription) {
+        // Remove from browser
+        await subscription.unsubscribe();
+
+        // Mark inactive in the database
+        await fetch("/api/push/subscribe", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            developerId,
+            endpoint: subscription.endpoint,
+          }),
+        });
+      }
+
+      setState("unsubscribed");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to unsubscribe";
+      setError(msg);
+      setState("subscribed"); // Roll back — we don't know if it actually unsubscribed
+      console.error("[usePushNotifications] unsubscribe error:", err);
+    }
+  }, [developerId]);
+
+  return { state, subscribe, unsubscribe, error };
+}


### PR DESCRIPTION
## What does this PR do?

Implements a fully functional Web Push notifications system using the `web-push` 
library and standard browser Service Worker APIs.

The server-side `dispatchPush()` in `src/lib/notifications.ts` was already 
implemented but had no client-side counterpart — meaning push subscriptions could 
never be created and push could never fire. This PR adds all the missing pieces:

- **`public/sw.js`** — Updated service worker that handles incoming `push` events 
  (shows OS notification) and `notificationclick` events (focuses/opens the correct 
  tab). Added `badge`, `tag`, `renotify`, and `data.url` support.

- **`src/hooks/usePushNotifications.ts`** — New React hook managing the full 
  subscription lifecycle: SW registration → permission request → 
  `pushManager.subscribe()` with VAPID key → POST to API. Also handles unsubscribe.

- **`src/app/api/push/subscribe/route.ts`** — New API route with `POST` (saves 
  PushSubscription to `push_subscriptions` table) and `DELETE` (marks inactive on 
  unsubscribe). Upserts on `token` to prevent duplicate rows.

- **`.env.example`** — Added `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, 
  and `VAPID_EMAIL` with comments explaining how to generate them.

- **`WEB_PUSH_SETUP.md`** — New setup guide covering VAPID key generation, DB 
  schema, environment variables, how all pieces connect, and Vercel deployment steps.

## Related issue

Fixes #615

## Screenshots

N/A — no visual changes (hook-based, no UI component included; 
UI toggle can be wired up using the exported `usePushNotifications` hook)

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ I have starred this repository!