### PR TITLE
feat: make ChronoTower clickable to open roadmap #664

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 /* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/refs, react-hooks/immutability */
 import { useRef, useEffect, useState, useMemo, lazy, Suspense } from "react";
+import { useRouter } from "next/navigation";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF, Stats } from "@react-three/drei";
 import * as THREE from "three";
@@ -2218,6 +2219,7 @@ export default function CityCanvas({
   multiplayerPlayers,
 }: Props) {
   const { isRaining } = useWeather();
+  const router = useRouter();
   const t = THEMES[themeIndex] ?? THEMES[0];
   const showPerf = typeof window !== "undefined" && new URLSearchParams(window.location.search).has("perf");
   const flyPosRef = useRef(new THREE.Vector3());
@@ -2231,7 +2233,9 @@ export default function CityCanvas({
     }
     return max;
   }, [buildings]);
-
+  const handleChronoTowerClick = () => {
+    router.push("/roadmap");
+  };
   const landmarkPositions = useMemo(() => {
     const radius = 380;
     const count = 14;
@@ -2426,7 +2430,10 @@ export default function CityCanvas({
             position={landmarkPositions[7]}
           />
           <Suspense fallback={null}>
-            <ChronoTower onClick={() => { }} position={landmarkPositions[8]} />
+            <ChronoTower
+              onClick={handleChronoTowerClick}
+              position={landmarkPositions[8]}
+            />
             <SkyTemple onClick={onSkyTempleClick ?? (() => { })} position={landmarkPositions[9]} />
             <FirecrawlBuilding onClick={() => { }} position={landmarkPositions[10]} />
             <SolanaBuilding onClick={() => { }} position={landmarkPositions[11]} />


### PR DESCRIPTION
## What does this PR do?
- Makes the ChronoTower clickable in the city scene
- Navigates users to `/roadmap` when ChronoTower is clicked
- Keeps the change scoped only to issue #664

## Related issue
Fixes #664 

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] I tested the change locally
- [x] The change is scoped only to this issue
- [x] No unrelated files were intentionally modified

## Visual Proof
### Before
ChronoTower was visible in the city scene but clicking it did not open the roadmap page.

### After
Clicking ChronoTower now navigates the user to `/roadmap`.

**Screenshot :**
<img width="948" height="464" alt="Screenshot 2026-06-25 222319" src="https://github.com/user-attachments/assets/af23b199-39ac-4c87-b9d7-8ad3ea1e348b" />

<img width="953" height="422" alt="Screenshot 2026-06-25 234654" src="https://github.com/user-attachments/assets/11d52270-249a-483c-80a0-ce0cc4263ab7" />

<img width="916" height="458" alt="image" src="https://github.com/user-attachments/assets/bb6f231f-0ff3-4348-88e3-34db3630ee9e" />

