### PR TITLE
[GSSoC'26] fix: reorder purchase INSERT before points deduction to eliminate TOCTOU rollback race (closes #690)

### DIFF
--- a/src/app/api/shop/buy-with-points/route.ts
+++ b/src/app/api/shop/buy-with-points/route.ts
@@ -86,32 +86,18 @@ export async function POST(request: Request) {
     const isDev = ["ishant_27", "ixotic", "ixotic27"].includes(dev.github_login.toLowerCase()) && dev_mode === true;
 
     let deductedPoints = dev.points ?? 0;
-    if (!isDev) {
-        // 3. Check points balance
-        if ((dev.points ?? 0) < item.price_points) {
-            return NextResponse.json({ error: "Not enough points" }, { status: 403 });
-        }
 
-        // 4. Atomic conditional deduction — only succeeds if balance is still sufficient
-        const { data: deducted, error: deductError } = await admin
-            .rpc("deduct_points_atomic", {
-                p_developer_id: dev.id,
-                p_price_points: item.price_points,
-            })
-            .select("success, remaining_points")
-            .maybeSingle();
-
-        if (deductError || !deducted?.success) {
-            return NextResponse.json({ error: "Not enough points or a concurrent purchase already deducted your balance. Please try again." }, { status: 409 });
-        }
-        deductedPoints = deducted.remaining_points;
+    // 3. Check points balance (early check, race condition handled by atomic RPC later)
+    if (!isDev && (dev.points ?? 0) < item.price_points) {
+        return NextResponse.json({ error: "Not enough points" }, { status: 403 });
     }
 
-    // Fulfill/grant consumable items to developers (updates tables and determines correct status string)
+    // 4. Fulfill/grant consumable items to developers (updates tables and determines correct status string)
     const { status: purchaseStatus } = await fulfillItemPurchase(dev.id, item_id, admin);
 
     const idempotencyKey = `points_${dev.id}_${item_id}_${Date.now()}`;
 
+    // 5. INSERT purchase record FIRST (before deduction)
     const { data: purchase, error: purchaseError } = await admin
         .from("purchases")
         .insert({
@@ -127,14 +113,25 @@ export async function POST(request: Request) {
         .single();
 
     if (purchaseError) {
-        if (!isDev) {
-            // Atomic rollback — add points back to the current DB value
-            await admin.rpc("add_points_atomic", {
+        return NextResponse.json({ error: "Failed to record purchase" }, { status: 500 });
+    }
+
+    // 6. Deduct points AFTER successful INSERT — no rollback needed
+    if (!isDev) {
+        const { data: deducted, error: deductError } = await admin
+            .rpc("deduct_points_atomic", {
                 p_developer_id: dev.id,
                 p_price_points: item.price_points,
-            });
+            })
+            .select("success, remaining_points")
+            .maybeSingle();
+
+        if (deductError || !deducted?.success) {
+            // Deduction failed — clean up the purchase record
+            await admin.from("purchases").delete().eq("id", purchase.id);
+            return NextResponse.json({ error: "Not enough points or a concurrent purchase already deducted your balance. Please try again." }, { status: 409 });
         }
-        return NextResponse.json({ error: "Failed to record purchase" }, { status: 500 });
+        deductedPoints = deducted.remaining_points;
     }
 
     // Insert activity feed


### PR DESCRIPTION
## What does this PR do?

Fixes a TOCTOU (time-of-check-time-of-use) vulnerability in the `/api/shop/buy-with-points` rollback logic.

**Root cause:** Points were deducted BEFORE the purchase INSERT. If the INSERT failed (e.g., transient DB error), the rollback called `add_points_atomic` which added points back to the *current* DB balance — not the pre-deduction balance. A concurrent purchase between deduction and rollback could over-credit points.

**Fix:** Reorder operations so the purchase INSERT happens FIRST. Points are only deducted after the INSERT succeeds. If deduction fails, the purchase record is deleted — no rollback needed since no points were deducted yet.

## Files Changed

- `src/app/api/shop/buy-with-points/route.ts`: Move points deduction after the purchase INSERT; remove `add_points_atomic` rollback; add cleanup deletion on deduction failure

## Related issue

Closes #690

## Screenshots

N/A — logic-only change

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
