### PR TITLE
refactor: replace any types with proper typing across multiple files

### DIFF
--- a/src/app/api/arena/challenge/[id]/route.ts
+++ b/src/app/api/arena/challenge/[id]/route.ts
@@ -2,6 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedDeveloper } from "@/lib/arena";
 
+interface ProblemRow {
+  id: number;
+  title: string;
+  description: string;
+  difficulty_rating: number;
+  tags: string[];
+  time_limit_ms: number;
+  memory_limit_mb: number;
+  sample_tests: unknown;
+  hidden_tests: unknown[] | null;
+}
+
 export async function GET(
   request: NextRequest,
   props: { params: Promise<{ id: string }> }
@@ -44,8 +56,7 @@ export async function GET(
     return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prob = challenge.problem as any;
+  const prob = challenge.problem as unknown as ProblemRow | null;
   if (!prob) {
     return NextResponse.json({ error: "Associated problem not found" }, { status: 404 });
   }

--- a/src/app/api/cron/city-snapshot/route.ts
+++ b/src/app/api/cron/city-snapshot/route.ts
@@ -5,23 +5,65 @@ import { serializeDeveloper } from "@/lib/serialize";
 const STORAGE_BUCKET = "city-data";
 const STORAGE_PATH = "snapshot.json";
 const PAGE_SIZE = 1000; // Supabase PostgREST caps at 1000 rows per request
+ 
+interface DeveloperRow {
+  id: number;
+  github_login: string;
+  name: string | null;
+  avatar_url: string | null;
+  contributions: number;
+  total_stars: number;
+  public_repos: number;
+  primary_language: string | null;
+  rank: number | null;
+  claimed: boolean;
+  kudos_count: number;
+  visit_count: number;
+  contributions_total: number;
+  contribution_years: number;
+  total_prs: number;
+  total_reviews: number;
+  repos_contributed_to: number;
+  followers: number;
+  following: number;
+  organizations_count: number;
+  account_created_at: string | null;
+  current_streak: number;
+  active_days_last_year: number;
+  language_diversity: number;
+  app_streak: number;
+  rabbit_completed: boolean;
+  district: string | null;
+  district_chosen: boolean;
+  xp_total: number;
+  xp_level: number;
+  raid_xp: number;
+  current_week_contributions?: number;
+  current_week_kudos_given?: number;
+  current_week_kudos_received?: number;
+}
+
+interface SupabaseQuery extends PromiseLike<{ data: unknown[] | null; error: { message: string } | null }> {
+  eq(column: string, value: unknown): SupabaseQuery;
+  is(column: string, value: unknown): SupabaseQuery;
+  not(column: string, operator: string, value: unknown): SupabaseQuery;
+  in(column: string, values: unknown[]): SupabaseQuery;
+  order(column: string, options?: { ascending?: boolean }): SupabaseQuery;
+}
 
 /** Paginate through all rows of a table. */
- 
 async function fetchAll<T>(
   sb: ReturnType<typeof getSupabaseAdmin>,
   table: string,
-  select: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apply?: (q: any) => any,
+  select: string, 
+  apply?: (q: SupabaseQuery) => SupabaseQuery,
   orderBy?: string,
 ): Promise<T[]> {
   const all: T[] = [];
   let from = 0;
 
-  while (true) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let q: any = sb.from(table).select(select).range(from, from + PAGE_SIZE - 1);
+  while (true) { 
+    let q = sb.from(table).select(select).range(from, from + PAGE_SIZE - 1) as unknown as SupabaseQuery;
     if (orderBy) q = q.order(orderBy, { ascending: true });
     if (apply) q = apply(q);
     const { data, error } = await q;
@@ -55,9 +97,8 @@ export async function GET(request: NextRequest) {
 
   // Fetch everything in parallel
   const [devs, purchases, giftPurchases, customizations, achievements, raidTags, statsResult] =
-    await Promise.all([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fetchAll<Record<string, any>>(
+    await Promise.all([ 
+      fetchAll<DeveloperRow>(
         sb,
         "developers",
         "id, github_login, name, avatar_url, contributions, total_stars, public_repos, primary_language, rank, claimed, kudos_count, visit_count, contributions_total, contribution_years, total_prs, total_reviews, repos_contributed_to, followers, following, organizations_count, account_created_at, current_streak, active_days_last_year, language_diversity, app_streak, rabbit_completed, district, district_chosen, xp_total, xp_level, raid_xp",

--- a/src/app/api/presence/route.ts
+++ b/src/app/api/presence/route.ts
@@ -44,9 +44,8 @@ export async function GET() {
       }
     }
 
-    const developers = Array.from(byDev.values()).map((s) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const dev = s.developers as any;
+    const developers = Array.from(byDev.values()).map((s) => { 
+      const dev = s.developers as unknown as { github_login: string; avatar_url: string | null };
       return {
         githubLogin: dev.github_login,
         avatarUrl: dev.avatar_url,

--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -9,8 +9,7 @@ import { InfrastructureError } from "@/lib/errors";
 
 export const dynamic = "force-dynamic";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractPixId(data: any): string | undefined {
+function extractPixId(data: { id?: string; pixQrCode?: { id?: string } } | undefined): string | undefined {
   // billing.paid payload: data.pixQrCode.id
   // pixQrCode.paid payload: data.id or data.pixQrCode.id
   return data?.pixQrCode?.id ?? data?.id;
@@ -32,9 +31,8 @@ export async function POST(request: Request) {
   }
 
   const rawBody = await request.text();
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let body: any;
+ 
+  let body: { event?: string; data?: { id?: string; pixQrCode?: { id?: string } } };
   try {
     body = JSON.parse(rawBody);
   } catch (err) { console.warn("[app/api/webhooks/abacatepay/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -33,8 +33,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let body: any;
+  let body: {
+    type?: string;
+    event?: string;
+    data?: {
+      order?: { order_id?: string };
+      customer_details?: { customer_email?: string };
+    };
+  };
   try {
     body = JSON.parse(rawBody);
   } catch {

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -7,7 +7,6 @@ import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
 import { SKY_AD_PLANS, isValidPlanId } from "@/lib/skyAdPlans";
 import { InfrastructureError } from "@/lib/errors";
 
-
 export const dynamic = "force-dynamic";
 
 /**
@@ -15,9 +14,8 @@ export const dynamic = "force-dynamic";
  */
 export async function POST(request: Request) {
   const rawBody = await request.text();
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let body: any;
+  let body: Record<string, unknown> & { payment_status: string; order_id?: string; payment_id?: string | number; customer_email?: string };
+  
   try {
     body = JSON.parse(rawBody);
   } catch (err) { console.warn("[app/api/webhooks/nowpayments/route.ts] error:", err); return NextResponse.json({ error: "Invalid body" }, { status: 400 });

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -171,9 +171,8 @@ export async function GET(request: Request) {
 
   return NextResponse.redirect(`${origin}/?user=${githubLogin}`);
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function countGifts(admin: any, devId: number, direction: "sent" | "received"): Promise<number> {
+ 
+async function countGifts(admin: ReturnType<typeof getSupabaseAdmin>, devId: number, direction: "sent" | "received"): Promise<number> {
   const column = direction === "sent" ? "developer_id" : "gifted_to";
   const { count } = await admin
     .from("purchases")

--- a/src/app/wallpaper/page.tsx
+++ b/src/app/wallpaper/page.tsx
@@ -8,6 +8,7 @@ import {
   type CityBuilding,
   type CityPlaza,
   type CityDecoration,
+  type DeveloperRecord,
 } from "@/lib/github";
 
 const CityCanvas = dynamic(() => import("@/components/CityCanvas"), { ssr: false });
@@ -34,8 +35,7 @@ function WallpaperInner() {
   const [ready, setReady] = useState(false);
 
   const fetchCity = useCallback(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let allDevs: any[] = [];
+    let allDevs: DeveloperRecord[] = [];
 
     // Try pre-computed snapshot first
     try {

--- a/src/lib/useCodingPresence.ts
+++ b/src/lib/useCodingPresence.ts
@@ -79,8 +79,14 @@ export function useCodingPresence() {
     channelRef.current = channel;
 
     channel
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .on("broadcast", { event: "heartbeat" }, ({ payload }: { payload: any }) => {
+      .on("broadcast", { event: "heartbeat" }, ({ payload }: {
+        payload: {
+          githubLogin: string;
+          status?: "active" | "offline";
+          avatarUrl?: string;
+          language?: string;
+        };
+      }) => {
         if (!payload?.githubLogin) return;
 
         // Offline signal: remove dev from live map immediately
@@ -92,7 +98,7 @@ export function useCodingPresence() {
 
         mapRef.current.set(payload.githubLogin, {
           githubLogin: payload.githubLogin,
-          avatarUrl: payload.avatarUrl,
+          avatarUrl: payload.avatarUrl ?? "",
           status: payload.status ?? "active",
           language: payload.language,
           lastUpdated: Date.now(),


### PR DESCRIPTION
## What does this PR do?
Removes all `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments and `any` types across the codebase, replacing them with proper interfaces/types. This restores TypeScript's type-checking on these code paths instead of silently bypassing it.

Files changed:
- `src/app/api/cron/city-snapshot/route.ts` — added `DeveloperRow` interface and a typed `SupabaseQuery` interface for the pagination helper
- `src/app/api/presence/route.ts` — typed the joined `developers` row
- `src/app/api/webhooks/abacatepay/route.ts` — typed `extractPixId`'s input and the parsed webhook body
- `src/app/api/webhooks/nowpayments/route.ts` — typed the parsed webhook body
- `src/app/api/webhooks/cashfree/route.ts` — typed the parsed webhook body
- `src/app/auth/callback/route.ts` — typed the `admin` client parameter using `ReturnType<typeof getSupabaseAdmin>`
- `src/app/api/arena/challenge/[id]/route.ts` — added a `ProblemRow` interface for the joined problem data
- `src/lib/useCodingPresence.ts` — typed the realtime broadcast heartbeat payload
- `src/app/wallpaper/page.tsx` — reused the existing `DeveloperRecord` type instead of `any[]`

## Related issue
Fixes #846

## Screenshots
No visual/UI changes — this is a type-safety refactor only.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**