### PR TITLE
fix(auth): enforce 5s timeout on Supabase session refresh

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -140,36 +140,36 @@ export async function middleware(request: NextRequest) {
           },
         );
 
+    try {
+      // Timeout auth validation to prevent slow Supabase responses from
+      // blocking the entire request (seen up to 28s in prod logs).
+      const authTimeout = 5_000; // 5 seconds
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("AuthTimeout")), authTimeout)
+      );
+
       try {
-        // Timeout auth validation to prevent slow Supabase responses from
-        // blocking the entire request (seen up to 28s in prod logs).
-        const authTimeout = 5_000; // 5 seconds
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("AuthTimeout")), authTimeout)
-        );
+        const { data: { user }, error } = await Promise.race([
+          supabase.auth.getUser(),
+          timeoutPromise
+        ]);
 
-        try {
-          const { data: { user }, error } = await Promise.race([
-            supabase.auth.getUser(),
-            timeoutPromise
-          ]);
-
-          if (error) {
-            console.warn(
-              "Supabase authentication validation failed:",
-              error.message || error,
-            );
-          } else {
-            void user; // session refreshed; user object not needed here
-          }
-        } catch (innerError) {
-          if (innerError instanceof Error && innerError.message === "AuthTimeout") {
-            console.warn("Supabase auth.getUser() timed out after 5s — continuing without session refresh");
-          } else {
-            throw innerError; // re-throw non-timeout errors to outer catch
-          }
+        if (error) {
+          console.warn(
+            "Supabase authentication validation failed:",
+            error.message || error,
+          );
+        } else {
+          void user; // session refreshed; user object not needed here
         }
-      } catch (error) {
+      } catch (innerError) {
+        if (innerError instanceof Error && innerError.message === "AuthTimeout") {
+          console.warn("Supabase auth.getUser() timed out after 5s — continuing without session refresh");
+        } else {
+          throw innerError; // re-throw non-timeout errors to outer catch
+        }
+      }
+    } catch (error) {
       console.warn(
         "Supabase authentication validation threw an error:",
         error instanceof Error ? error.message : error,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -140,34 +140,36 @@ export async function middleware(request: NextRequest) {
           },
         );
 
-    try {
-      // Timeout auth validation to prevent slow Supabase responses from
-      // blocking the entire request (seen up to 28s in prod logs).
-      const authTimeout = 5_000; // 5 seconds
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), authTimeout);
-
       try {
-        const { data: { user }, error } = await supabase.auth.getUser();
-        clearTimeout(timer);
+        // Timeout auth validation to prevent slow Supabase responses from
+        // blocking the entire request (seen up to 28s in prod logs).
+        const authTimeout = 5_000; // 5 seconds
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("AuthTimeout")), authTimeout)
+        );
 
-        if (error) {
-          console.warn(
-            "Supabase authentication validation failed:",
-            error.message || error,
-          );
-        } else {
-          void user; // session refreshed; user object not needed here
+        try {
+          const { data: { user }, error } = await Promise.race([
+            supabase.auth.getUser(),
+            timeoutPromise
+          ]);
+
+          if (error) {
+            console.warn(
+              "Supabase authentication validation failed:",
+              error.message || error,
+            );
+          } else {
+            void user; // session refreshed; user object not needed here
+          }
+        } catch (innerError) {
+          if (innerError instanceof Error && innerError.message === "AuthTimeout") {
+            console.warn("Supabase auth.getUser() timed out after 5s — continuing without session refresh");
+          } else {
+            throw innerError; // re-throw non-timeout errors to outer catch
+          }
         }
-      } catch (innerError) {
-        clearTimeout(timer);
-        if (innerError instanceof DOMException && innerError.name === "AbortError") {
-          console.warn("Supabase auth.getUser() timed out after 5s — continuing without session refresh");
-        } else {
-          throw innerError; // re-throw non-timeout errors to outer catch
-        }
-      }
-    } catch (error) {
+      } catch (error) {
       console.warn(
         "Supabase authentication validation threw an error:",
         error instanceof Error ? error.message : error,


### PR DESCRIPTION
## What does this PR do?

Fixes a critical bug in the edge middleware where the 5-second `setTimeout` failed to abort the Supabase `auth.getUser()` fetch call. Because the SDK doesn't natively accept the `controller.signal`, the fetch would hang until the Vercel execution limit was reached, causing 504 Gateway Timeouts during latency spikes. This PR implements a `Promise.race()` to correctly enforce the timeout at the event loop level and allow the fallback logic to execute.

## Related issue

Fixes #950

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
