### PR TITLE
fix(streak-reminder): paginate dailies section to process all users

### DIFF
--- a/src/app/api/cron/streak-reminder/route.ts
+++ b/src/app/api/cron/streak-reminder/route.ts
@@ -81,7 +81,7 @@ export async function GET(request: NextRequest) {
 
   // ─── Dailies reminders: users with 1-2 missions done but not 3 ────
   const dailiesResults = { reminded: 0, skipped: 0 };
-  const dailiesOffset = 0;
+  let dailiesOffset = 0;
 
   while (true) {
     // Find devs who have some (but not all) missions done today
@@ -128,8 +128,8 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Only one pass needed since we fetched all progress rows at once
-    break;
+    if (batch.length < batchSize) break;
+    dailiesOffset += batchSize;
   }
 
   return NextResponse.json({ ok: true, ...results, dailies: dailiesResults });


### PR DESCRIPTION
## What does this PR do?
Fixes the dailies reminder section silently dropping reminders for users beyond the first 50.

The dailies section fetched ALL partial-progress developers but only processed the first 50 (`batchSize`). The `while (true)` loop broke immediately after the first batch because:
1. `dailiesOffset` was declared as `const` and never incremented
2. The loop had an unconditional `break` at the end

The streak section (top of file) already correctly paginated with `offset += batchSize`. This applies the same pattern to the dailies section.

## Related issue
Fixes #704

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested this change locally
- [x] My code follows the style guidelines of this project