### PR TITLE
refactor: replace fabricated and placeholder usernames with active verified LeetCode accounts (#814)

### DIFF
--- a/scripts/seed-lc.ts
+++ b/scripts/seed-lc.ts
@@ -32,29 +32,32 @@ const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: fa
 // Includes top contest participants, editorial contributors, etc.
 
 const LC_USERS = [
-    // 100% API Verified Global Competitors & Contest Winners
-    "neal_wu", "tourist", "jiangly", "ecnerwala", "Um_nik",
-    "Benq", "ksun48", "tfg", "prabowo", "nhho", "uwi", 
-    "maroonrk", "kamyu", "dietpepsi", "chokudai", "wata", 
-    "heltion", "wisdompeak", "georgelyu", "shockwave", "lee215", 
-    "awice", "stefanpochmann", "votrubac", "hiepit", "DBabichev", 
-    "errichto", "ye15", "SaveVMK", "radib", "Wanderer", 
-    "hujunxiang98", "skyline", "vipul_7", "praveen_123", "shubham_coder", 
-    "aman_kumar", "rohit_99", "666sb", "manish_kumar", "papaya",
+    // 100% API Verified Global Competitors & Contest Winners (Top Rankings)
+    "fjzzq2002", "neal_wu", "Yawn_Sean", "ahmed007boss", "liming-v", 
+    "numb3r5", "PurpleCrayon", "hankray", "HazemAllaham", "fmota", 
+    "pandaforever", "xiaowuc1", "zhoupeiyun", "Nahin_Imtiaz", "qeetcode", 
+    "Shandse40", "Carefreejs", "jonathanirvings", "wwwwodddd", "TheWander", 
+    "_kevinyang", "emthrm", "MisterSoandSo", "snap_dragon", "dong_liu", 
+    "thenymphsofdelphi", "usephysics", "tmwilliamlin168", "user8991p", "Naruto_x", 
+    "ayushkumar980", "lympanda", "satyajeetramnit2708", "bucker", "mohfadhil", 
+    "natsugiri", "manohar.morthala", "getnaukri", "tabr", "queerAsfolk", 
+    "Allink", "hitonanode", "stany", "waakaaka", "bucketpotato", 
+    "Aging", "rfpermen", "kirika-comp", "0suoicsnocbus", "karate", 
+    "dreamoon", "python_champ123", "LayCurse", "bilyhurington", "skpeng", 
+    "tarek", "parallel_stream", "penguinhacker", "Poojash18", "youtube_aryanc403", 
+    "MichaelPengDeveloper", "flashmt", "Nirav5502", "klion26", "zeusmx", 
+    "pathetic-dog", "dnialh", "VeritasVelata", "mayur0055", "AntonRaichuk", 
+    "zacharychao", "vince1114", "smax", "kaikaikaikaikai", "369488685", 
+    "superlevelup", "katcibo", "green_pig", "shyamjha12", "friedall", 
+    "gdkat", "istiak227", "R3mix", "cai_lw", "awice", "wery0", 
+    "doc967", "Sd-Invol", "Dear_starboy", "chalowis", "scanhex", 
+    "beet", "freeyourmind", "lachy_136", "theone7", "homedir", 
+    "sqqqqqq", "viraaj", "enev13", "superluminal",
 
-    // Additional Verified Top-Tier Global Handles
-    "hsinmin", "Y0u", "attttrx", "mrdw", "mickey",
-    "mikasha", "jack_chen", "amir_noob", "shashi_04", "rahul_5",
-
-    // 100% API Verified Community Profiles & Tech Educators
+    // Famous Community Profiles & Tech Educators
     "NeetCode", "striver", "loveBabbar", "kunal_kushwaha", "nishant_chahar", 
-    "freeCodeCamp", "ThePrimeagen", "TechLead", "JomaTech", "user1234",
-    "Simran_9262", "code_with_harry", "taiin", "agrawalkrish", "mattrul284yej",
-
-    // 100% API Verified Core Dev Semantics
-    "code_runner", "shadow_coder", "delta_v", "cyber_knight", "matrix_reloaded", 
-    "bit_crusher", "null_pointer", "void_main", "console_log", "return_zero", 
-    "infinite_loop", "catch_me", "git_pull", "merge_conflict"
+    "freeCodeCamp", "ThePrimeagen", "TechLead", "JomaTech", "code_with_harry",
+    "lee215", "stefanpochmann", "votrubac", "hiepit", "DBabichev", "errichto"
 ];
 
 // ─── LeetCode GraphQL fetcher ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #814


## What does this PR do?

This PR replaces fabricated, inactive and placeholder LeetCode usernames in `scripts/seed-lc.ts` with 100% real, active, and API-verified usernames sourced directly from the LeetCode global ranking pages (pages 1-4) and notable tech education/community accounts. This ensures that the seeder doesn't waste API calls on non-existent accounts and runs efficiently.

## Screenshots

N/A (Backend script changes only)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
