### PR TITLE
fix: validate Sky Ads admin mutation payloads

### DIFF
--- a/src/app/api/sky-ads/manage/route.test.ts
+++ b/src/app/api/sky-ads/manage/route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST, PUT } from "./route";
+
+const { mockGetUser, mockInsert, mockUpdate } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabase: vi.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: vi.fn(() => ({
+      insert: mockInsert,
+      update: mockUpdate,
+    })),
+  })),
+}));
+
+describe("/api/sky-ads/manage route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { user_metadata: { user_name: "Ixotic27" } } } });
+
+    mockInsert.mockReturnValue({
+      select: () => ({
+        single: async () => ({ data: { id: "ad-1" }, error: null }),
+      }),
+    });
+
+    mockUpdate.mockReturnValue({
+      eq: () => ({
+        select: () => ({
+          single: async () => ({ data: { id: "ad-1" }, error: null }),
+        }),
+      }),
+    });
+  });
+
+  it("rejects create payloads with blocked content", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "POST",
+      body: JSON.stringify({
+        id: "ad-1",
+        brand: "Test Brand",
+        text: "buy followers fast",
+      }),
+    });
+
+    const response = await POST(request as unknown as Request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe("Content contains prohibited language");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects update payloads with suspicious links", async () => {
+    const request = new Request("http://localhost/api/sky-ads/manage", {
+      method: "PUT",
+      body: JSON.stringify({
+        id: "ad-1",
+        link: "https://paypal.verify.com",
+      }),
+    });
+
+    const response = await PUT(request as unknown as Request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe("This link is not allowed");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/sky-ads/manage/route.ts
+++ b/src/app/api/sky-ads/manage/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { containsBlockedContent, isSuspiciousLink } from "@/lib/ad-moderation";
+import { MAX_TEXT_LENGTH } from "@/lib/skyAds";
 
 const OWNER_LOGIN = "Ixotic27";
+const ALLOWED_LINK = /^(https:\/\/|mailto:)/;
 
 function generateToken(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -21,7 +24,7 @@ async function checkAdmin() {
     user.user_metadata.preferred_username ??
     ""
   ).toLowerCase();
-  return login === OWNER_LOGIN ? user : null;
+  return login === OWNER_LOGIN.toLowerCase() ? user : null;
 }
 
 // Create a new ad
@@ -40,6 +43,40 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing required fields: id, brand, text" }, { status: 400 });
   }
 
+  const safeText = String(text).slice(0, MAX_TEXT_LENGTH).trim();
+  if (!safeText) {
+    return NextResponse.json({ error: "Text is required" }, { status: 400 });
+  }
+
+  const modText = containsBlockedContent(safeText);
+  if (modText.blocked) {
+    return NextResponse.json({ error: modText.reason ?? "Text not allowed" }, { status: 400 });
+  }
+
+  const safeBrand = String(brand).slice(0, 60).trim();
+  if (safeBrand) {
+    const modBrand = containsBlockedContent(safeBrand);
+    if (modBrand.blocked) {
+      return NextResponse.json({ error: modBrand.reason ?? "Brand not allowed" }, { status: 400 });
+    }
+  }
+
+  const safeDescription = typeof description === "string" ? description.slice(0, 200).trim() : "";
+  if (safeDescription) {
+    const modDescription = containsBlockedContent(safeDescription);
+    if (modDescription.blocked) {
+      return NextResponse.json({ error: modDescription.reason ?? "Description not allowed" }, { status: 400 });
+    }
+  }
+
+  const safeLink = typeof link === "string" ? link.trim() : "";
+  if (safeLink && !ALLOWED_LINK.test(safeLink)) {
+    return NextResponse.json({ error: "Link must start with https:// or mailto:" }, { status: 400 });
+  }
+  if (safeLink && isSuspiciousLink(safeLink)) {
+    return NextResponse.json({ error: "This link is not allowed" }, { status: 400 });
+  }
+
   const validVehicles = ["plane", "blimp", "billboard", "rooftop_sign", "led_wrap"];
   const safeVehicle = validVehicles.includes(vehicle) ? vehicle : "plane";
 
@@ -48,12 +85,12 @@ export async function POST(request: Request) {
   const admin = getSupabaseAdmin();
   const { data, error } = await admin.from("sky_ads").insert({
     id,
-    brand,
-    text,
-    description: description ?? null,
+    brand: safeBrand,
+    text: safeText,
+    description: safeDescription || null,
     color: color ?? "#f8d880",
     bg_color: bg_color ?? "#1a1018",
-    link: link ?? null,
+    link: safeLink || null,
     vehicle: safeVehicle,
     priority: priority ?? 50,
     starts_at: starts_at ?? null,
@@ -100,6 +137,51 @@ export async function PUT(request: Request) {
 
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  if ("text" in updates) {
+    const safeText = String(updates.text ?? "").slice(0, MAX_TEXT_LENGTH).trim();
+    if (!safeText) {
+      return NextResponse.json({ error: "Text is required" }, { status: 400 });
+    }
+    const modText = containsBlockedContent(safeText);
+    if (modText.blocked) {
+      return NextResponse.json({ error: modText.reason ?? "Text not allowed" }, { status: 400 });
+    }
+    updates.text = safeText;
+  }
+
+  if ("brand" in updates) {
+    const safeBrand = String(updates.brand ?? "").slice(0, 60).trim();
+    if (safeBrand) {
+      const modBrand = containsBlockedContent(safeBrand);
+      if (modBrand.blocked) {
+        return NextResponse.json({ error: modBrand.reason ?? "Brand not allowed" }, { status: 400 });
+      }
+    }
+    updates.brand = safeBrand || null;
+  }
+
+  if ("description" in updates) {
+    const safeDescription = typeof updates.description === "string" ? updates.description.slice(0, 200).trim() : "";
+    if (safeDescription) {
+      const modDescription = containsBlockedContent(safeDescription);
+      if (modDescription.blocked) {
+        return NextResponse.json({ error: modDescription.reason ?? "Description not allowed" }, { status: 400 });
+      }
+    }
+    updates.description = safeDescription || null;
+  }
+
+  if ("link" in updates) {
+    const safeLink = typeof updates.link === "string" ? updates.link.trim() : "";
+    if (safeLink && !ALLOWED_LINK.test(safeLink)) {
+      return NextResponse.json({ error: "Link must start with https:// or mailto:" }, { status: 400 });
+    }
+    if (safeLink && isSuspiciousLink(safeLink)) {
+      return NextResponse.json({ error: "This link is not allowed" }, { status: 400 });
+    }
+    updates.link = safeLink || null;
   }
 
   const admin = getSupabaseAdmin();


### PR DESCRIPTION
## What does this PR do?

This PR adds payload validation to the Sky Ads admin create and update API so it follows the same validation behavior as the public Sky Ads flow.

The changes include:

* Validating `text` for blocked content and maximum length.
* Validating `brand` and `description` for prohibited content.
* Validating `link` format and rejecting suspicious links.
* Adding regression tests to verify invalid admin payloads are rejected with appropriate `400` responses.

These changes help ensure consistent validation across both public and admin entry points while preventing invalid or unsafe payloads from being persisted.

> **Note:** The admin username comparison was also updated to compare normalized (lowercased) values, matching the existing normalization already applied to the authenticated username.

## Related issue

Fixes #733

## Screenshots

N/A (backend validation and test changes only)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or `.env` values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
