### PR TITLE
fix(arcade-shop): return error responses instead of fabricated success on DB failures

### DIFF
--- a/src/app/api/arcade/shop/route.ts
+++ b/src/app/api/arcade/shop/route.ts
@@ -73,8 +73,8 @@ export async function GET() {
       owned: owned.has(item.id),
     }));
     balance = walletRes.data?.balance ?? 0;
-  } catch (err: any) {
-    console.error("[shop] Failed to load shop data:", err.message);
+  } catch (err: unknown) {
+    console.error("[shop] Failed to load shop data:", err instanceof Error ? err.message : err);
     return NextResponse.json(
       { error: "Failed to load shop data" },
       { status: 500 },

--- a/src/app/api/arcade/shop/route.ts
+++ b/src/app/api/arcade/shop/route.ts
@@ -74,9 +74,11 @@ export async function GET() {
     }));
     balance = walletRes.data?.balance ?? 0;
   } catch (err: any) {
-    console.debug("[shop] DB table not found, using fallback items:", err.message);
-    items = FALLBACK_ITEMS.map(item => ({ ...item, owned: true }));
-    balance = 100;
+    console.error("[shop] Failed to load shop data:", err.message);
+    return NextResponse.json(
+      { error: "Failed to load shop data" },
+      { status: 500 },
+    );
   }
 
   return NextResponse.json({
@@ -151,11 +153,10 @@ export async function POST(request: Request) {
       price: result?.price ?? 0,
     });
   } catch (e) {
-    console.warn("Could not purchase item via DB, mocking success:", e);
-    return NextResponse.json({
-      purchased: itemId,
-      balance: 100,
-      price: 0,
-    });
+    console.error("[shop] Purchase failed:", e);
+    return NextResponse.json(
+      { error: "Purchase failed" },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?
Fixes the arcade shop route returning fabricated success responses when database operations fail.

- **GET handler:** catch block returned fallback items with `owned: true` and `balance: 100`, causing the shop UI to show every item as owned even when the user has zero items and zero balance.
- **POST handler:** catch block returned `{ purchased: itemId, balance: 100, price: 0 }`, masking real DB errors from the client.

Both now return proper 500 error responses so the client receives accurate error information.

## Related issue
Fixes #701

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested this change locally
- [x] My code follows the style guidelines of this project