### PR TITLE
fix: use valid default tab in leaderboard-position api

### DIFF
--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -6,7 +6,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const tab = searchParams.get("tab") ?? "contributors";
+  const tab = searchParams.get("tab") ?? "solved";
   const login = searchParams.get("login")?.toLowerCase();
 
   if (!login) {


### PR DESCRIPTION
## What does this PR do?

Updates the `/api/leaderboard-position` endpoint to use a supported default tab value when the `tab` query parameter is omitted.

Previously, the endpoint defaulted to `"contributors"`, which is not a valid leaderboard tab and is not handled by the leaderboard position calculation logic. This could result in incomplete or incorrect position and metric data being returned.

The default value has been changed to `"solved"`.

## Related issue

Fixes #672

## Screenshots

N/A

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
