### PR TITLE
fix: prevent stale state in arcade favorite toggle

### DIFF
--- a/src/app/arcade/page.tsx
+++ b/src/app/arcade/page.tsx
@@ -112,11 +112,17 @@ export default function ArcadeBrowserPage() {
   };
 
   const toggleFavorite = async (roomId: string) => {
+    // Capture snapshot for rollback (snapshot at click time)
     const prev = new Set(favorites);
-    const next = new Set(favorites);
-    if (next.has(roomId)) next.delete(roomId);
-    else next.add(roomId);
-    setFavorites(next);
+
+    // Use functional updater to avoid operating on a stale `favorites` snapshot
+    // when multiple toggles happen before a rerender.
+    setFavorites((cur) => {
+      const next = new Set(cur);
+      if (next.has(roomId)) next.delete(roomId);
+      else next.add(roomId);
+      return next;
+    });
 
     try {
       const res = await fetch("/api/arcade/favorites", {


### PR DESCRIPTION
## What does this PR do?

Fixes a stale state issue in the Arcade favorites toggle.

Previously, optimistic updates were derived from a closure-captured `favorites` state snapshot. During rapid consecutive toggle actions, multiple updates could be calculated from the same stale snapshot, resulting in an incorrect final favorite state.

This change updates the toggle logic to use a functional state updater so each toggle is computed from the latest available state while preserving existing rollback behavior when the API request fails.

## Related issue

Fixes #673

## Screenshots

N/A

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
