### PR TITLE
test(weather): add coordinate validation regression tests

### DIFF
--- a/src/app/api/weather/route.test.ts
+++ b/src/app/api/weather/route.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+describe("/api/weather route", () => {
+  const originalApiKey = process.env.OPENWEATHER_API_KEY;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENWEATHER_API_KEY = "test-api-key";
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ weather: [{ id: 800 }] }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    process.env.OPENWEATHER_API_KEY = originalApiKey;
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["0", "0"],
+    ["90", "180"],
+    ["-90", "-180"],
+  ])("accepts valid coordinates lat=%s lon=%s", async (lat, lon) => {
+    const request = new Request(`http://localhost/api/weather?lat=${lat}&lon=${lon}`);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=test-api-key`,
+    );
+  });
+
+  it.each([
+    ["91", "0"],
+    ["-91", "0"],
+    ["0", "181"],
+    ["0", "-181"],
+    ["150", "200"],
+  ])("rejects invalid coordinates lat=%s lon=%s", async (lat, lon) => {
+    const request = new Request(`http://localhost/api/weather?lat=${lat}&lon=${lon}`);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Invalid coordinates: lat must be -90..90, lon must be -180..180.",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/weather/route.test.ts
+++ b/src/app/api/weather/route.test.ts
@@ -16,7 +16,11 @@ describe("/api/weather route", () => {
   });
 
   afterEach(() => {
-    process.env.OPENWEATHER_API_KEY = originalApiKey;
+    if (originalApiKey === undefined) {
+      delete process.env.OPENWEATHER_API_KEY;
+    } else {
+      process.env.OPENWEATHER_API_KEY = originalApiKey;
+    }
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## What does this PR do?

This PR adds regression tests for the Weather API coordinate validation to ensure invalid geographic coordinates are rejected before any external Weather API request is made.

### Changes

* Added tests for valid boundary coordinates:

  * `(0, 0)`
  * `(90, 180)`
  * `(-90, -180)`
* Added tests to verify that out-of-range coordinates return **400 Bad Request**:

  * `lat=91`
  * `lat=-91`
  * `lon=181`
  * `lon=-181`
  * `lat=150, lon=200`
* Verified that invalid coordinate requests do **not** trigger an external Weather API call.
* Preserved the existing Weather API implementation while improving regression coverage.

## Related issue

Fixes #787

## Screenshots

N/A – This PR adds regression tests only and does not introduce any UI changes.

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or `.env` values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
