### PR TITLE
test: add regression tests for Sky Ads API routes

### DIFF
--- a/src/app/api/sky-ads/checkout/route.test.ts
+++ b/src/app/api/sky-ads/checkout/route.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { MAX_TEXT_LENGTH } from "@/lib/skyAds";
 
-var mockGetUser = vi.fn();
-var mockFrom = vi.fn();
-var mockRateLimit = vi.fn(async () => ({ ok: true }));
-var mockCreateSession = vi.fn();
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockRateLimit = vi.fn(async () => ({ ok: true }));
+const mockCreateSession = vi.fn();
 
 vi.mock("@/lib/supabase-server", () => ({
   createServerSupabase: vi.fn(() => ({
@@ -35,7 +35,7 @@ vi.mock("@/lib/stripe", () => ({
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
-  rateLimit: (...args: any[]) => mockRateLimit(...args),
+  rateLimit: (...args: Parameters<typeof mockRateLimit>) => mockRateLimit(...args),
 }));
 
 import { POST } from "./route";

--- a/src/app/api/sky-ads/checkout/route.test.ts
+++ b/src/app/api/sky-ads/checkout/route.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MAX_TEXT_LENGTH } from "@/lib/skyAds";
+
+var mockGetUser = vi.fn();
+var mockFrom = vi.fn();
+var mockRateLimit = vi.fn(async () => ({ ok: true }));
+var mockCreateSession = vi.fn();
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabase: vi.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+vi.mock("@/lib/base-url", () => ({
+  getBaseUrl: vi.fn(() => "https://localhost"),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn(() => ({
+    checkout: {
+      sessions: {
+        create: mockCreateSession,
+      },
+    },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: (...args: any[]) => mockRateLimit(...args),
+}));
+
+import { POST } from "./route";
+
+describe("/api/sky-ads/checkout route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockRateLimit.mockResolvedValue({ ok: true });
+    mockCreateSession.mockResolvedValue({ id: "sess_123", url: "https://stripe.com/checkout" });
+
+    mockFrom.mockImplementation(() => ({
+      insert: async () => ({ error: null }),
+      update: () => ({
+        eq: async () => ({ error: null }),
+      }),
+    }));
+  });
+
+  it("returns 400 for an invalid plan", async () => {
+    const request = new Request("http://localhost/api/sky-ads/checkout", {
+      method: "POST",
+      body: JSON.stringify({
+        plan_id: "invalid_plan",
+        text: "Hello world",
+        color: "#ffffff",
+        bgColor: "#000000",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid plan" });
+  });
+
+  it("returns 400 for blocked ad text", async () => {
+    const request = new Request("http://localhost/api/sky-ads/checkout", {
+      method: "POST",
+      body: JSON.stringify({
+        plan_id: "plane_weekly",
+        text: "Free money guaranteed",
+        color: "#ffffff",
+        bgColor: "#000000",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Content contains prohibited language" });
+  });
+
+  it("returns 400 for invalid JSON payload", async () => {
+    const request = new Request("http://localhost/api/sky-ads/checkout", {
+      method: "POST",
+      body: "not-json",
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("creates a Stripe checkout session on success", async () => {
+    const request = new Request("http://localhost/api/sky-ads/checkout", {
+      method: "POST",
+      body: JSON.stringify({
+        plan_id: "plane_weekly",
+        text: "Hello LeetCode City",
+        color: "#ffffff",
+        bgColor: "#000000",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://stripe.com/checkout" });
+    expect(mockCreateSession).toHaveBeenCalled();
+  });
+
+  it("returns 400 when text exceeds the maximum length", async () => {
+    const request = new Request("http://localhost/api/sky-ads/checkout", {
+      method: "POST",
+      body: JSON.stringify({
+        plan_id: "plane_weekly",
+        text: "A".repeat(MAX_TEXT_LENGTH + 1),
+        color: "#ffffff",
+        bgColor: "#000000",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: `Text must be ${MAX_TEXT_LENGTH} characters or less`,
+    });
+  });
+});

--- a/src/app/api/sky-ads/manage/route.test.ts
+++ b/src/app/api/sky-ads/manage/route.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { POST, PUT } from "./route";
+import { DELETE, PATCH, POST, PUT } from "./route";
 
-const { mockGetUser, mockInsert, mockUpdate } = vi.hoisted(() => ({
+const { mockGetUser, mockInsert, mockUpdate, mockFrom } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockInsert: vi.fn(),
   mockUpdate: vi.fn(),
+  mockFrom: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase-server", () => ({
@@ -17,17 +18,22 @@ vi.mock("@/lib/supabase-server", () => ({
 
 vi.mock("@/lib/supabase", () => ({
   getSupabaseAdmin: vi.fn(() => ({
-    from: vi.fn(() => ({
-      insert: mockInsert,
-      update: mockUpdate,
-    })),
+    from: mockFrom,
   })),
 }));
 
 describe("/api/sky-ads/manage route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetUser.mockResolvedValue({ data: { user: { user_metadata: { user_name: "Ixotic27" } } } });
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          user_metadata: {
+            user_name: "Ixotic27",
+          },
+        },
+      },
+    });
 
     mockInsert.mockReturnValue({
       select: () => ({
@@ -41,6 +47,27 @@ describe("/api/sky-ads/manage route", () => {
           single: async () => ({ data: { id: "ad-1" }, error: null }),
         }),
       }),
+      in: async () => ({ error: null }),
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "sky_ad_events") {
+        return {
+          delete: () => ({
+            eq: async () => ({ error: null }),
+            in: async () => ({ error: null }),
+          }),
+        };
+      }
+
+      return {
+        insert: mockInsert,
+        update: mockUpdate,
+        delete: () => ({
+          eq: async () => ({ error: null }),
+          in: async () => ({ error: null }),
+        }),
+      };
     });
   });
 
@@ -77,5 +104,105 @@ describe("/api/sky-ads/manage route", () => {
     const json = await response.json();
     expect(json.error).toBe("This link is not allowed");
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when non-admin attempts create", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { user_metadata: { user_name: "other" } } } });
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "POST",
+      body: JSON.stringify({ id: "ad-1", brand: "B", text: "T" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 400 when required fields are missing on create", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "POST",
+      body: JSON.stringify({ brand: "B", text: "T" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing required fields: id, brand, text" });
+  });
+
+  it("creates an ad successfully", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "POST",
+      body: JSON.stringify({ id: "ad-1", brand: "B", text: "T" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ id: "ad-1" });
+  });
+
+  it("returns 400 when updating without valid fields", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PUT",
+      body: JSON.stringify({ id: "ad-1", unknown: "value" }),
+    });
+
+    const response = await PUT(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "No valid fields to update" });
+  });
+
+  it("updates an ad successfully", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PUT",
+      body: JSON.stringify({ id: "ad-1", text: "Updated" }),
+    });
+
+    const response = await PUT(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "ad-1" });
+  });
+
+  it("returns 400 when delete request is missing id", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", { method: "DELETE" });
+    const response = await DELETE(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing ad id" });
+  });
+
+  it("deletes an ad successfully", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage?id=ad-1", { method: "DELETE" });
+    const response = await DELETE(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it("returns 400 when batch action is missing ids", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PATCH",
+      body: JSON.stringify({ action: "pause" }),
+    });
+    const response = await PATCH(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing ids array" });
+  });
+
+  it("returns 400 when batch action is invalid", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PATCH",
+      body: JSON.stringify({ ids: ["ad-1"], action: "invalid" }),
+    });
+    const response = await PATCH(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid action. Use: pause, resume, delete" });
+  });
+
+  it("pauses ads successfully", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PATCH",
+      body: JSON.stringify({ ids: ["ad-1"], action: "pause" }),
+    });
+    const response = await PATCH(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, affected: 1 });
   });
 });

--- a/src/app/api/sky-ads/setup/route.test.ts
+++ b/src/app/api/sky-ads/setup/route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "./route";
+
+var mockFrom = vi.fn();
+var mockRateLimit = vi.fn(async () => ({ ok: true }));
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: (...args: any[]) => mockRateLimit(...args),
+}));
+
+let mockAdResponse: any;
+
+const buildSkyAdsFrom = () => ({
+  select: () => ({
+    eq: () => ({
+      maybeSingle: async () => mockAdResponse,
+    }),
+  }),
+  update: (updatePayload: any) => ({
+    eq: async () => ({ error: null }),
+  }),
+});
+
+describe("/api/sky-ads/setup route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimit.mockResolvedValue({ ok: true });
+    mockAdResponse = { data: { id: "ad-1", active: true } };
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "sky_ads") return buildSkyAdsFrom();
+      return {} as any;
+    });
+  });
+
+  it("returns 400 when token is invalid", async () => {
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({ token: "short" }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid token" });
+  });
+
+  it("returns 404 when ad is not found", async () => {
+    mockAdResponse = { data: null };
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({ token: "validtoken123" }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Ad not found" });
+  });
+
+  it("returns ok when no update fields are provided", async () => {
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({ token: "validtoken123" }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 400 when brand contains blocked content", async () => {
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({
+        token: "validtoken123",
+        brand: "Free money Brand",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Content contains prohibited language" });
+  });
+
+  it("returns 400 when link is invalid", async () => {
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({
+        token: "validtoken123",
+        link: "http://example.com",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Link must start with https:// or mailto:" });
+  });
+
+  it("updates ad text successfully", async () => {
+    const request = new Request("http://localhost/api/sky-ads/setup", {
+      method: "POST",
+      body: JSON.stringify({
+        token: "validtoken123",
+        text: "New text",
+      }),
+    });
+
+    const res = await POST(request);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/src/app/api/sky-ads/setup/route.test.ts
+++ b/src/app/api/sky-ads/setup/route.test.ts
@@ -1,26 +1,30 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "./route";
 
-var mockFrom = vi.fn();
-var mockRateLimit = vi.fn(async () => ({ ok: true }));
+const mockFrom = vi.fn();
+const mockRateLimit = vi.fn(async () => ({ ok: true }));
 vi.mock("@/lib/supabase", () => ({
   getSupabaseAdmin: vi.fn(() => ({
     from: mockFrom,
   })),
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  rateLimit: (...args: any[]) => mockRateLimit(...args),
+  rateLimit: (...args: unknown[]) => mockRateLimit(...args),
 }));
 
-let mockAdResponse: any;
+type SkyAdsResponse = {
+  data: { id: string; active: boolean } | null;
+};
+
+let mockAdResponse: SkyAdsResponse;
 
 const buildSkyAdsFrom = () => ({
   select: () => ({
     eq: () => ({
-      maybeSingle: async () => mockAdResponse,
+      maybeSingle: async (): Promise<SkyAdsResponse> => mockAdResponse,
     }),
   }),
-  update: (updatePayload: any) => ({
+  update: () => ({
     eq: async () => ({ error: null }),
   }),
 });
@@ -32,7 +36,7 @@ describe("/api/sky-ads/setup route", () => {
     mockAdResponse = { data: { id: "ad-1", active: true } };
     mockFrom.mockImplementation((table: string) => {
       if (table === "sky_ads") return buildSkyAdsFrom();
-      return {} as any;
+      return {} as unknown;
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

This PR adds route-level regression tests for the Sky Ads API endpoints without modifying production behavior.

The new test suite covers the following routes:

* `/api/sky-ads/checkout`
* `/api/sky-ads/setup`
* `/api/sky-ads/manage`

The tests verify successful requests as well as important failure scenarios, including validation errors, authorization checks, and other route-specific edge cases where applicable. These tests help prevent future regressions while following the repository's existing testing patterns.

## Related issue

Fixes #734

## Screenshots

N/A (test-only changes)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
