### PR TITLE
fix(docker): guard build-time env vars and supabase client initialization - #806

### DIFF
--- a/src/app/api/compare-card/[userA]/[userB]/route.tsx
+++ b/src/app/api/compare-card/[userA]/[userB]/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createClient } from "@supabase/supabase-js";
+import { getSafeSupabaseClient } from "@/lib/supabase";
 import { type NextRequest } from "next/server";
 
 export const runtime = "nodejs";
@@ -123,7 +123,7 @@ export async function GET(
   const t = i18n[lang];
 
   const fontData = await readFile(join(process.cwd(), "public/fonts/Silkscreen-Regular.ttf"));
-  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+  const supabase = getSafeSupabaseClient();
 
   const fields = "github_login, name, avatar_url, contributions, contributions_total, public_repos, total_stars, rank, kudos_count";
   const [{ data: devA }, { data: devB }] = await Promise.all([

--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createClient } from "@supabase/supabase-js";
+import { getSafeSupabaseClient } from "@/lib/supabase";
 import { type NextRequest } from "next/server";
 
 export const runtime = "nodejs";
@@ -85,10 +85,7 @@ export async function GET(
     join(process.cwd(), "public/fonts/Silkscreen-Regular.ttf")
   );
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const supabase = getSafeSupabaseClient();
 
   const { data: dev } = await supabase
     .from("developers")

--- a/src/app/compare/[userA]/[userB]/opengraph-image.tsx
+++ b/src/app/compare/[userA]/[userB]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createClient } from "@supabase/supabase-js";
+import { getSafeSupabaseClient } from "@/lib/supabase";
 
 export const alt = "Developer Comparison - LeetCode City";
 export const size = { width: 1200, height: 630 };
@@ -18,10 +18,7 @@ export default async function Image({
     join(process.cwd(), "public/fonts/Silkscreen-Regular.ttf")
   );
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const supabase = getSafeSupabaseClient();
 
   const accent = "#ffa116";
   const bg = "#0d0d0f";

--- a/src/app/compare/[userA]/[userB]/page.tsx
+++ b/src/app/compare/[userA]/[userB]/page.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { getSafeSupabaseClient } from "@/lib/supabase";
 import type { Metadata } from "next";
 import { CompareRedirect } from "./compare-redirect";
 
@@ -9,10 +9,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { userA, userB } = await params;
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const supabase = getSafeSupabaseClient();
 
   const [{ data: devA }, { data: devB }] = await Promise.all([
     supabase

--- a/src/app/dev/[username]/opengraph-image.tsx
+++ b/src/app/dev/[username]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createClient } from "@supabase/supabase-js";
+import { getSafeSupabaseClient } from "@/lib/supabase";
 
 export const alt = "Developer Profile - LeetCode City";
 export const size = { width: 1200, height: 630 };
@@ -18,10 +18,7 @@ export default async function Image({
     join(process.cwd(), "public/fonts/Silkscreen-Regular.ttf")
   );
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const supabase = getSafeSupabaseClient();
 
   const { data: dev } = await supabase
     .from("developers")

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -5,8 +5,8 @@ import { isValidUrl, createDummyClient } from "./supabase";
 /** Server-side Supabase client with cookie-based auth (for Server Components & Route Handlers) */
 export async function createServerSupabase() {
   const cookieStore = await cookies();
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const url = process.env['NEXT_PUBLIC_SUPABASE_URL'];
+  const key = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'];
 
   if (!isValidUrl(url) || !key) {
     console.warn(`[Supabase] Returning dummy server client due to missing or invalid URL/Key. URL: "${url}"`);

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,13 +1,21 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { isValidUrl, createDummyClient } from "./supabase";
 
 /** Server-side Supabase client with cookie-based auth (for Server Components & Route Handlers) */
 export async function createServerSupabase() {
   const cookieStore = await cookies();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!isValidUrl(url) || !key) {
+    console.warn(`[Supabase] Returning dummy server client due to missing or invalid URL/Key. URL: "${url}"`);
+    return createDummyClient() as unknown as ReturnType<typeof createServerClient>;
+  }
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    url!,
+    key,
     {
       cookies: {
         getAll() {
@@ -26,3 +34,4 @@ export async function createServerSupabase() {
     }
   );
 }
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -47,8 +47,8 @@ export function createDummyClient(): any {
  * returns a chainable dummy client to prevent build/runtime crashes.
  */
 export function getSafeSupabaseClient(url?: string, key?: string): SupabaseClient {
-  const targetUrl = url || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const targetKey = key || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const targetUrl = url || process.env['NEXT_PUBLIC_SUPABASE_URL'];
+  const targetKey = key || process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'];
 
   if (!isValidUrl(targetUrl) || !targetKey) {
     console.warn(`[Supabase] Returning dummy client due to missing or invalid URL/Key. URL: "${targetUrl}"`);
@@ -70,8 +70,8 @@ export function isDevMode(): boolean {
 export function createBrowserSupabase() {
   if (browserClient) return browserClient;
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const url = process.env['NEXT_PUBLIC_SUPABASE_URL'];
+  const key = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'];
 
   if (!isValidUrl(url) || !key) {
     console.warn(`[Supabase] Returning dummy client for browser client due to missing or invalid URL/Key. URL: "${url}"`);
@@ -91,7 +91,7 @@ export function createBrowserSupabase() {
 let adminClientWarned = false;
 export function getSupabaseAdmin(): SupabaseClient {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = process.env['NEXT_PUBLIC_SUPABASE_URL'];
 
   if (!isValidUrl(url) || !key) {
     console.warn(`[Supabase] Returning dummy admin client due to missing or invalid URL/Key. URL: "${url}"`);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -23,11 +23,14 @@ export function isValidUrl(url: string | undefined): boolean {
 /**
  * Creates a robust, chainable dummy/noop client to prevent runtime crashes during build.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createDummyClient(): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dummy: any = () => dummy;
   return new Proxy(dummy, {
     get(target, prop) {
       if (prop === "then") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (resolve: any) => resolve({ data: null, error: null });
       }
       if (prop === "auth") {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,6 +8,57 @@ let lastAdminKey: string | null = null;
 let lastAdminUrl: string | null = null;
 
 /**
+ * Returns true if the string is a valid URL starting with http/https.
+ */
+export function isValidUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates a robust, chainable dummy/noop client to prevent runtime crashes during build.
+ */
+export function createDummyClient(): any {
+  const dummy: any = () => dummy;
+  return new Proxy(dummy, {
+    get(target, prop) {
+      if (prop === "then") {
+        return (resolve: any) => resolve({ data: null, error: null });
+      }
+      if (prop === "auth") {
+        return {
+          onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+          getSession: async () => ({ data: { session: null }, error: null }),
+          getUser: async () => ({ data: { user: null }, error: null }),
+        };
+      }
+      return dummy;
+    }
+  });
+}
+
+/**
+ * Safely creates a Supabase client. If the URL is invalid or key is missing,
+ * returns a chainable dummy client to prevent build/runtime crashes.
+ */
+export function getSafeSupabaseClient(url?: string, key?: string): SupabaseClient {
+  const targetUrl = url || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const targetKey = key || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!isValidUrl(targetUrl) || !targetKey) {
+    console.warn(`[Supabase] Returning dummy client due to missing or invalid URL/Key. URL: "${targetUrl}"`);
+    return createDummyClient() as unknown as SupabaseClient;
+  }
+
+  return createClient(targetUrl!, targetKey, { auth: { persistSession: false } });
+}
+
+/**
  * Returns true when running without the service-role key.
  * In dev mode, admin operations gracefully degrade (read-only via anon key).
  */
@@ -19,10 +70,15 @@ export function isDevMode(): boolean {
 export function createBrowserSupabase() {
   if (browserClient) return browserClient;
 
-  browserClient = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!isValidUrl(url) || !key) {
+    console.warn(`[Supabase] Returning dummy client for browser client due to missing or invalid URL/Key. URL: "${url}"`);
+    return createDummyClient() as unknown as ReturnType<typeof createBrowserClient>;
+  }
+
+  browserClient = createBrowserClient(url!, key);
   return browserClient;
 }
 
@@ -35,7 +91,12 @@ export function createBrowserSupabase() {
 let adminClientWarned = false;
 export function getSupabaseAdmin(): SupabaseClient {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!isValidUrl(url) || !key) {
+    console.warn(`[Supabase] Returning dummy admin client due to missing or invalid URL/Key. URL: "${url}"`);
+    return createDummyClient() as unknown as SupabaseClient;
+  }
 
   // Return cached instance if credentials haven't changed
   if (adminClient && lastAdminKey === key && lastAdminUrl === url) {
@@ -51,12 +112,12 @@ export function getSupabaseAdmin(): SupabaseClient {
   }
 
   adminClient = createClient(
-    url,
-    key!,
+    url!,
+    key,
     { auth: { persistSession: false } }
   );
   lastAdminKey = key ?? null;
-  lastAdminUrl = url;
+  lastAdminUrl = url ?? null;
 
   return adminClient;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -115,8 +115,8 @@ export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   if (hasSession) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const url = process.env['NEXT_PUBLIC_SUPABASE_URL'];
+    const key = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'];
     const supabase = (!isValidUrl(url) || !key)
       ? createDummyClient() as unknown as ReturnType<typeof createServerClient>
       : createServerClient(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { rateLimit } from "@/lib/rate-limit";
+import { isValidUrl, createDummyClient } from "./lib/supabase";
+
 
 // ---------------------------------------------------------------------------
 // Route-specific rate limits: [maxRequests, windowMs]
@@ -113,26 +115,30 @@ export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   if (hasSession) {
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll() {
-            return request.cookies.getAll();
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const supabase = (!isValidUrl(url) || !key)
+      ? createDummyClient() as unknown as ReturnType<typeof createServerClient>
+      : createServerClient(
+          url!,
+          key,
+          {
+            cookies: {
+              getAll() {
+                return request.cookies.getAll();
+              },
+              setAll(cookiesToSet) {
+                cookiesToSet.forEach(({ name, value }) =>
+                  request.cookies.set(name, value),
+                );
+                supabaseResponse = NextResponse.next({ request });
+                cookiesToSet.forEach(({ name, value, options }) =>
+                  supabaseResponse.cookies.set(name, value, options),
+                );
+              },
+            },
           },
-          setAll(cookiesToSet) {
-            cookiesToSet.forEach(({ name, value }) =>
-              request.cookies.set(name, value),
-            );
-            supabaseResponse = NextResponse.next({ request });
-            cookiesToSet.forEach(({ name, value, options }) =>
-              supabaseResponse.cookies.set(name, value, options),
-            );
-          },
-        },
-      },
-    );
+        );
 
     try {
       // Timeout auth validation to prevent slow Supabase responses from


### PR DESCRIPTION
## What does this PR do?

This PR resolves failures during `docker build` (specifically at the `npm run build` stage) when required `NEXT_PUBLIC_*` environment variables are missing or set to placeholder/invalid values. 

Key changes include:
- Introduced a URL validation utility (`isValidUrl`) in `src/lib/supabase.ts`.
- Introduced a Proxy-based chainable dummy client `createDummyClient()` that catches calls (like `.from()`, `.select()`, `.eq()`, etc.) and handles promise resolution (`.then`) safely to return `{ data: null, error: null }` rather than throwing errors.
- Exported `getSafeSupabaseClient()` to automatically return the mock/dummy client if variables are missing or invalid, preventing compilation crashes.
- Guarded `createBrowserSupabase()`, `getSupabaseAdmin()`, `createServerSupabase()`, and client creation within `middleware.ts`.
- Refactored direct `createClient` instantiations in Route Handlers and Server Components to use the safe client wrapper.

## Related issue

Fixes #806

## Screenshots

N/A (No visual UI changes).

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
