### PR TITLE
fix: filter map_json and portals for non-public arcade rooms

### DIFF
--- a/src/app/api/arcade/rooms/[slug]/route.ts
+++ b/src/app/api/arcade/rooms/[slug]/route.ts
@@ -18,6 +18,12 @@ export async function GET(
     .eq("slug", slug)
     .single();
 
+  const isPublic = data?.visibility === 'open' || data?.visibility === 'public';
+  if (!isPublic && data) {
+    data.map_json = null;
+    data.portals = null;
+  }
+
   if (error || !data) {
     if (slug === "lobby") {
       try {


### PR DESCRIPTION
Closes #872

Filters map_json and portals from API responses for rooms that are not publicly accessible.