### PR TITLE
fix(fly-scores): resolve username/avatar from to-one developers embed (#714)

### DIFF
--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -3,6 +3,7 @@ import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
 import { trackDailyMission } from "@/lib/dailies";
+import { buildFlyLeaderboard, type FlyScoreRow } from "@/lib/fly-leaderboard";
 
 function getTodaySeed() {
   const now = new Date();
@@ -23,27 +24,6 @@ function maxScoreForCollected(collected: number): number {
 
 interface FlyScoreDev {
   developer_id: number;
-}
-
-interface FlyScoreLeaderboard {
-  score: number;
-  collected: number;
-  max_combo: number;
-  flight_ms: number;
-  created_at: string;
-  developer_id: number;
-  developers: any;
-}
-
-// Type for the raw data from Supabase (developers is an array)
-interface FlyScoreRaw {
-  score: number;
-  collected: number;
-  max_combo: number;
-  flight_ms: number;
-  created_at: string;
-  developer_id: number;
-  developers: { github_login: string; avatar_url: string }[] | null;
 }
 
 export async function POST(request: Request) {
@@ -217,23 +197,11 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Failed to fetch" }, { status: 500 });
   }
 
-  const seen = new Set<number>();
-  // Use the raw type for filtering since developers comes as array
-  const unique = (data ?? []).filter((row: FlyScoreRaw) => {
-    if (seen.has(row.developer_id)) return false;
-    seen.add(row.developer_id);
-    return true;
-  });
-
-  const leaderboard = unique.slice(0, 20).map((row: FlyScoreRaw) => ({
-    score: row.score,
-    collected: row.collected,
-    max_combo: row.max_combo,
-    flight_ms: row.flight_ms,
-    created_at: row.created_at,
-    github_login: row.developers?.[0]?.github_login,
-    avatar_url: row.developers?.[0]?.avatar_url,
-  }));
+  // `developers` is a to-one embed (single object); buildFlyLeaderboard
+  // dedupes per developer, takes the top 20, and resolves login/avatar.
+  const leaderboard = buildFlyLeaderboard(
+    (data ?? []) as unknown as FlyScoreRow[],
+  );
 
   const total = new Set((devIds ?? []).map((r: FlyScoreDev) => r.developer_id)).size;
 

--- a/src/lib/__tests__/fly-leaderboard.test.ts
+++ b/src/lib/__tests__/fly-leaderboard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { buildFlyLeaderboard, type FlyScoreRow } from "../fly-leaderboard";
+
+function row(overrides: Partial<FlyScoreRow> = {}): FlyScoreRow {
+  return {
+    score: 100,
+    collected: 5,
+    max_combo: 3,
+    flight_ms: 12_000,
+    created_at: "2026-06-01T00:00:00.000Z",
+    developer_id: 1,
+    developers: { github_login: "alice", avatar_url: "https://img/alice.png" },
+    ...overrides,
+  };
+}
+
+describe("buildFlyLeaderboard", () => {
+  it("resolves github_login/avatar_url from a to-one object embed (regression for #714)", () => {
+    // `developers` arrives as a single object for the to-one FK relationship.
+    const result = buildFlyLeaderboard([row()]);
+    expect(result[0].github_login).toBe("alice");
+    expect(result[0].avatar_url).toBe("https://img/alice.png");
+  });
+
+  it("still resolves login/avatar if the embed arrives as an array (typegen quirk)", () => {
+    const result = buildFlyLeaderboard([
+      row({
+        developers: [{ github_login: "bob", avatar_url: "https://img/bob.png" }],
+      }),
+    ]);
+    expect(result[0].github_login).toBe("bob");
+    expect(result[0].avatar_url).toBe("https://img/bob.png");
+  });
+
+  it("returns null login/avatar (never undefined) when the embed is missing", () => {
+    const result = buildFlyLeaderboard([row({ developers: null })]);
+    expect(result[0].github_login).toBeNull();
+    expect(result[0].avatar_url).toBeNull();
+  });
+
+  it("keeps only the first (best) row per developer", () => {
+    const result = buildFlyLeaderboard([
+      row({ developer_id: 1, score: 200 }),
+      row({ developer_id: 1, score: 50 }),
+      row({ developer_id: 2, score: 80, developers: { github_login: "carol", avatar_url: null } }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ score: 200, github_login: "alice" });
+    expect(result[1]).toMatchObject({ score: 80, github_login: "carol" });
+  });
+
+  it("caps the leaderboard at the requested limit", () => {
+    const rows = Array.from({ length: 25 }, (_, i) =>
+      row({ developer_id: i + 1, github_login: `u${i}` } as Partial<FlyScoreRow>),
+    );
+    expect(buildFlyLeaderboard(rows)).toHaveLength(20);
+    expect(buildFlyLeaderboard(rows, 5)).toHaveLength(5);
+  });
+
+  it("projects the scalar score fields unchanged", () => {
+    const result = buildFlyLeaderboard([
+      row({ score: 321, collected: 9, max_combo: 7, flight_ms: 9999 }),
+    ]);
+    expect(result[0]).toMatchObject({
+      score: 321,
+      collected: 9,
+      max_combo: 7,
+      flight_ms: 9999,
+      created_at: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("handles null/undefined input", () => {
+    expect(buildFlyLeaderboard(null)).toEqual([]);
+    expect(buildFlyLeaderboard(undefined)).toEqual([]);
+  });
+});

--- a/src/lib/fly-leaderboard.ts
+++ b/src/lib/fly-leaderboard.ts
@@ -1,0 +1,70 @@
+// Helpers for building the Fly-game leaderboard from raw Supabase rows.
+//
+// `fly_scores.developer_id` is a single-column FK to `developers(id)`, so the
+// `developers` embed is a to-one relationship and PostgREST returns it as a
+// single object (not an array). Supabase's generated types sometimes still
+// type to-one embeds as arrays, so we normalize defensively here.
+
+export interface FlyDeveloperEmbed {
+  github_login: string | null;
+  avatar_url: string | null;
+}
+
+export interface FlyScoreRow {
+  score: number;
+  collected: number;
+  max_combo: number;
+  flight_ms: number;
+  created_at: string;
+  developer_id: number;
+  // Object for a to-one embed; array tolerated for resilience to typegen quirks.
+  developers: FlyDeveloperEmbed | FlyDeveloperEmbed[] | null;
+}
+
+export interface FlyLeaderboardEntry {
+  score: number;
+  collected: number;
+  max_combo: number;
+  flight_ms: number;
+  created_at: string;
+  github_login: string | null;
+  avatar_url: string | null;
+}
+
+/** Normalize a to-one embed that may arrive as an object, an array, or null. */
+function firstDeveloper(
+  embed: FlyDeveloperEmbed | FlyDeveloperEmbed[] | null,
+): FlyDeveloperEmbed | null {
+  if (!embed) return null;
+  return Array.isArray(embed) ? (embed[0] ?? null) : embed;
+}
+
+/**
+ * Build the Fly leaderboard: keep the best row per developer (rows are expected
+ * pre-sorted best-first), take the top `limit`, and project to public entries
+ * with the developer's login/avatar resolved from the to-one embed.
+ */
+export function buildFlyLeaderboard(
+  rows: FlyScoreRow[] | null | undefined,
+  limit = 20,
+): FlyLeaderboardEntry[] {
+  const seen = new Set<number>();
+  const unique = (rows ?? []).filter((row) => {
+    if (seen.has(row.developer_id)) return false;
+    seen.add(row.developer_id);
+    return true;
+  });
+
+  return unique.slice(0, limit).map((row) => {
+    const dev = firstDeveloper(row.developers);
+    return {
+      score: row.score,
+      collected: row.collected,
+      max_combo: row.max_combo,
+      flight_ms: row.flight_ms,
+      created_at: row.created_at,
+      github_login: dev?.github_login ?? null,
+      avatar_url: dev?.avatar_url ?? null,
+    };
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the Fly-game leaderboard returning `undefined` usernames and avatars.

`GET /api/fly-scores` indexed the `developers` Supabase embed as an array (`row.developers?.[0]?.github_login`), but `fly_scores.developer_id` is a single-column FK to `developers(id)` — a **to-one** relationship — so PostgREST returns the embed as a **single object**, not an array. The `?.[0]` access was therefore always `undefined`, so the Fly leaderboard showed no names/avatars and `FlyLeaderboard.tsx` could never highlight the current user (it matches on `github_login`).

Changes:
- Extracted a pure, unit-tested helper `src/lib/fly-leaderboard.ts` (`buildFlyLeaderboard`) that dedupes per developer, caps at top 20, and resolves `github_login`/`avatar_url` from the to-one embed (normalizing defensively if the embed ever arrives as an array, returning `null` rather than `undefined` when absent).
- Removed the misleading `FlyScoreRaw` / unused `FlyScoreLeaderboard` types and the stale "developers comes as array" comments.
- Added `src/lib/__tests__/fly-leaderboard.test.ts` (7 cases).

This matches how `arena/leaderboard` (`row.developer.github_login`) and `raid/history` (`r.attacker?.github_login`) already consume the to-one `developers` embed. No change to the API response shape (`{ seed, leaderboard, total }`) or to scoring/ranking — only the previously-`undefined` `github_login`/`avatar_url` fields are now populated.

## Related issue

Fixes #714

## Screenshots

No visual asset attached — server-side data fix. Behavioural change: each `leaderboard[]` entry from `GET /api/fly-scores` now includes the real `github_login` and `avatar_url` instead of `undefined`.

## Checklist

- [x] `npm run lint` passes (eslint clean on changed files)
- [x] Tested locally (`vitest run` — 7/7 pass; `tsc --noEmit` — no errors in changed files)
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ I have starred this repository!
