### PR TITLE
feat: add DungeonModal for daily coding challenge #666

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -338,7 +337,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -350,7 +348,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1794,7 +1791,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1816,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1832,7 +1827,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -1866,7 +1860,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -1884,7 +1877,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1944,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2485,7 +2476,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.2.tgz",
       "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.2",
         "@supabase/functions-js": "2.106.2",
@@ -2852,7 +2842,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2868,7 +2857,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2903,7 +2891,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2975,7 +2962,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3524,7 +3510,6 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
       "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -3743,7 +3728,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4189,7 +4173,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4976,7 +4959,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5162,7 +5144,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7257,7 +7238,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -7677,7 +7657,6 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
       "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
       "license": "Zlib",
-      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.184.0"
       }
@@ -7765,7 +7744,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7775,7 +7753,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8699,8 +8676,7 @@
       "version": "0.183.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.0.tgz",
       "integrity": "sha512-G6SH2jfefIVa2YI4JL2VbgQhrrbp1A8dRc7lr3PW827kdVyaX2RgH6M5FmjmdVFLgSHppyg3OYOZdTfWElle+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8792,7 +8768,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8904,7 +8879,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9052,7 +9026,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9231,7 +9204,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9868,7 +9840,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -21,7 +21,6 @@ import DungeonModal from "./DungeonModal";
 
 const Colosseum = lazy(() => import("./Colosseum"));
 const VoidObelisk = lazy(() => import("./VoidObelisk"));
-<DungeonPortal onClick={() => setDungeonOpen(true)} position={landmarkPositions[2]} />
 const DungeonPortal = lazy(() => import("./DungeonPortal"));
 const AstralObservatory = lazy(() => import("./AstralObservatory"));
 const CryptOfEchoes = lazy(() => import("./CryptOfEchoes"));
@@ -2416,6 +2415,7 @@ export default function CityCanvas({
               themeFace={t.building.face}
             />
             <VoidObelisk onClick={() => { }} position={landmarkPositions[1]} />
+            <DungeonPortal onClick={() => setDungeonOpen(true)} position={landmarkPositions[2]} />
             <AstralObservatory onClick={() => { }} position={landmarkPositions[3]} />
             <CryptOfEchoes onClick={() => { }} position={landmarkPositions[4]} />
             <SunkenSanctum onClick={() => { }} position={landmarkPositions[5]} />

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -17,6 +17,7 @@ import type { RaidExecuteResponse } from "@/lib/raid";
 import FounderSpire from "./FounderSpire";
 import LeaderboardHolograms from "./LeaderboardHolograms";
 import EArcadeLandmark from "./EArcadeLandmark";
+import DungeonModal from "./DungeonModal";
 
 const Colosseum = lazy(() => import("./Colosseum"));
 const VoidObelisk = lazy(() => import("./VoidObelisk"));
@@ -2214,6 +2215,7 @@ export default function CityCanvas({
   multiplayerPlayers,
 }: Props) {
   const { isRaining } = useWeather();
+  const [dungeonOpen, setDungeonOpen] = useState(false);
   const t = THEMES[themeIndex] ?? THEMES[0];
   const showPerf = typeof window !== "undefined" && new URLSearchParams(window.location.search).has("perf");
   const flyPosRef = useRef(new THREE.Vector3());
@@ -2274,6 +2276,7 @@ export default function CityCanvas({
     return () => clearTimeout(timer);
   }, [visibleBuildings.length, buildings]);
   return (
+    <>
     <Canvas
       camera={{ position: [400, 450, 600], fov: 55, near: 1.0, far: 4000 }}
       dpr={[1, 2]}
@@ -2408,7 +2411,6 @@ export default function CityCanvas({
               themeFace={t.building.face}
             />
             <VoidObelisk onClick={() => { }} position={landmarkPositions[1]} />
-            <DungeonPortal onClick={() => { }} position={landmarkPositions[2]} />
             <AstralObservatory onClick={() => { }} position={landmarkPositions[3]} />
             <CryptOfEchoes onClick={() => { }} position={landmarkPositions[4]} />
             <SunkenSanctum onClick={() => { }} position={landmarkPositions[5]} />
@@ -2494,5 +2496,9 @@ export default function CityCanvas({
       )}
 
     </Canvas>
+    {dungeonOpen && (
+      <DungeonModal onClose={() => setDungeonOpen(false)} />
+    )}
+  </>
   );
 }

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -21,6 +21,7 @@ import DungeonModal from "./DungeonModal";
 
 const Colosseum = lazy(() => import("./Colosseum"));
 const VoidObelisk = lazy(() => import("./VoidObelisk"));
+<DungeonPortal onClick={() => setDungeonOpen(true)} position={landmarkPositions[2]} />
 const DungeonPortal = lazy(() => import("./DungeonPortal"));
 const AstralObservatory = lazy(() => import("./AstralObservatory"));
 const CryptOfEchoes = lazy(() => import("./CryptOfEchoes"));

--- a/src/components/DungeonModal.tsx
+++ b/src/components/DungeonModal.tsx
@@ -7,7 +7,7 @@ interface DailyProblem { title: string; difficulty: string; titleSlug: string; }
 const BOSS_MAP: Record<string, { name: string; emoji: string; color: string }> = {
   Easy: { name: "Goblin", emoji: "👺", color: "#4ade80" },
   Medium: { name: "Orc", emoji: "👹", color: "#fb923c" },
-  Hard: { name: "Dragon", emoji: "🐉", color: "#f87171" },
+  Hard: { name: "Dragon", emoji: "🐉", color: "#ef4444" },
 };
 
 export default function DungeonModal({ onClose }: DungeonModalProps) {
@@ -16,34 +16,113 @@ export default function DungeonModal({ onClose }: DungeonModalProps) {
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    fetch("https://alfa-leetcode-api.onrender.com/daily")
-      .then((res) => res.json())
-      .then((data) => {
+    const controller = new AbortController();
+    const load = async () => {
+      try {
+        const res = await fetch("https://alfa-leetcode-api.onrender.com/daily", { signal: controller.signal });
+        if (!res.ok) throw new Error("fetch failed");
+        const data = await res.json();
+        if (!data?.questionTitle || !data?.difficulty || !data?.titleSlug) throw new Error("bad data");
         setProblem({ title: data.questionTitle, difficulty: data.difficulty, titleSlug: data.titleSlug });
+      } catch (err: unknown) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setError(true);
+      } finally {
         setLoading(false);
-      })
-      .catch(() => { setError(true); setLoading(false); });
+      }
+    };
+    load();
+    return () => controller.abort();
   }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
 
   const boss = problem ? (BOSS_MAP[problem.difficulty] ?? BOSS_MAP["Medium"]) : null;
   const leetcodeUrl = problem ? "https://leetcode.com/problems/" + problem.titleSlug + "/" : "#";
 
   return (
-    <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.75)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }} onClick={onClose}>
-      <div style={{ backgroundColor: "#1e1e2e", border: "2px solid #7c3aed", borderRadius: "16px", padding: "2rem", maxWidth: "420px", width: "90%", textAlign: "center", fontFamily: "monospace", color: "white" }} onClick={(e) => e.stopPropagation()}>
-        <h2 style={{ color: "#a78bfa", fontSize: "1.4rem", marginBottom: "0.5rem" }}>⚔️ Daily Coding Dungeon</h2>
-        {loading && <p style={{ color: "#94a3b8" }}>Summoning dungeon boss...</p>}
-        {error && <p style={{ color: "#f87171" }}>Failed to load dungeon.</p>}
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.85)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}
+      onClick={onClose}
+    >
+      <div
+        aria-labelledby="dungeon-modal-title"
+        style={{
+          backgroundColor: "#0a0a0a",
+          border: "2px solid #ef4444",
+          outline: "2px solid #7f1d1d",
+          padding: "2rem",
+          maxWidth: "420px",
+          width: "90%",
+          textAlign: "center",
+          fontFamily: "'Silkscreen', monospace",
+          color: "white",
+          imageRendering: "pixelated",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="dungeon-modal-title" style={{ color: "#ef4444", fontSize: "1rem", marginBottom: "0.5rem", letterSpacing: "0.1em", textTransform: "uppercase" }}>
+          ⚔ DAILY CODING DUNGEON
+        </h2>
+        <div style={{ borderTop: "1px solid #7f1d1d", margin: "0.75rem 0" }} />
+
+        {loading && <p style={{ color: "#94a3b8", fontSize: "0.75rem" }}>SUMMONING BOSS...</p>}
+        {error && <p style={{ color: "#ef4444", fontSize: "0.75rem" }}>DUNGEON UNAVAILABLE</p>}
+
         {problem && boss && (
           <div>
-            <div style={{ fontSize: "4rem", margin: "1rem 0" }}>{boss.emoji}</div>
-            <p style={{ color: "#94a3b8" }}>Today&apos;s Boss</p>
-            <h3 style={{ color: boss.color }}>{boss.name} — {problem.difficulty}</h3>
-            <p style={{ color: "#e2e8f0", marginBottom: "1.5rem" }}>{problem.title}</p>
-            <a href={leetcodeUrl} target="_blank" rel="noopener noreferrer" style={{ backgroundColor: "#7c3aed", color: "white", padding: "0.75rem 1.5rem", borderRadius: "8px", textDecoration: "none", fontWeight: "bold", display: "inline-block" }}>⚔️ Fight Boss</a>
+            <div style={{ fontSize: "3rem", margin: "1rem 0" }}>{boss.emoji}</div>
+            <p style={{ color: "#64748b", fontSize: "0.65rem", marginBottom: "0.25rem", letterSpacing: "0.15em" }}>TODAY&apos;S BOSS</p>
+            <h3 style={{ color: boss.color, fontSize: "0.85rem", marginBottom: "0.25rem", letterSpacing: "0.1em" }}>
+              {boss.name.toUpperCase()} — {problem.difficulty.toUpperCase()}
+            </h3>
+            <p style={{ color: "#e2e8f0", marginBottom: "1.5rem", fontSize: "0.75rem", letterSpacing: "0.05em" }}>
+              {problem.title}
+            </p>
+            <a
+              href={leetcodeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                backgroundColor: "#ef4444",
+                color: "white",
+                padding: "0.6rem 1.25rem",
+                textDecoration: "none",
+                fontWeight: "bold",
+                display: "inline-block",
+                fontSize: "0.75rem",
+                letterSpacing: "0.1em",
+                border: "2px solid #fca5a5",
+                fontFamily: "'Silkscreen', monospace",
+              }}
+            >
+              ⚔ FIGHT BOSS
+            </a>
           </div>
         )}
-        <button onClick={onClose} style={{ display: "block", margin: "1rem auto 0", background: "transparent", border: "1px solid #475569", color: "#94a3b8", padding: "0.4rem 1rem", borderRadius: "6px", cursor: "pointer" }}>Retreat</button>
+
+        <div style={{ borderTop: "1px solid #7f1d1d", margin: "1rem 0 0.5rem" }} />
+        <button
+          onClick={onClose}
+          style={{
+            background: "transparent",
+            border: "1px solid #374151",
+            color: "#64748b",
+            padding: "0.4rem 1rem",
+            cursor: "pointer",
+            fontFamily: "'Silkscreen', monospace",
+            fontSize: "0.65rem",
+            letterSpacing: "0.1em",
+          }}
+        >
+          [ RETREAT ]
+        </button>
       </div>
     </div>
   );

--- a/src/components/DungeonModal.tsx
+++ b/src/components/DungeonModal.tsx
@@ -5,9 +5,9 @@ interface DungeonModalProps { onClose: () => void; }
 interface DailyProblem { title: string; difficulty: string; titleSlug: string; }
 
 const BOSS_MAP: Record<string, { name: string; emoji: string; color: string }> = {
-  Easy: { name: "Goblin", emoji: "👺", color: "#4ade80" },
-  Medium: { name: "Orc", emoji: "👹", color: "#fb923c" },
-  Hard: { name: "Dragon", emoji: "🐉", color: "#ef4444" },
+  Easy:   { name: "Goblin", emoji: "👺", color: "#4ade80" },
+  Medium: { name: "Orc",    emoji: "👹", color: "#fb923c" },
+  Hard:   { name: "Dragon", emoji: "🐉", color: "#ef4444" },
 };
 
 export default function DungeonModal({ onClose }: DungeonModalProps) {
@@ -48,78 +48,66 @@ export default function DungeonModal({ onClose }: DungeonModalProps) {
     <div
       role="dialog"
       aria-modal="true"
-      style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.85)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85"
       onClick={onClose}
     >
       <div
         aria-labelledby="dungeon-modal-title"
-        style={{
-          backgroundColor: "#0a0a0a",
-          border: "2px solid #ef4444",
-          outline: "2px solid #7f1d1d",
-          padding: "2rem",
-          maxWidth: "420px",
-          width: "90%",
-          textAlign: "center",
-          fontFamily: "'Silkscreen', monospace",
-          color: "white",
-          imageRendering: "pixelated",
-        }}
+        className="relative w-[90%] max-w-[420px] border-[2px] border-red-500/60 bg-bg-raised p-8 text-center font-silkscreen text-cream [image-rendering:pixelated]"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 id="dungeon-modal-title" style={{ color: "#ef4444", fontSize: "1rem", marginBottom: "0.5rem", letterSpacing: "0.1em", textTransform: "uppercase" }}>
+        {/* Title */}
+        <h2
+          id="dungeon-modal-title"
+          className="text-[13px] uppercase tracking-[0.1em] text-red-400"
+        >
           ⚔ DAILY CODING DUNGEON
         </h2>
-        <div style={{ borderTop: "1px solid #7f1d1d", margin: "0.75rem 0" }} />
 
-        {loading && <p style={{ color: "#94a3b8", fontSize: "0.75rem" }}>SUMMONING BOSS...</p>}
-        {error && <p style={{ color: "#ef4444", fontSize: "0.75rem" }}>DUNGEON UNAVAILABLE</p>}
+        <div className="my-3 border-t border-red-500/30" />
 
+        {/* Loading / Error states */}
+        {loading && (
+          <p className="text-[11px] text-muted">SUMMONING BOSS...</p>
+        )}
+        {error && (
+          <p className="text-[11px] text-red-400">DUNGEON UNAVAILABLE</p>
+        )}
+
+        {/* Problem content */}
         {problem && boss && (
           <div>
-            <div style={{ fontSize: "3rem", margin: "1rem 0" }}>{boss.emoji}</div>
-            <p style={{ color: "#64748b", fontSize: "0.65rem", marginBottom: "0.25rem", letterSpacing: "0.15em" }}>TODAY&apos;S BOSS</p>
-            <h3 style={{ color: boss.color, fontSize: "0.85rem", marginBottom: "0.25rem", letterSpacing: "0.1em" }}>
+            <div className="my-4 text-5xl">{boss.emoji}</div>
+
+            <p className="mb-1 text-[10px] tracking-[0.15em] text-muted">
+              TODAY&apos;S BOSS
+            </p>
+
+            <h3 className="mb-1 text-[13px] tracking-[0.1em]" style={{ color: boss.color }}>
               {boss.name.toUpperCase()} — {problem.difficulty.toUpperCase()}
             </h3>
-            <p style={{ color: "#e2e8f0", marginBottom: "1.5rem", fontSize: "0.75rem", letterSpacing: "0.05em" }}>
+
+            <p className="mb-6 text-[11px] tracking-[0.05em] text-cream">
               {problem.title}
             </p>
+
             <a
               href={leetcodeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              style={{
-                backgroundColor: "#ef4444",
-                color: "white",
-                padding: "0.6rem 1.25rem",
-                textDecoration: "none",
-                fontWeight: "bold",
-                display: "inline-block",
-                fontSize: "0.75rem",
-                letterSpacing: "0.1em",
-                border: "2px solid #fca5a5",
-                fontFamily: "'Silkscreen', monospace",
-              }}
+              className="inline-block border-[2px] border-red-300/60 bg-red-500 px-5 py-2.5 text-[11px] font-bold tracking-[0.1em] text-white no-underline transition-opacity hover:opacity-90"
             >
               ⚔ FIGHT BOSS
             </a>
           </div>
         )}
 
-        <div style={{ borderTop: "1px solid #7f1d1d", margin: "1rem 0 0.5rem" }} />
+        <div className="mb-2 mt-4 border-t border-red-500/30" />
+
+        {/* Close button */}
         <button
           onClick={onClose}
-          style={{
-            background: "transparent",
-            border: "1px solid #374151",
-            color: "#64748b",
-            padding: "0.4rem 1rem",
-            cursor: "pointer",
-            fontFamily: "'Silkscreen', monospace",
-            fontSize: "0.65rem",
-            letterSpacing: "0.1em",
-          }}
+          className="btn-press border border-border bg-transparent px-4 py-1.5 text-[10px] tracking-[0.1em] text-muted transition-colors hover:border-border-light hover:text-cream"
         >
           [ RETREAT ]
         </button>

--- a/src/components/DungeonModal.tsx
+++ b/src/components/DungeonModal.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface DungeonModalProps { onClose: () => void; }
+interface DailyProblem { title: string; difficulty: string; titleSlug: string; }
+
+const BOSS_MAP: Record<string, { name: string; emoji: string; color: string }> = {
+  Easy: { name: "Goblin", emoji: "👺", color: "#4ade80" },
+  Medium: { name: "Orc", emoji: "👹", color: "#fb923c" },
+  Hard: { name: "Dragon", emoji: "🐉", color: "#f87171" },
+};
+
+export default function DungeonModal({ onClose }: DungeonModalProps) {
+  const [problem, setProblem] = useState<DailyProblem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("https://alfa-leetcode-api.onrender.com/daily")
+      .then((res) => res.json())
+      .then((data) => {
+        setProblem({ title: data.questionTitle, difficulty: data.difficulty, titleSlug: data.titleSlug });
+        setLoading(false);
+      })
+      .catch(() => { setError(true); setLoading(false); });
+  }, []);
+
+  const boss = problem ? (BOSS_MAP[problem.difficulty] ?? BOSS_MAP["Medium"]) : null;
+  const leetcodeUrl = problem ? "https://leetcode.com/problems/" + problem.titleSlug + "/" : "#";
+
+  return (
+    <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.75)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }} onClick={onClose}>
+      <div style={{ backgroundColor: "#1e1e2e", border: "2px solid #7c3aed", borderRadius: "16px", padding: "2rem", maxWidth: "420px", width: "90%", textAlign: "center", fontFamily: "monospace", color: "white" }} onClick={(e) => e.stopPropagation()}>
+        <h2 style={{ color: "#a78bfa", fontSize: "1.4rem", marginBottom: "0.5rem" }}>⚔️ Daily Coding Dungeon</h2>
+        {loading && <p style={{ color: "#94a3b8" }}>Summoning dungeon boss...</p>}
+        {error && <p style={{ color: "#f87171" }}>Failed to load dungeon.</p>}
+        {problem && boss && (
+          <div>
+            <div style={{ fontSize: "4rem", margin: "1rem 0" }}>{boss.emoji}</div>
+            <p style={{ color: "#94a3b8" }}>Today&apos;s Boss</p>
+            <h3 style={{ color: boss.color }}>{boss.name} — {problem.difficulty}</h3>
+            <p style={{ color: "#e2e8f0", marginBottom: "1.5rem" }}>{problem.title}</p>
+            <a href={leetcodeUrl} target="_blank" rel="noopener noreferrer" style={{ backgroundColor: "#7c3aed", color: "white", padding: "0.75rem 1.5rem", borderRadius: "8px", textDecoration: "none", fontWeight: "bold", display: "inline-block" }}>⚔️ Fight Boss</a>
+          </div>
+        )}
+        <button onClick={onClose} style={{ display: "block", margin: "1rem auto 0", background: "transparent", border: "1px solid #475569", color: "#94a3b8", padding: "0.4rem 1rem", borderRadius: "6px", cursor: "pointer" }}>Retreat</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DungeonPortal.tsx
+++ b/src/components/DungeonPortal.tsx
@@ -19,8 +19,8 @@ const LIT_COLORS = ["#ef4444", "#dc2626", "#ff6b6b", "#fca5a5", "#f87171"];
 // Twin tower fortress dimensions
 const TW_W = 50, TW_D = 50, TW_H_BASE = 200, TW_H_UPPER = 160;
 const TOWER_OFFSET = 55;
-const GATE_W = 90, GATE_H = 120;
-const TOTAL_H = TW_H_BASE + TW_H_UPPER + 8; // ~368
+const TOTAL_H = TW_H_BASE + TW_H_UPPER + 8;
+const GATE_H = 120;
 
 // Skull pixel art (7×7)
 const SKULL_BM: number[][] = [
@@ -76,7 +76,7 @@ interface DungeonPortalProps {
 
 export default function DungeonPortal({
   onClick,
-  position = [-735, 0, -235], // Ring 1, plaza 2 (opposite to VoidObelisk)
+  position = [-735, 0, -235],
 }: DungeonPortalProps) {
   const groupRef = useRef<THREE.Group>(null);
   const chainRef1 = useRef<THREE.Group>(null);
@@ -166,16 +166,16 @@ export default function DungeonPortal({
 
   const B_Y = TW_H_BASE / 2 + 4;
   const U_Y = TW_H_BASE + 4 + TW_H_UPPER / 2;
+  const topY = TOTAL_H;
 
   const leftSkull = useMemo(() => createVoxelSkull(ACCENT), []);
   const rightSkull = useMemo(() => createVoxelSkull(ACCENT), []);
 
-  // Animation
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime();
     if (chainRef1.current) chainRef1.current.rotation.z = Math.sin(t * 1.2) * 0.08;
     if (chainRef2.current) chainRef2.current.rotation.z = Math.sin(t * 1.2 + 1) * 0.08;
-    
+
     if (portalGlowRef.current) {
       (portalGlowRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity =
         2 + Math.sin(t * 2) * 1;
@@ -195,17 +195,6 @@ export default function DungeonPortal({
     if (fireRef1.current) fireRef1.current.intensity = flicker;
     if (fireRef2.current) fireRef2.current.intensity = flicker;
   });
-
-  const topY = TOTAL_H;
-
-  useFrame((state)) => {
-    const t = state.clock.elapsedTime;
-    if (leftSkullRef.current) {
-      leftSkullRef.current.rotation.y = t * 0.5;
-      leftSkullRef.current.position.y = topY + 22 + Math.sin(t * 2) * 1.5;
-    }
-
-  }
 
   return (
     <group ref={groupRef} position={position} userData={{ isLandmark: true }}>
@@ -229,14 +218,12 @@ export default function DungeonPortal({
           shellColor={shellColor} glassFront={tFrontL} glassSide={tSide}
           emColor={LIT_COLORS[0]} accent={ACCENT}
         />
-        {/* Battlements */}
         {[-1, 0, 1].map(i => (
           <mesh key={`l-bat-${i}`} position={[i * 14, topY + 8, 0]}>
             <boxGeometry args={[8, 16, TW_D - 10]} />
             <meshStandardMaterial color={shellColor} roughness={0.3} metalness={0.7} />
           </mesh>
         ))}
-        {/* Voxel Skull mascot */}
         <group ref={leftSkullRef} position={[0, topY + 22, 0]} scale={1.2}>
           <primitive object={leftSkull} />
         </group>
@@ -254,14 +241,12 @@ export default function DungeonPortal({
           shellColor={shellColor} glassFront={tFrontR} glassSide={tSide}
           emColor={LIT_COLORS[0]} accent={ACCENT}
         />
-        {/* Battlements */}
         {[-1, 0, 1].map(i => (
           <mesh key={`r-bat-${i}`} position={[i * 14, topY + 8, 0]}>
             <boxGeometry args={[8, 16, TW_D - 10]} />
             <meshStandardMaterial color={shellColor} roughness={0.3} metalness={0.7} />
           </mesh>
         ))}
-        {/* Voxel Skull mascot */}
         <group ref={rightSkullRef} position={[0, topY + 22, 0]} scale={1.2}>
           <primitive object={rightSkull} />
         </group>
@@ -291,7 +276,7 @@ export default function DungeonPortal({
         </group>
       ))}
 
-      {/* Portal glow (between towers at ground level) */}
+      {/* Portal glow */}
       <mesh ref={portalGlowRef} position={[0, 40, TW_D / 2 + 2]}>
         <planeGeometry args={[TOWER_OFFSET * 2 - TW_W - 10, 70]} />
         <meshStandardMaterial color="#200000" emissive={ACCENT} emissiveIntensity={2} toneMapped={false} transparent opacity={0.5} side={THREE.DoubleSide} />

--- a/src/components/DungeonPortal.tsx
+++ b/src/components/DungeonPortal.tsx
@@ -108,7 +108,10 @@ export default function DungeonPortal({
 
     let tap: { time: number; x: number; y: number } | null = null;
     const onDown = (e: PointerEvent) => {
-      if (hits(e)) tap = { time: performance.now(), x: e.clientX, y: e.clientY };
+      if (hits(e)) {
+        e.stopPropagation();
+        tap = { time: performance.now(), x: e.clientX, y: e.clientY };
+      }
     };
     const onUp = (e: PointerEvent) => {
       if (!tap) return;

--- a/src/components/DungeonPortal.tsx
+++ b/src/components/DungeonPortal.tsx
@@ -198,6 +198,15 @@ export default function DungeonPortal({
 
   const topY = TOTAL_H;
 
+  useFrame((state)) => {
+    const t = state.clock.elapsedTime;
+    if (leftSkullRef.current) {
+      leftSkullRef.current.rotation.y = t * 0.5;
+      leftSkullRef.current.position.y = topY + 22 + Math.sin(t * 2) * 1.5;
+    }
+
+  }
+
   return (
     <group ref={groupRef} position={position} userData={{ isLandmark: true }}>
       {/* Invisible hitbox */}


### PR DESCRIPTION
Fixes #666

## What does this PR do?
Adds a Daily Coding Dungeon modal triggered by clicking the DungeonPortal landmark in LeetCode City. The modal fetches today's LeetCode daily problem and presents it as a boss fight — Goblin (Easy), Orc (Medium), or Dragon (Hard) — with a "Fight Boss" button linking directly to the problem.

## Related Issue
Fixes #666

## Screenshots

**Before — City view:**
<img width="1093" height="476" alt="image" src="https://github.com/user-attachments/assets/e5dc5759-b011-45e8-85cd-996fcb3983d5" />



**After — Dungeon modal open:**
<img width="1806" height="757" alt="image" src="https://github.com/user-attachments/assets/041d4dad-1975-4f04-a8e3-026017988b81" />


## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository**