### PR TITLE
implement 2D spatial culling and viewport virtualization for Global City Map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -338,7 +337,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -350,7 +348,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1794,7 +1791,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1816,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1832,7 +1827,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -1866,7 +1860,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -1884,7 +1877,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1944,7 +1936,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2485,7 +2476,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.2.tgz",
       "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.2",
         "@supabase/functions-js": "2.106.2",
@@ -2852,7 +2842,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2868,7 +2857,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2903,7 +2891,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2975,7 +2962,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3524,7 +3510,6 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
       "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -3743,7 +3728,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4189,7 +4173,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4976,7 +4959,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5162,7 +5144,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7257,7 +7238,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -7677,7 +7657,6 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
       "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
       "license": "Zlib",
-      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.184.0"
       }
@@ -7765,7 +7744,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7775,7 +7753,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8699,8 +8676,7 @@
       "version": "0.183.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.0.tgz",
       "integrity": "sha512-G6SH2jfefIVa2YI4JL2VbgQhrrbp1A8dRc7lr3PW827kdVyaX2RgH6M5FmjmdVFLgSHppyg3OYOZdTfWElle+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8792,7 +8768,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8904,7 +8879,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9052,7 +9026,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9231,7 +9204,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9868,7 +9840,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -2251,14 +2251,14 @@ export default function CityCanvas({
 
 
 const [viewport, setViewport] = useState<Viewport2D>({
-  minX: -1500, minZ: -1500, maxX: 1500, maxZ: 1500,
+  minX: 2500, minZ: 2500, maxX: 1500, maxZ: 2500,
 });
 
 const handleViewportChange = useCallback((vp: Viewport2D) => {
   setViewport(vp);
 }, []);
 
-const visibleBuildings = useSpatialCulling(buildings, viewport, 400);
+const visibleBuildings = useSpatialCulling(buildings, viewport, 800);
   return (
     <Canvas
       camera={{ position: [400, 450, 600], fov: 55, near: 1.0, far: 4000 }}
@@ -2311,7 +2311,7 @@ const visibleBuildings = useSpatialCulling(buildings, viewport, 400);
     >
       {showPerf && <Stats />}
       <CityExposure cityEnergy={cityEnergy ?? 1} />
-<ViewportTracker onViewportChange={handleViewportChange} intervalMs={100} />
+      <ViewportTracker onViewportChange={handleViewportChange} intervalMs={200} />
       <AtmosphereCycleManager
         theme={t}
         themeIndex={themeIndex}

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 /* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/refs, react-hooks/immutability */
-import { useRef, useEffect, useState, useMemo, lazy, Suspense } from "react";
+import { useRef, useEffect, useState, useMemo, lazy, Suspense, useCallback } from "react";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF, Stats } from "@react-three/drei";
 import * as THREE from "three";
@@ -41,7 +41,9 @@ import { useWeather } from '@/context/WeatherContext';
 import { RainParticles } from './weather/RainParticles';
 import { RainRippleGround } from './weather/RainRippleGround';
 import TrafficSystem from "./TrafficSystem";
-
+import ViewportTracker from "./ViewportTracker";
+import { useSpatialCulling } from "@/hooks/useSpatialCulling";
+import type { Viewport2D } from "@/lib/spatialGrid";
 // ─── Theme Definitions ───────────────────────────────────────
 
 export const THEME_NAMES = [
@@ -2247,36 +2249,16 @@ export default function CityCanvas({
     return posList;
   }, []);
 
-  const initialBuildings = useMemo(() => {
-    if (buildings.length <= 150) return buildings;
-    const sorted = [...buildings].sort((a, b) => {
-      const distA = a.position[0] ** 2 + a.position[2] ** 2;
-      const distB = b.position[0] ** 2 + b.position[2] ** 2;
-      return distA - distB;
-    });
-    return sorted.slice(0, 150);
-  }, [buildings]);
 
-  const [visibleBuildings, setVisibleBuildings] = useState<CityBuilding[]>(initialBuildings);
+const [viewport, setViewport] = useState<Viewport2D>({
+  minX: -1500, minZ: -1500, maxX: 1500, maxZ: 1500,
+});
 
-  useEffect(() => {
-    setVisibleBuildings(initialBuildings);
-  }, [initialBuildings]);
+const handleViewportChange = useCallback((vp: Viewport2D) => {
+  setViewport(vp);
+}, []);
 
-  useEffect(() => {
-    if (visibleBuildings.length >= buildings.length) return;
-
-    const timer = setTimeout(() => {
-      setVisibleBuildings((prev) => {
-        const prevLogins = new Set(prev.map(b => b.login.toLowerCase()));
-        const remaining = buildings.filter(b => !prevLogins.has(b.login.toLowerCase()));
-        const nextBatch = remaining.slice(0, 250);
-        return [...prev, ...nextBatch];
-      });
-    }, 150);
-
-    return () => clearTimeout(timer);
-  }, [visibleBuildings.length, buildings]);
+const visibleBuildings = useSpatialCulling(buildings, viewport, 400);
   return (
     <Canvas
       camera={{ position: [400, 450, 600], fov: 55, near: 1.0, far: 4000 }}
@@ -2329,6 +2311,7 @@ export default function CityCanvas({
     >
       {showPerf && <Stats />}
       <CityExposure cityEnergy={cityEnergy ?? 1} />
+<ViewportTracker onViewportChange={handleViewportChange} intervalMs={100} />
       <AtmosphereCycleManager
         theme={t}
         themeIndex={themeIndex}

--- a/src/components/ViewportTracker.tsx
+++ b/src/components/ViewportTracker.tsx
@@ -4,88 +4,120 @@ import { useRef } from "react";
 import * as THREE from "three";
 import type { Viewport2D } from "@/lib/spatialGrid";
 
-const _frustum = new THREE.Frustum();
-const _projScreenMatrix = new THREE.Matrix4();
-// A flat plane at Y=0 — we intersect camera frustum corners with it
-const _groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+// Pre-allocated to avoid GC pressure in useFrame
 const _ray = new THREE.Ray();
-const _target = new THREE.Vector3();
+const _groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+const _corners = [
+  new THREE.Vector3(), new THREE.Vector3(),
+  new THREE.Vector3(), new THREE.Vector3(),
+];
+const _ndc = new THREE.Vector3();
 
-/** Unprojects an NDC corner through the camera onto the Y=0 ground plane */
-function ndcToGround(
-  camera: THREE.Camera,
-  ndcX: number,
-  ndcY: number,
-  out: THREE.Vector3
-): boolean {
-  // Build a ray from the camera through the NDC point
-  const ndc = new THREE.Vector3(ndcX, ndcY, 0.5).unproject(camera);
+/**
+ * Unprojects an NDC point through the camera and intersects with Y=0 ground plane.
+ * Returns false if the ray points away from the ground (camera looking up/horizontal).
+ */
+function ndcToGround(camera: THREE.Camera, ndcX: number, ndcY: number, out: THREE.Vector3): boolean {
+  _ndc.set(ndcX, ndcY, 0.5).unproject(camera);
   _ray.origin.copy(camera.position);
-  _ray.direction.copy(ndc).sub(camera.position).normalize();
-  const t = _groundPlane.distanceToPoint(_ray.origin) / -_groundPlane.normal.dot(_ray.direction);
-  if (!isFinite(t) || t < 0) return false;
+  _ray.direction.copy(_ndc).sub(camera.position).normalize();
+
+  // dot(normal, direction) — if >= 0 ray is parallel or pointing away from ground
+  const denom = _groundPlane.normal.dot(_ray.direction);
+  if (denom >= -0.0001) return false;
+
+  const t = -(_groundPlane.distanceToPoint(_ray.origin)) / denom;
+  if (t < 0 || !isFinite(t)) return false;
+
   out.copy(_ray.origin).addScaledVector(_ray.direction, t);
   return true;
 }
 
+const NDC_CORNERS: [number, number][] = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+
 interface Props {
   onViewportChange: (vp: Viewport2D) => void;
-  /** How often to update in ms — 100ms is plenty for culling */
+  /**
+   * How often to recompute (ms). 200ms gives smooth culling without
+   * triggering excessive React re-renders during fast orbit.
+   */
   intervalMs?: number;
 }
 
-export default function ViewportTracker({ onViewportChange, intervalMs = 100 }: Props) {
+export default function ViewportTracker({ onViewportChange, intervalMs = 200 }: Props) {
   const { camera } = useThree();
-  const lastUpdate = useRef(0);
-  const corners = [
-    new THREE.Vector3(), new THREE.Vector3(),
-    new THREE.Vector3(), new THREE.Vector3(),
-  ];
+  const elapsed = useRef(0);
+  // Store last emitted viewport to skip unchanged updates
+  const lastVp = useRef<Viewport2D>({ minX: -9999, minZ: -9999, maxX: 9999, maxZ: 9999 });
 
   useFrame((_, delta) => {
-    lastUpdate.current += delta * 1000;
-    if (lastUpdate.current < intervalMs) return;
-    lastUpdate.current = 0;
+    elapsed.current += delta * 1000;
+    if (elapsed.current < intervalMs) return;
+    elapsed.current = 0;
 
-    // Project the 4 NDC screen corners onto the ground plane
     const hits: THREE.Vector3[] = [];
-    const ndcCorners: [number, number][] = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+
     for (let i = 0; i < 4; i++) {
-      if (ndcToGround(camera, ndcCorners[i][0], ndcCorners[i][1], corners[i])) {
-        hits.push(corners[i]);
+      if (ndcToGround(camera, NDC_CORNERS[i][0], NDC_CORNERS[i][1], _corners[i])) {
+        hits.push(_corners[i]);
       }
     }
 
-    // Fallback: camera is looking horizontally (no ground intersection)
-    // Use a wide box around camera XZ position instead
+    let minX: number, minZ: number, maxX: number, maxZ: number;
+
     if (hits.length < 2) {
-      const fallbackRadius = 1500;
-      onViewportChange({
-        minX: camera.position.x - fallbackRadius,
-        minZ: camera.position.z - fallbackRadius,
-        maxX: camera.position.x + fallbackRadius,
-        maxZ: camera.position.z + fallbackRadius,
-      });
-      return;
+      // Camera is looking nearly horizontal or upward — use a wide fallback
+      // centered on where the camera is pointing at ground level
+      const camDir = new THREE.Vector3();
+      camera.getWorldDirection(camDir);
+
+      // Project camera forward direction onto ground to find approximate look-at point
+      let lookX = camera.position.x;
+      let lookZ = camera.position.z;
+      if (Math.abs(camDir.y) > 0.01) {
+        const t = -camera.position.y / camDir.y;
+        if (t > 0 && t < 5000) {
+          lookX = camera.position.x + camDir.x * t;
+          lookZ = camera.position.z + camDir.z * t;
+        }
+      }
+
+      // Wide fallback — show everything within 2500 units of look target
+      const R = 2500;
+      minX = lookX - R; minZ = lookZ - R;
+      maxX = lookX + R; maxZ = lookZ + R;
+    } else {
+      minX = Infinity; minZ = Infinity; maxX = -Infinity; maxZ = -Infinity;
+      for (const h of hits) {
+        if (h.x < minX) minX = h.x;
+        if (h.x > maxX) maxX = h.x;
+        if (h.z < minZ) minZ = h.z;
+        if (h.z > maxZ) maxZ = h.z;
+      }
+
+      // Cap at 4000 units — beyond this everything is fog anyway
+      const MAX = 4000;
+      const cx = camera.position.x;
+      const cz = camera.position.z;
+      minX = Math.max(minX, cx - MAX);
+      maxX = Math.min(maxX, cx + MAX);
+      minZ = Math.max(minZ, cz - MAX);
+      maxZ = Math.min(maxZ, cz + MAX);
     }
 
-    // Compute bounding box of ground intersections
-    let minX = Infinity, minZ = Infinity, maxX = -Infinity, maxZ = -Infinity;
-    for (const h of hits) {
-      if (h.x < minX) minX = h.x;
-      if (h.x > maxX) maxX = h.x;
-      if (h.z < minZ) minZ = h.z;
-      if (h.z > maxZ) maxZ = h.z;
-    }
+    // Skip update if viewport hasn't changed meaningfully (50 unit threshold)
+    const prev = lastVp.current;
+    const THRESHOLD = 50;
+    if (
+      Math.abs(minX - prev.minX) < THRESHOLD &&
+      Math.abs(minZ - prev.minZ) < THRESHOLD &&
+      Math.abs(maxX - prev.maxX) < THRESHOLD &&
+      Math.abs(maxZ - prev.maxZ) < THRESHOLD
+    ) return;
 
-    // Clamp to sane values (avoid Infinity when camera looks at horizon)
-    const MAX_RANGE = 3000;
-    minX = Math.max(minX, camera.position.x - MAX_RANGE);
-    maxX = Math.min(maxX, camera.position.x + MAX_RANGE);
-    minZ = Math.max(minZ, camera.position.z - MAX_RANGE);
-    maxZ = Math.min(maxZ, camera.position.z + MAX_RANGE);
-
-    onViewportChange({ minX, minZ, maxX, maxZ });
+    const vp: Viewport2D = { minX, minZ, maxX, maxZ };
+    lastVp.current = vp;
+    onViewportChange(vp);
   });
 
   return null;

--- a/src/components/ViewportTracker.tsx
+++ b/src/components/ViewportTracker.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useThree, useFrame } from "@react-three/fiber";
+import { useRef } from "react";
+import * as THREE from "three";
+import type { Viewport2D } from "@/lib/spatialGrid";
+
+const _frustum = new THREE.Frustum();
+const _projScreenMatrix = new THREE.Matrix4();
+// A flat plane at Y=0 — we intersect camera frustum corners with it
+const _groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+const _ray = new THREE.Ray();
+const _target = new THREE.Vector3();
+
+/** Unprojects an NDC corner through the camera onto the Y=0 ground plane */
+function ndcToGround(
+  camera: THREE.Camera,
+  ndcX: number,
+  ndcY: number,
+  out: THREE.Vector3
+): boolean {
+  // Build a ray from the camera through the NDC point
+  const ndc = new THREE.Vector3(ndcX, ndcY, 0.5).unproject(camera);
+  _ray.origin.copy(camera.position);
+  _ray.direction.copy(ndc).sub(camera.position).normalize();
+  const t = _groundPlane.distanceToPoint(_ray.origin) / -_groundPlane.normal.dot(_ray.direction);
+  if (!isFinite(t) || t < 0) return false;
+  out.copy(_ray.origin).addScaledVector(_ray.direction, t);
+  return true;
+}
+
+interface Props {
+  onViewportChange: (vp: Viewport2D) => void;
+  /** How often to update in ms — 100ms is plenty for culling */
+  intervalMs?: number;
+}
+
+export default function ViewportTracker({ onViewportChange, intervalMs = 100 }: Props) {
+  const { camera } = useThree();
+  const lastUpdate = useRef(0);
+  const corners = [
+    new THREE.Vector3(), new THREE.Vector3(),
+    new THREE.Vector3(), new THREE.Vector3(),
+  ];
+
+  useFrame((_, delta) => {
+    lastUpdate.current += delta * 1000;
+    if (lastUpdate.current < intervalMs) return;
+    lastUpdate.current = 0;
+
+    // Project the 4 NDC screen corners onto the ground plane
+    const hits: THREE.Vector3[] = [];
+    const ndcCorners: [number, number][] = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+    for (let i = 0; i < 4; i++) {
+      if (ndcToGround(camera, ndcCorners[i][0], ndcCorners[i][1], corners[i])) {
+        hits.push(corners[i]);
+      }
+    }
+
+    // Fallback: camera is looking horizontally (no ground intersection)
+    // Use a wide box around camera XZ position instead
+    if (hits.length < 2) {
+      const fallbackRadius = 1500;
+      onViewportChange({
+        minX: camera.position.x - fallbackRadius,
+        minZ: camera.position.z - fallbackRadius,
+        maxX: camera.position.x + fallbackRadius,
+        maxZ: camera.position.z + fallbackRadius,
+      });
+      return;
+    }
+
+    // Compute bounding box of ground intersections
+    let minX = Infinity, minZ = Infinity, maxX = -Infinity, maxZ = -Infinity;
+    for (const h of hits) {
+      if (h.x < minX) minX = h.x;
+      if (h.x > maxX) maxX = h.x;
+      if (h.z < minZ) minZ = h.z;
+      if (h.z > maxZ) maxZ = h.z;
+    }
+
+    // Clamp to sane values (avoid Infinity when camera looks at horizon)
+    const MAX_RANGE = 3000;
+    minX = Math.max(minX, camera.position.x - MAX_RANGE);
+    maxX = Math.min(maxX, camera.position.x + MAX_RANGE);
+    minZ = Math.max(minZ, camera.position.z - MAX_RANGE);
+    maxZ = Math.min(maxZ, camera.position.z + MAX_RANGE);
+
+    onViewportChange({ minX, minZ, maxX, maxZ });
+  });
+
+  return null;
+}

--- a/src/hooks/useSpatialCulling.ts
+++ b/src/hooks/useSpatialCulling.ts
@@ -1,0 +1,32 @@
+
+import { useMemo, useRef } from "react";
+import { SpatialGrid, type Viewport2D } from "@/lib/spatialGrid";
+import type { CityBuilding } from "@/lib/github";
+
+/**
+ * Builds a spatial grid from allBuildings (rebuilt only when buildings change),
+ * then returns only buildings visible inside the current camera viewport.
+ *
+ * @param allBuildings  Full list of buildings from Supabase
+ * @param viewport      Current XZ viewport derived from camera frustum
+ * @param padding       Extra world-units buffer beyond viewport edges (prevents pop-in)
+ */
+export function useSpatialCulling(
+  allBuildings: CityBuilding[],
+  viewport: Viewport2D,
+  padding = 400
+): CityBuilding[] {
+  const gridRef = useRef<SpatialGrid | null>(null);
+
+  const grid = useMemo(() => {
+    const g = new SpatialGrid(600);
+    for (const b of allBuildings) g.insert(b);
+    gridRef.current = g;
+    return g;
+  }, [allBuildings]);
+
+  return useMemo(
+    () => grid.query(viewport, padding),
+    [grid, viewport, padding]
+  );
+}

--- a/src/hooks/useSpatialCulling.ts
+++ b/src/hooks/useSpatialCulling.ts
@@ -1,8 +1,8 @@
-
+ 
 import { useMemo, useRef } from "react";
 import { SpatialGrid, type Viewport2D } from "@/lib/spatialGrid";
 import type { CityBuilding } from "@/lib/github";
-
+ 
 /**
  * Builds a spatial grid from allBuildings (rebuilt only when buildings change),
  * then returns only buildings visible inside the current camera viewport.
@@ -14,19 +14,22 @@ import type { CityBuilding } from "@/lib/github";
 export function useSpatialCulling(
   allBuildings: CityBuilding[],
   viewport: Viewport2D,
-  padding = 400
+  padding = 800
 ): CityBuilding[] {
   const gridRef = useRef<SpatialGrid | null>(null);
-
+ 
+  // Rebuild grid only when the buildings array changes
   const grid = useMemo(() => {
     const g = new SpatialGrid(600);
     for (const b of allBuildings) g.insert(b);
     gridRef.current = g;
     return g;
   }, [allBuildings]);
-
+ 
+  // Query is cheap — runs on every viewport change
   return useMemo(
     () => grid.query(viewport, padding),
     [grid, viewport, padding]
   );
 }
+ 

--- a/src/lib/spatialGrid.ts
+++ b/src/lib/spatialGrid.ts
@@ -1,0 +1,59 @@
+export interface BuildingData {
+  id: string;
+  x: number;        // world-space X position
+  y: number;        // world-space Y position (or Z if isometric)
+  [key: string]: unknown;
+}
+
+export interface Viewport {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * Uniform spatial grid for O(1) average-case building lookup.
+ * cellSize should roughly match the average spacing between buildings.
+ */
+export class SpatialGrid<T extends BuildingData> {
+  private cells = new Map<string, T[]>();
+  private cellSize: number;
+
+  constructor(cellSize = 500) {
+    this.cellSize = cellSize;
+  }
+
+  private cellKey(cx: number, cy: number): string {
+    return `${cx}|${cy}`;
+  }
+
+  insert(item: T): void {
+    const cx = Math.floor(item.x / this.cellSize);
+    const cy = Math.floor(item.y / this.cellSize);
+    const key = this.cellKey(cx, cy);
+    if (!this.cells.has(key)) this.cells.set(key, []);
+    this.cells.get(key)!.push(item);
+  }
+
+  /** Returns all items whose cell overlaps the given viewport (with optional padding). */
+  query(viewport: Viewport, padding = 0): T[] {
+    const minCX = Math.floor((viewport.minX - padding) / this.cellSize);
+    const minCY = Math.floor((viewport.minY - padding) / this.cellSize);
+    const maxCX = Math.floor((viewport.maxX + padding) / this.cellSize);
+    const maxCY = Math.floor((viewport.maxY + padding) / this.cellSize);
+
+    const results: T[] = [];
+    for (let cx = minCX; cx <= maxCX; cx++) {
+      for (let cy = minCY; cy <= maxCY; cy++) {
+        const cell = this.cells.get(this.cellKey(cx, cy));
+        if (cell) results.push(...cell);
+      }
+    }
+    return results;
+  }
+
+  clear(): void {
+    this.cells.clear();
+  }
+}

--- a/src/lib/spatialGrid.ts
+++ b/src/lib/spatialGrid.ts
@@ -1,58 +1,53 @@
-export interface BuildingData {
-  id: string;
-  x: number;        // world-space X position
-  y: number;        // world-space Y position (or Z if isometric)
-  [key: string]: unknown;
-}
 
-export interface Viewport {
+import type { CityBuilding } from "@/lib/github";
+ 
+export interface Viewport2D {
   minX: number;
-  minY: number;
+  minZ: number;
   maxX: number;
-  maxY: number;
+  maxZ: number;
 }
-
+ 
 /**
- * Uniform spatial grid for O(1) average-case building lookup.
- * cellSize should roughly match the average spacing between buildings.
+ * Uniform spatial grid for fast XZ-plane building queries.
+ * Uses position[0] (X) and position[2] (Z) matching CityBuilding layout.
  */
-export class SpatialGrid<T extends BuildingData> {
-  private cells = new Map<string, T[]>();
-  private cellSize: number;
-
-  constructor(cellSize = 500) {
+export class SpatialGrid {
+  private cells = new Map<string, CityBuilding[]>();
+  private readonly cellSize: number;
+ 
+  constructor(cellSize = 600) {
     this.cellSize = cellSize;
   }
-
-  private cellKey(cx: number, cy: number): string {
-    return `${cx}|${cy}`;
+ 
+  private key(cx: number, cz: number): string {
+    return `${cx}|${cz}`;
   }
-
-  insert(item: T): void {
-    const cx = Math.floor(item.x / this.cellSize);
-    const cy = Math.floor(item.y / this.cellSize);
-    const key = this.cellKey(cx, cy);
-    if (!this.cells.has(key)) this.cells.set(key, []);
-    this.cells.get(key)!.push(item);
+ 
+  insert(b: CityBuilding): void {
+    const cx = Math.floor(b.position[0] / this.cellSize);
+    const cz = Math.floor(b.position[2] / this.cellSize);
+    const k = this.key(cx, cz);
+    if (!this.cells.has(k)) this.cells.set(k, []);
+    this.cells.get(k)!.push(b);
   }
-
-  /** Returns all items whose cell overlaps the given viewport (with optional padding). */
-  query(viewport: Viewport, padding = 0): T[] {
-    const minCX = Math.floor((viewport.minX - padding) / this.cellSize);
-    const minCY = Math.floor((viewport.minY - padding) / this.cellSize);
-    const maxCX = Math.floor((viewport.maxX + padding) / this.cellSize);
-    const maxCY = Math.floor((viewport.maxY + padding) / this.cellSize);
-
-    const results: T[] = [];
+ 
+  query(vp: Viewport2D, padding = 400): CityBuilding[] {
+    const minCX = Math.floor((vp.minX - padding) / this.cellSize);
+    const minCZ = Math.floor((vp.minZ - padding) / this.cellSize);
+    const maxCX = Math.floor((vp.maxX + padding) / this.cellSize);
+    const maxCZ = Math.floor((vp.maxZ + padding) / this.cellSize);
+ 
+    const out: CityBuilding[] = [];
     for (let cx = minCX; cx <= maxCX; cx++) {
-      for (let cy = minCY; cy <= maxCY; cy++) {
-        const cell = this.cells.get(this.cellKey(cx, cy));
-        if (cell) results.push(...cell);
+      for (let cz = minCZ; cz <= maxCZ; cz++) {
+        const cell = this.cells.get(this.key(cx, cz));
+        if (cell) out.push(...cell);
       }
     }
-    return results;
+    return out;
   }
-
+ 
   clear(): void {
     this.cells.clear();
   }


### PR DESCRIPTION

<img width="1470" height="956" alt="Screenshot 2026-06-25 at 9 01 43 AM" src="https://github.com/user-attachments/assets/f641eebe-d998-45f2-abd8-856f54e365fb" />

## Summary
Implements 2D spatial culling and viewport virtualization for the Global 
City Map, replacing the previous batch-loading approach with a camera-driven 
system that only renders buildings visible in the current viewport.

## Changes

### New Files
- `src/lib/spatialGrid.ts` — Uniform spatial grid data structure using 
  CityBuilding's XZ coordinate system (`position[0]`, `position[2]`). 
  Supports O(1) average-case insertion and fast range queries.
- `src/hooks/useSpatialCulling.ts` — React hook that builds the spatial 
  grid from all buildings and returns only those within the current viewport 
  bounds. Grid is rebuilt only when the buildings array changes.
- `src/components/ViewportTracker.tsx` — Three.js component that runs inside 
  `<Canvas>` and projects camera frustum corners onto the Y=0 ground plane 
  every 200ms to derive the visible world-space viewport. Includes a smart 
  fallback for high-angle/horizontal camera views and skips updates when 
  viewport hasn't changed meaningfully (50-unit threshold).

### Modified Files
- `src/components/CityCanvas.tsx` — Replaced the previous `initialBuildings` 
  + `setTimeout` batch-loading system with spatial culling. Buildings are now 
  dynamically shown/hidden based on camera position and orientation.

## How It Works
1. All buildings are inserted into a `SpatialGrid` (cell size: 600 units) 
   when the buildings array loads.
2. `ViewportTracker` reads the Three.js camera every 200ms and projects the 
   4 screen corners onto the ground plane to get world-space bounds.
3. `useSpatialCulling` queries the grid with an 800-unit padding buffer and 
   returns only visible buildings.
4. `CityScene` receives and renders only the culled subset — unmounted 
   buildings have zero GPU cost.

## Performance Impact
- Reduces draw calls proportionally to zoom level
- Buildings outside the viewport are fully unmounted (no GPU overhead)
- Viewport recalculation runs at most every 200ms and skips no-op updates
- Grid rebuild only happens when Supabase data changes

## Testing
- [x] Buildings are clickable at all zoom levels
- [x] No buildings pop in/out visibly at screen edges while orbiting
- [x] Fly mode renders buildings correctly as camera moves
- [x] Performance improvement visible with `?perf` query param (Stats panel)

closes #687 