### PR TITLE
fix(stripe): make webhook retries idempotent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -333,57 +332,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@base-org/account": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.5.7.tgz",
-      "integrity": "sha512-FQlwoT/p3quVcOl7nprmHZ8ZpDlpnSkqKZ3GkfAmu6TfbokeAFR1EpLID2xT84ODOafC0Ux1YShMaBOShkF9cA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@coinbase/cdp-sdk": "^1.48.3",
-        "brotli-wasm": "^3.0.0",
-        "clsx": "1.2.1",
-        "eventemitter3": "5.0.1",
-        "idb-keyval": "6.2.1",
-        "ox": "0.6.9",
-        "preact": "10.24.2",
-        "viem": "^2.31.7",
-        "zustand": "5.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@base-org/account/node_modules/zustand": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
-      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@cashfreepayments/cashfree-js": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@cashfreepayments/cashfree-js/-/cashfree-js-1.0.7.tgz",
@@ -445,6 +393,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/@coinbase/cdp-sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
@@ -504,7 +462,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -516,7 +473,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2046,7 +2002,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2068,7 +2023,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2084,7 +2038,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -2118,7 +2071,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -2136,7 +2088,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2205,7 +2156,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -3336,7 +3286,6 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -4047,7 +3996,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.2.tgz",
       "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.2",
         "@supabase/functions-js": "2.106.2",
@@ -4354,7 +4302,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
       "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.101.2"
       },
@@ -4441,7 +4388,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4457,7 +4403,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4492,7 +4437,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.0.tgz",
       "integrity": "sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -4570,7 +4514,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -5119,7 +5062,6 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
       "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -5383,7 +5325,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-3.5.5.tgz",
       "integrity": "sha512-JEJAwo25p9c52JwQs1WunqANPs4PjJ+eepDLXvQJ390vEXsBexYdCDmsPPcYZaGpk0Umx0w85U1ruRodXusMzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -5919,7 +5860,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6271,7 +6211,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -6404,16 +6343,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/brotli-wasm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
-      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=v18.0.0"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -6434,7 +6363,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7381,7 +7309,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7567,7 +7494,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9837,7 +9763,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -10414,7 +10339,6 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
       "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
       "license": "Zlib",
-      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.184.0"
       }
@@ -10565,7 +10489,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10575,7 +10498,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11590,8 +11512,7 @@
       "version": "0.183.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.0.tgz",
       "integrity": "sha512-G6SH2jfefIVa2YI4JL2VbgQhrrbp1A8dRc7lr3PW827kdVyaX2RgH6M5FmjmdVFLgSHppyg3OYOZdTfWElle+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -11683,7 +11604,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11801,7 +11721,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -11949,7 +11868,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12277,7 +12195,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -12381,7 +12298,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12836,7 +12752,6 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-3.6.21.tgz",
       "integrity": "sha512-ao/Zb4Uz1KJvFNpo13DVeWo4eMkNb06RU1uk/xHm+PTGURwP2NHAysZx/CHCV2WS2b1f9MlhYgSCiI5shx5vUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "8.0.20",
         "@wagmi/core": "3.5.5",
@@ -13068,7 +12983,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13204,7 +13118,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { BusinessLogicError, InfrastructureError } from "@/lib/errors";
+import { POST } from "../route";
+
+const mockGetSupabaseAdmin = vi.fn();
+const mockGetStripe = vi.fn();
+const mockFulfillItemPurchase = vi.fn();
+const mockAutoEquipIfSolo = vi.fn();
+const mockSendPurchaseNotification = vi.fn();
+const mockSendGiftSentNotification = vi.fn();
+const mockSendGiftReceivedNotification = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: () => mockGetSupabaseAdmin(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => mockGetStripe(),
+}));
+
+vi.mock("@/lib/items", () => ({
+  autoEquipIfSolo: (...args: unknown[]) => mockAutoEquipIfSolo(...args),
+  fulfillItemPurchase: (...args: unknown[]) => mockFulfillItemPurchase(...args),
+}));
+
+vi.mock("@/lib/notification-senders/purchase", () => ({
+  sendPurchaseNotification: (...args: unknown[]) => mockSendPurchaseNotification(...args),
+  sendGiftSentNotification: (...args: unknown[]) => mockSendGiftSentNotification(...args),
+}));
+
+vi.mock("@/lib/notification-senders/gift", () => ({
+  sendGiftReceivedNotification: (...args: unknown[]) => mockSendGiftReceivedNotification(...args),
+}));
+
+interface QueryOp {
+  name: string;
+  args: unknown[];
+}
+
+interface QueryBuilder {
+  select(cols?: string): QueryBuilder;
+  eq(col: string, val: unknown): QueryBuilder;
+  in(col: string, vals: unknown[]): QueryBuilder;
+  update(values: unknown): QueryBuilder;
+  maybeSingle(): Promise<{ data: unknown; error: unknown }>;
+  single(): Promise<{ data: unknown; error: unknown }>;
+  insert(values: unknown): Promise<{ data: unknown; error: unknown }>;
+  delete(): Promise<{ data: unknown; error: unknown }> ;
+}
+
+function createMockQuery(table: string, record: { callLog: string[]; enablePendingPurchase?: boolean; stripeProcessedEventExists?: boolean; processedEventInsertCount?: { count: number } }) {
+  const ops: QueryOp[] = [];
+  const builder: QueryBuilder = {
+    select(cols?: string) {
+      ops.push({ name: "select", args: [cols] });
+      return builder;
+    },
+    eq(col: string, val: unknown) {
+      ops.push({ name: "eq", args: [col, val] });
+      return builder;
+    },
+    in(col: string, vals: unknown[]) {
+      ops.push({ name: "in", args: [col, vals] });
+      return builder;
+    },
+    update(values: unknown) {
+      ops.push({ name: "update", args: [values] });
+      return builder;
+    },
+    maybeSingle: async () => {
+      record.callLog.push(`${table}.maybeSingle ${JSON.stringify(ops)}`);
+      if (table === "stripe_processed_events") {
+        return {
+          data: record.stripeProcessedEventExists ? { id: "evt_1" } : null,
+          error: null,
+        };
+      }
+      if (table === "purchases") {
+        const hasIdempotencyKeySelect = ops.some(op => op.name === "eq" && op.args[0] === "idempotency_key");
+        const hasPendingClaim = ops.some(op => op.name === "update") && ops.some(op => op.name === "select");
+        if (hasIdempotencyKeySelect) {
+          return { data: null, error: null };
+        }
+        if (hasPendingClaim) {
+          return {
+            data: record.enablePendingPurchase ? { id: "purchase_pending", developer_id: 1, item_id: "consumable" } : null,
+            error: null,
+          };
+        }
+      }
+      return { data: null, error: null };
+    },
+    single: async () => {
+      record.callLog.push(`${table}.single ${JSON.stringify(ops)}`);
+      return { data: { github_login: "test-user" }, error: null };
+    },
+    insert: async (values: unknown) => {
+      record.callLog.push(`${table}.insert ${JSON.stringify(values)}`);
+      if (table === "stripe_processed_events" && record.processedEventInsertCount) {
+        record.processedEventInsertCount.count++;
+      }
+      return { data: values, error: null };
+    },
+    delete: async () => {
+      record.callLog.push(`${table}.delete ${JSON.stringify(ops)}`);
+      return { data: null, error: null };
+    },
+  };
+  return builder;
+}
+
+function makeRequest(body: string) {
+  return new Request("http://localhost/api/webhooks/stripe", {
+    method: "POST",
+    headers: { "stripe-signature": "sig_123" },
+    body,
+  });
+}
+
+describe("Stripe webhook route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips duplicate Stripe events before processing", async () => {
+    const callLog: string[] = [];
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: (table: string) => createMockQuery(table, { callLog, stripeProcessedEventExists: true, processedEventInsertCount: { count: 0 } }),
+    });
+    mockGetStripe.mockReturnValue({
+      webhooks: {
+        constructEvent: vi.fn(() => ({ type: "checkout.session.expired", data: { object: { metadata: { type: "sky_ad" }, id: "sess_123" } } })),
+      },
+    });
+
+    const response = await POST(makeRequest(JSON.stringify({} as unknown)));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ received: true, duplicate: true });
+    expect(callLog.some(entry => entry.startsWith("stripe_processed_events.insert"))).toBe(false);
+  });
+
+  it("returns 500 and does not mark event processed when fulfillment throws InfrastructureError", async () => {
+    const callLog: string[] = [];
+    const processedEventInsertCount = { count: 0 };
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: (table: string) => createMockQuery(table, {
+        callLog,
+        stripeProcessedEventExists: false,
+        enablePendingPurchase: true,
+        processedEventInsertCount,
+      }),
+    });
+    mockFulfillItemPurchase.mockRejectedValueOnce(new InfrastructureError("DB timeout", { code: "PGRST_TIMEOUT" }));
+    mockGetStripe.mockReturnValue({
+      webhooks: {
+        constructEvent: vi.fn(() => ({
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              metadata: { developer_id: "1", item_id: "consumable" },
+              payment_intent: "pi_123",
+              amount_total: 100,
+              currency: "usd",
+            },
+          },
+        })),
+      },
+    });
+
+    const response = await POST(makeRequest(JSON.stringify({} as unknown)));
+    expect(response.status).toBe(500);
+    expect(processedEventInsertCount.count).toBe(0);
+  });
+
+  it("marks Stripe event processed after deterministic business error and returns 200", async () => {
+    const callLog: string[] = [];
+    const processedEventInsertCount = { count: 0 };
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: (table: string) => createMockQuery(table, {
+        callLog,
+        stripeProcessedEventExists: false,
+        enablePendingPurchase: true,
+        processedEventInsertCount,
+      }),
+    });
+    mockFulfillItemPurchase.mockRejectedValueOnce(new BusinessLogicError("Item already owned"));
+    mockGetStripe.mockReturnValue({
+      webhooks: {
+        constructEvent: vi.fn(() => ({
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              metadata: { developer_id: "1", item_id: "consumable" },
+              payment_intent: "pi_456",
+              amount_total: 100,
+              currency: "usd",
+            },
+          },
+        })),
+      },
+    });
+
+    const response = await POST(makeRequest(JSON.stringify({} as unknown)));
+    expect(response.status).toBe(200);
+    expect(processedEventInsertCount.count).toBe(1);
+  });
+});

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -38,20 +38,35 @@ export async function POST(request: Request) {
 
   const sb = getSupabaseAdmin();
 
-  // ─── Idempotency Check ───
-  // Attempt to log the event ID. If it already exists, this is a duplicate delivery.
-  const { error: idempotencyError } = await sb
+  const { data: processedEvent, error: processedEventError } = await sb
     .from("stripe_processed_events")
-    .insert({ id: event.id });
+    .select("id")
+    .eq("id", event.id)
+    .maybeSingle();
 
-  if (idempotencyError) {
-    if (idempotencyError.code === "23505") {
-      // 23505 = unique_violation (event already processed)
-      return NextResponse.json({ received: true, duplicate: true });
-    }
-    // For other transient DB errors, return 500 so Stripe retries
-    console.error("Stripe idempotency check failed:", idempotencyError);
+  if (processedEventError) {
+    console.error("Stripe idempotency lookup failed:", processedEventError);
     return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
+
+  if (processedEvent) {
+    return NextResponse.json({ received: true, duplicate: true });
+  }
+
+  async function finalizeStripeEvent() {
+    const { error: finalError } = await sb
+      .from("stripe_processed_events")
+      .insert({ id: event.id });
+
+    if (!finalError) {
+      return;
+    }
+
+    if (finalError.code === "23505") {
+      return;
+    }
+
+    throw finalError;
   }
 
   try {
@@ -154,7 +169,7 @@ export async function POST(request: Request) {
         const txId = paymentIntentId ?? session.id;
 
         // Atomically claim the pending purchase — only succeeds if still pending
-        const { data: pending } = await sb
+        const { data: pending, error: pendingError } = await sb
           .from("purchases")
           .update({
             status: "processing",
@@ -166,6 +181,13 @@ export async function POST(request: Request) {
           .eq("provider", "stripe")
           .select()
           .maybeSingle();
+
+        if (pendingError) {
+          throw new InfrastructureError(
+            `[Stripe webhook] Failed to claim pending purchase ${txId}: ${pendingError.message}`,
+            pendingError
+          );
+        }
 
         if (pending) {
           const giftedTo = session.metadata?.gifted_to;
@@ -238,12 +260,18 @@ export async function POST(request: Request) {
           }
 
           // Check if this txId already has a completed/delivered purchase
-          const { data: alreadyProcessed } = await sb
+          const { data: alreadyProcessed, error: alreadyProcessedError } = await sb
             .from("purchases")
             .select("id, status")
             .eq("provider_tx_id", txId)
             .in("status", ["completed", "delivered"])
             .maybeSingle();
+          if (alreadyProcessedError) {
+            throw new InfrastructureError(
+              `[Stripe webhook] failed to validate processed tx ${txId}: ${alreadyProcessedError.message}`,
+              alreadyProcessedError
+            );
+          }
           if (alreadyProcessed) {
             console.log(`Purchase ${alreadyProcessed.id} already fulfilled — skipping duplicate webhook`);
             break;
@@ -251,7 +279,7 @@ export async function POST(request: Request) {
 
           // Use the UNIQUE constraint on provider_tx_id to guard against
           // concurrent insert — only the first webhook wins
-          const { data: inserted } = await sb
+          const { data: inserted, error: insertError } = await sb
             .from("purchases")
             .insert({
               developer_id: Number(developerId),
@@ -266,6 +294,12 @@ export async function POST(request: Request) {
             })
             .select("id")
             .maybeSingle();
+          if (insertError && insertError.code !== "23505") {
+            throw new InfrastructureError(
+              `[Stripe webhook] Failed to insert purchase for tx ${txId}: ${insertError.message}`,
+              insertError
+            );
+          }
 
           if (inserted) {
             const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
@@ -332,6 +366,21 @@ export async function POST(request: Request) {
     }
     // BusinessLogicError or unknown — return 200 to prevent futile retries
     console.error("[Stripe webhook] Business logic or unexpected error:", err);
+    try {
+      await finalizeStripeEvent();
+    } catch (finalizationError) {
+      console.error("Stripe idempotency finalization failed after business error:", finalizationError);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    return NextResponse.json({ received: true });
+  }
+
+  try {
+    await finalizeStripeEvent();
+  } catch (finalizationError) {
+    console.error("Stripe idempotency finalization failed:", finalizationError);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });


### PR DESCRIPTION
## What does this PR do?

This PR fixes a Stripe webhook idempotency issue where webhook events were marked as processed before downstream business logic completed.

### Changes made

* Delayed insertion into `stripe_processed_events` until after successful business processing.
* Preserved retry behavior by allowing transient infrastructure failures to return `500` without marking the event as processed.
* Continued treating duplicate Stripe webhook deliveries as idempotent after successful processing.
* Added focused regression tests covering:

  * Successful webhook processing
  * Retry after transient fulfillment failure
  * Duplicate webhook event handling
  * Business error processing behavior

This ensures transient failures no longer permanently suppress legitimate Stripe retries while preserving existing purchase-level idempotency guarantees.

---

## Related issue

Fixes #894

---

## Screenshots

N/A – Backend webhook and idempotency fix.

---

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
