### PR TITLE
[GSSoC'26] fix: stop encrypting hidden_tests that are identical to sample_tests (closes #689)

### DIFF
--- a/src/app/api/arena/challenge/[id]/route.ts
+++ b/src/app/api/arena/challenge/[id]/route.ts
@@ -44,6 +44,7 @@ export async function GET(
     return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const prob = challenge.problem as any;
   if (!prob) {
     return NextResponse.json({ error: "Associated problem not found" }, { status: 404 });

--- a/src/app/api/arena/challenge/[id]/route.ts
+++ b/src/app/api/arena/challenge/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
-import { getAuthenticatedDeveloper, encryptHiddenTests } from "@/lib/arena";
+import { getAuthenticatedDeveloper } from "@/lib/arena";
 
 export async function GET(
   request: NextRequest,
@@ -49,10 +49,6 @@ export async function GET(
     return NextResponse.json({ error: "Associated problem not found" }, { status: 404 });
   }
 
-  // Encrypt the hidden tests
-  const hiddenTests = prob.hidden_tests || [];
-  const encrypted = encryptHiddenTests(hiddenTests);
-
   const responsePayload = {
     id: challenge.id,
     difficulty: challenge.difficulty,
@@ -68,8 +64,7 @@ export async function GET(
       time_limit_ms: prob.time_limit_ms,
       memory_limit_mb: prob.memory_limit_mb,
       sample_tests: prob.sample_tests,
-      encrypted_hidden_tests: encrypted.encryptedData,
-      iv: encrypted.iv
+      hidden_tests: prob.hidden_tests || []
     }
   };
 

--- a/src/lib/arena.ts
+++ b/src/lib/arena.ts
@@ -1,6 +1,8 @@
 import { getSupabaseAdmin } from "./supabase";
 import { createServerSupabase } from "./supabase-server";
 import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 
 const MIN_ARENA_CRYPTO_KEY_LENGTH = 32;
 
@@ -192,8 +194,8 @@ export async function scrapeCodeforcesProblem(contestId: number, index: string) 
       timeLimitMs,
       memoryLimitMb,
     };
-  } catch (err: any) {
-    console.error(`Error scraping problem ${contestId}${index}:`, err.message);
+  } catch (err: unknown) {
+    console.error(`Error scraping problem ${contestId}${index}:`, err instanceof Error ? err.message : err);
     throw err;
   }
 }
@@ -204,8 +206,6 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
   console.log("Seeding problem pool from local predefined_problems.json...");
 
   try {
-    const fs = require("fs");
-    const path = require("path");
     const filePath = path.join(process.cwd(), "src/lib/predefined_problems.json");
     const fileContent = fs.readFileSync(filePath, "utf8");
     const predefinedProblems = JSON.parse(fileContent);
@@ -215,7 +215,7 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
 
     for (const diff of difficulties) {
       let syncedForDiff = 0;
-      const diffProblems = predefinedProblems.filter((p: any) => p.difficulty === diff);
+      const diffProblems = predefinedProblems.filter((p: Record<string, unknown>) => p.difficulty === diff);
 
       for (const p of diffProblems) {
         if (syncedForDiff >= limitPerDifficulty) break;
@@ -261,8 +261,8 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
 
     console.log(`Predefined seed complete. Seeded: ${totalSynced} problems.`);
     return totalSynced;
-  } catch (err: any) {
-    console.warn("Failed to seed from predefined list, falling back to network fetch:", err.message);
+  } catch (err: unknown) {
+    console.warn("Failed to seed from predefined list, falling back to network fetch:", err instanceof Error ? err.message : err);
   }
 
   console.log("Fetching problem list from Codeforces API...");
@@ -324,7 +324,6 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
       try {
         console.log(`Syncing CF problem ${sourceId} (${cand.name}) - ${difficulty}...`);
         const scraped = await scrapeCodeforcesProblem(cand.contestId!, cand.index);
-        const hiddenTests = scraped.sampleTests;
 
         const { error } = await sb.from("arena_problems").insert({
           source: "codeforces",
@@ -337,7 +336,7 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
           time_limit_ms: scraped.timeLimitMs,
           memory_limit_mb: scraped.memoryLimitMb,
           sample_tests: scraped.sampleTests,
-          hidden_tests: hiddenTests,
+          hidden_tests: [],
           hints: []
         });
 
@@ -347,8 +346,8 @@ export async function syncCodeforcesProblems(limitPerDifficulty = 3): Promise<nu
           console.log(`Successfully synced CF problem ${sourceId}`);
           synced++;
         }
-      } catch (err: any) {
-        console.warn(`Skipping candidate ${sourceId} due to sync error:`, err.message);
+      } catch (err: unknown) {
+        console.warn(`Skipping candidate ${sourceId} due to sync error:`, err instanceof Error ? err.message : err);
       }
 
       await new Promise(r => setTimeout(r, 1000));
@@ -470,8 +469,8 @@ export async function rotateDailyChallenges(dateStr: string): Promise<boolean> {
 
     console.log(`Successfully rotated daily challenges for ${dateStr}!`);
     return true;
-  } catch (err: any) {
-    console.error(`Failed to rotate daily challenges:`, err.message);
+  } catch (err: unknown) {
+    console.error(`Failed to rotate daily challenges:`, err instanceof Error ? err.message : err);
     return false;
   }
 }
@@ -512,7 +511,7 @@ export async function getAuthenticatedDeveloper(req: Request) {
 }
 
 /** Encrypt hidden tests using AES-256-CBC */
-export function encryptHiddenTests(tests: any[]): { iv: string; encryptedData: string } {
+export function encryptHiddenTests(tests: unknown[]): { iv: string; encryptedData: string } {
   const algorithm = "aes-256-cbc";
   const key = getArenaCryptoKey();
   const iv = crypto.randomBytes(16);


### PR DESCRIPTION
## What does this PR do?

Removes pointless AES encryption on hidden test cases. The Codeforces scraper (`scrapeCodeforcesProblem`) only parses sample tests from the HTML — hidden test data is never available server-side. The sync code was assigning `scraped.sampleTests` to both `sample_tests` and `hidden_tests`, making encryption a no-op (identical data in both columns, and `sample_tests` is returned unencrypted via `/api/arena/challenge/today`).

Changes:
- `src/lib/arena.ts`: Stop storing `scraped.sampleTests` in the `hidden_tests` column (set to empty array instead)
- `src/app/api/arena/challenge/[id]/route.ts`: Return `hidden_tests` as plain data instead of encrypting it; remove `encryptHiddenTests` import and call

The `encryptHiddenTests` and `getArenaCryptoKey` functions remain exported for backward compatibility but are no longer used at runtime.

## Related issue

Closes #689

## Screenshots

N/A — logic-only change

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
