### PR TITLE
[Bug]: Add WeatherData interface and typed return for fetchWeatherByCoords

### DIFF
--- a/src/hooks/useWeatherMap.ts
+++ b/src/hooks/useWeatherMap.ts
@@ -54,18 +54,18 @@ export function useWeatherMap() {
   );
 
   // Map OpenWeather codes (2xx Thunderstorm, 3xx Drizzle, 5xx Rain) to our boolean
-const weatherId = data?.weather?.[0]?.id;
-const isRaining = weatherId >= 200 && weatherId < 600;
+  const weatherId = data?.weather?.[0]?.id;
+  const isRaining = weatherId !== undefined && weatherId >= 200 && weatherId < 600;
 
-// Convert whatever error happens into a clean string text
-const errorMessage = geoError 
-  ? geoError 
-  : error 
-    ? (error instanceof Error ? error.message : String(error)) 
-    : null;
+  // Convert whatever error happens into a clean string text
+  const errorMessage = geoError 
+    ? geoError 
+    : error 
+      ? (error instanceof Error ? error.message : String(error)) 
+      : null;
 
-// Hook is loading if either geolocation or SWR is loading
-const isLoading = isGeoLoading || (isSWRILoading && !geoError);
+  // Hook is loading if either geolocation or SWR is loading
+  const isLoading = isGeoLoading || (isSWRILoading && !geoError);
 
-return { isRaining, data, isLoading, error: errorMessage };
+  return { isRaining, data, isLoading, error: errorMessage };
 }

--- a/src/hooks/useWeatherMap.ts
+++ b/src/hooks/useWeatherMap.ts
@@ -2,8 +2,6 @@ import { useState, useEffect } from 'react';
 import useSWR from 'swr';
 import { fetchWeatherByCoords } from '@/services/weatherService';
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
-
 export function useWeatherMap() {
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [geoError, setGeoError] = useState<string | null>(null);
@@ -11,42 +9,28 @@ export function useWeatherMap() {
 
   // 1. Get User Coordinates
   useEffect(() => {
-    let isMounted = true;
-
     if (!navigator.geolocation) {
-      if (isMounted) {
-        setGeoError("Geolocation is not supported by your browser");
-        setIsGeoLoading(false);
-      }
+      setGeoError("Geolocation is not supported by your browser");
+      setIsGeoLoading(false);
       return;
     }
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        if (isMounted) {
-          setCoords({
-            lat: position.coords.latitude,
-            lon: position.coords.longitude,
-          });
-          setIsGeoLoading(false);
-        }
+        setCoords({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+        });
+        setIsGeoLoading(false);
       },
       (err) => {
-        if (isMounted) {
-          setGeoError(err.message);
-          setIsGeoLoading(false);
-        }
+        setGeoError(err.message);
+        setIsGeoLoading(false);
       }
     );
-
-    return () => {
-      isMounted = false;
-    };
   }, []);
 
   // 2. Fetch Weather Data via SWR (only runs if coords exist)
-  // Note: You will need a free OpenWeatherMap API key in your .env.local
-  const apiKey = process.env.NEXT_PUBLIC_OPENWEATHER_API_KEY; 
   const { data, error, isLoading: isSWRILoading } = useSWR(
     coords ? ['weather', coords.lat, coords.lon] : null,
     () => fetchWeatherByCoords(coords!.lat, coords!.lon),

--- a/src/hooks/useWeatherMap.ts
+++ b/src/hooks/useWeatherMap.ts
@@ -4,19 +4,22 @@ import { fetchWeatherByCoords } from '@/services/weatherService';
 
 export function useWeatherMap() {
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
-  const [geoError, setGeoError] = useState<string | null>(null);
-  const [isGeoLoading, setIsGeoLoading] = useState(true);
+  const [geoError, setGeoError] = useState<string | null>(() =>
+    typeof navigator !== 'undefined' && !navigator.geolocation
+      ? 'Geolocation is not supported by your browser'
+      : null
+  );
+  const [isGeoLoading, setIsGeoLoading] = useState(() =>
+    typeof navigator !== 'undefined' && !!navigator.geolocation
+  );
 
-  // 1. Get User Coordinates
   useEffect(() => {
-    if (!navigator.geolocation) {
-      setGeoError("Geolocation is not supported by your browser");
-      setIsGeoLoading(false);
-      return;
-    }
+    if (!navigator.geolocation) return;
 
+    let cancel = false;
     navigator.geolocation.getCurrentPosition(
       (position) => {
+        if (cancel) return;
         setCoords({
           lat: position.coords.latitude,
           lon: position.coords.longitude,
@@ -24,31 +27,29 @@ export function useWeatherMap() {
         setIsGeoLoading(false);
       },
       (err) => {
+        if (cancel) return;
         setGeoError(err.message);
         setIsGeoLoading(false);
       }
     );
+    return () => { cancel = true; };
   }, []);
 
-  // 2. Fetch Weather Data via SWR (only runs if coords exist)
   const { data, error, isLoading: isSWRILoading } = useSWR(
     coords ? ['weather', coords.lat, coords.lon] : null,
     () => fetchWeatherByCoords(coords!.lat, coords!.lon),
     { refreshInterval: 600000 }
   );
 
-  // Map OpenWeather codes (2xx Thunderstorm, 3xx Drizzle, 5xx Rain) to our boolean
   const weatherId = data?.weather?.[0]?.id;
   const isRaining = weatherId !== undefined && weatherId >= 200 && weatherId < 600;
 
-  // Convert whatever error happens into a clean string text
-  const errorMessage = geoError 
-    ? geoError 
-    : error 
-      ? (error instanceof Error ? error.message : String(error)) 
+  const errorMessage = geoError
+    ? geoError
+    : error
+      ? (error instanceof Error ? error.message : String(error))
       : null;
 
-  // Hook is loading if either geolocation or SWR is loading
   const isLoading = isGeoLoading || (isSWRILoading && !geoError);
 
   return { isRaining, data, isLoading, error: errorMessage };

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -1,10 +1,62 @@
-export const fetchWeatherByCoords = async (lat: number, lon: number): Promise<any> => {
-  // Instead of hitting OpenWeatherMap directly, we hit our own safe Next.js API route
+export interface WeatherData {
+  coord: {
+    lon: number;
+    lat: number;
+  };
+  weather: Array<{
+    id: number;
+    main: string;
+    description: string;
+    icon: string;
+  }>;
+  base: string;
+  main: {
+    temp: number;
+    feels_like: number;
+    temp_min: number;
+    temp_max: number;
+    pressure: number;
+    humidity: number;
+    sea_level?: number;
+    grnd_level?: number;
+  };
+  visibility: number;
+  wind: {
+    speed: number;
+    deg: number;
+    gust?: number;
+  };
+  clouds: {
+    all: number;
+  };
+  rain?: {
+    "1h"?: number;
+    "3h"?: number;
+  };
+  snow?: {
+    "1h"?: number;
+    "3h"?: number;
+  };
+  dt: number;
+  sys: {
+    type?: number;
+    id?: number;
+    country?: string;
+    sunrise: number;
+    sunset: number;
+  };
+  timezone: number;
+  id: number;
+  name: string;
+  cod: number;
+}
+
+export const fetchWeatherByCoords = async (lat: number, lon: number): Promise<WeatherData> => {
   const response = await fetch(`/api/weather?lat=${lat}&lon=${lon}`);
-  
+
   if (!response.ok) {
     throw new Error("Weather data fetch failed via internal API");
   }
-  
+
   return response.json();
 };


### PR DESCRIPTION
## What does this PR do?

Defines and exports a `WeatherData` interface matching the OpenWeatherMap API response shape, and changes `fetchWeatherByCoords` return type from `Promise<any>` to `Promise<WeatherData>`. This provides compile-time type safety for all consumers (e.g., `useWeatherMap.ts`).

## Related issue

Fixes #721

## Screenshots

N/A

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
