### PR TITLE
[Bug]: Remove duplicate ARENA_CRYPTO_KEY definition in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,11 +80,6 @@ CACHE_TTL_HOURS=
 # OpenWeatherMap API (Weather feature)
 OPENWEATHER_API_KEY=
 
-# ── Arena Crypto Key (REQUIRED for arena features) ───────────
-# Used to encrypt/decrypt hidden test cases for arena challenges.
-# Generate one with: openssl rand -hex 32
-ARENA_CRYPTO_KEY=
-
 # ── E.Arcade Admin/Editor configuration ──────────────────────
 # Comma-separated list of GitHub usernames permitted to edit maps/portals.
 ADMIN_GITHUB_LOGINS=


### PR DESCRIPTION
## What does this PR do?

Removes the duplicate `ARENA_CRYPTO_KEY` at the "Arena Crypto Key (REQUIRED for arena features)" section (lines 83-86). The key is already defined once at the "Arena hidden-test encryption" section (lines 30-34). The duplicate causes silent config failures — developers who fill the first occurrence but miss the second get an empty key at runtime.

## Related issue

Fixes #720

## Screenshots

N/A

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
