### PR TITLE
fix(checkout): block re-purchasing of gifted items

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -229,7 +229,7 @@ export async function POST(request: Request) {
     const { data: existingPurchases } = await sb
       .from("purchases")
       .select("id, amount_cents, provider")
-      .eq("developer_id", dev.id)
+      .or(`and(developer_id.eq.${dev.id},gifted_to.is.null),gifted_to.eq.${dev.id}`)
       .eq("item_id", item_id)
       .eq("status", "completed");
 


### PR DESCRIPTION
## What does this PR do?

Fixes a financial logic flaw where users could accidentally purchase non-consumable items with real money that they already owned via a gift. The previous validation query only checked if the user was the direct buyer (`developer_id`), completely missing the check for `gifted_to`. This PR correctly scopes the duplicate ownership check to either direct ownership (`developer_id = user && gifted_to IS NULL`) or received gifts (`gifted_to = user`).

## Related issue

Fixes #951

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
