### PR TITLE
fix(checkout): use last x-forwarded-for entry for rate-limit IP

### DIFF
--- a/src/app/api/support/checkout/route.ts
+++ b/src/app/api/support/checkout/route.ts
@@ -6,10 +6,12 @@ import { rateLimit } from "@/lib/rate-limit";
 const MIN_AMOUNT = 10; // minimum ₹10 INR for checkouts
 
 export async function POST(request: Request) {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    "unknown";
+  const forwarded = request.headers.get("x-forwarded-for");
+  let ip = request.headers.get("x-real-ip") ?? "unknown";
+  if (forwarded) {
+    const ips = forwarded.split(",").map((s) => s.trim()).filter(Boolean);
+    if (ips.length > 0) ip = ips[ips.length - 1];
+  }
 
   const { ok } = await rateLimit(`checkout:${ip}`, 1, 5_000);
   if (!ok) {


### PR DESCRIPTION
## What does this PR do?
Fixes the support checkout route using a spoofable IP extraction for rate limiting.

The checkout route extracted the client IP using `x-forwarded-for.split(",")[0]` (the first entry), which is the most easily spoofable position. An attacker can send `X-Forwarded-For: 1.2.3.4` to bypass the rate limit.

Now uses the **last** entry (`ips[ips.length - 1]`), matching the existing pattern in `src/middleware.ts` which already has an explicit comment explaining why the first entry is spoofable.

## Related issue
Fixes #702

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested this change locally
- [x] My code follows the style guidelines of this project