### PR TITLE
[GSSoC'26] fix: replace per-process Map rate limiter with centralized rateLimit() in support/checkout

### DIFF
--- a/src/app/api/support/checkout/route.ts
+++ b/src/app/api/support/checkout/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
     request.headers.get("x-real-ip") ??
     "unknown";
 
-  const { ok } = rateLimit(`checkout:${ip}`, 1, 5_000);
+  const { ok } = await rateLimit(`checkout:${ip}`, 1, 5_000);
   if (!ok) {
     return NextResponse.json({ error: "Too fast. Wait a few seconds." }, { status: 429 });
   }

--- a/src/app/api/support/checkout/route.ts
+++ b/src/app/api/support/checkout/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ paymentSessionId, orderId });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Support checkout error:", err);
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to create checkout" },

--- a/src/app/api/support/checkout/route.ts
+++ b/src/app/api/support/checkout/route.ts
@@ -1,27 +1,20 @@
 import { NextResponse } from "next/server";
 import { getBaseUrl } from "@/lib/base-url";
 import { createCashfreeOrder } from "@/lib/cashfree";
+import { rateLimit } from "@/lib/rate-limit";
 
 const MIN_AMOUNT = 10; // minimum ₹10 INR for checkouts
 
-// Simple IP-based rate limit (1 request per 5 seconds)
-const lastRequest = new Map<string, number>();
-
-/**
- * @param {Request} request
- */
 export async function POST(request: Request) {
   const ip =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     request.headers.get("x-real-ip") ??
     "unknown";
 
-  const now = Date.now();
-  const last = lastRequest.get(ip);
-  if (last && now - last < 5_000) {
+  const { ok } = rateLimit(`checkout:${ip}`, 1, 5_000);
+  if (!ok) {
     return NextResponse.json({ error: "Too fast. Wait a few seconds." }, { status: 429 });
   }
-  lastRequest.set(ip, now);
 
   let body: { amount: number; email?: string; name?: string; phone?: string };
   try {


### PR DESCRIPTION
## What does this PR do?

Replaced the per-process `Map<string, number>()` rate limiter in `/api/support/checkout` with the centralized `rateLimit()` utility from `@/lib/rate-limit`. This makes the checkout route consistent with all other rate-limited routes in the codebase and avoids the per-instance bypass vulnerability on serverless deployments.

## Related issue

Closes #691

## Screenshots

N/A — logic-only change, no visual impact.

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Diff: 3 insertions, 10 deletions — only rate-limit logic changed. All other routes use the same `rateLimit()` pattern without issue.

## Known Limitations

- None. Rate-limit behavior is identical (1 req / 5s per IP)

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.
