### PR TITLE
fix: stabilize raid week start date

### DIFF
--- a/src/app/api/raid/execute/route.ts
+++ b/src/app/api/raid/execute/route.ts
@@ -79,6 +79,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing target_login" }, { status: 400 });
   }
 
+  const raidWeekStart = getIsoWeekStartDateString();
+
   const admin = getSupabaseAdmin();
 
   // Fetch attacker + defender in parallel (no guard reads here —
@@ -163,7 +165,6 @@ export async function POST(request: Request) {
   let attackerConsumableItemId: string | null = null;
 
   if (consumable_item_id) {
-    const currentWeekStr = getIsoWeekStartDateString();
     const { data: consumable } = await admin
       .from("developer_consumables")
       .select("id, quantity, weekly_uses, last_reset_week")
@@ -176,13 +177,13 @@ export async function POST(request: Request) {
 
     if (consumable && consumable.quantity > 0) {
       let currentUses = consumable.weekly_uses;
-      if (currentWeekStr !== resetWeekStr) currentUses = 0;
+      if (raidWeekStart !== resetWeekStr) currentUses = 0;
       if (currentUses < 3) attackerConsumableItemId = consumable_item_id;
     } else {
       const reqLevel = ITEM_UNLOCK_LEVELS[consumable_item_id];
       const isLevelUnlocked = reqLevel && xpLevel >= reqLevel;
       if (isLevelUnlocked || consumable_item_id === "scouting_satellite") {
-        if (!consumable || consumable.weekly_uses < 3 || resetWeekStr !== currentWeekStr) {
+        if (!consumable || consumable.weekly_uses < 3 || resetWeekStr !== raidWeekStart) {
           attackerConsumableItemId = consumable_item_id;
         }
       }
@@ -206,11 +207,10 @@ export async function POST(request: Request) {
   }
 
   const consumeDeveloperItem = async (devId: number, itemId: string) => {
-    const currentWeekStr = getIsoWeekStartDateString();
     const { data, error } = await admin.rpc("consume_consumable", {
       p_developer_id: devId,
       p_item_id: itemId,
-      p_week_start: currentWeekStr,
+      p_week_start: raidWeekStart,
     });
 
     if (error) {
@@ -235,10 +235,9 @@ export async function POST(request: Request) {
       .gt("quantity", 0);
 
     if (availableDefenses && availableDefenses.length > 0) {
-      const currentWeekStr = getIsoWeekStartDateString();
       for (const def of availableDefenses) {
         let currentUses = def.weekly_uses;
-        if (getUtcDateString(def.last_reset_week) !== currentWeekStr) currentUses = 0;
+        if (getUtcDateString(def.last_reset_week) !== raidWeekStart) currentUses = 0;
         if (currentUses < 3) {
           activeDefenses = [def.item_id];
           defenderItemUsed = true;
@@ -299,7 +298,7 @@ export async function POST(request: Request) {
     p_vehicle:           vehicle,
     p_tag_style:         tagStyle,
     p_consumable_item_id: attackerConsumableItemId,
-    p_week_start:        getIsoWeekStartDateString(),
+    p_week_start:        raidWeekStart,
   });
 
   if (raidError) {


### PR DESCRIPTION
﻿## What does this PR do?

Stabilizes the raid weekly-use calculation by deriving one mutation-safe ISO week-start date at the start of the raid request and reusing it for:

- attacker consumable weekly-use checks
- defender auto-defense weekly-use checks
- `consume_consumable` RPC calls
- the final `execute_raid` RPC payload

This keeps all weekly reset comparisons consistent for the whole request and continues using the shared non-mutating week helper.

## Related issue

Fixes #815

## Screenshots

Not applicable; this is a backend route fix with no UI changes.

## Validation

- `npm.cmd run lint -- src/app/api/raid/execute/route.ts`
- `npm.cmd test -- src/lib/__tests__/week.test.ts`

## Checklist

- [x] `npm run lint` passes for the touched route
- [x] Tested locally with the relevant week utility tests
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
