### PR TITLE
fix(storage): delete old billboard image before upsert to prevent storage leak

### DIFF
--- a/src/app/api/customizations/upload/route.ts
+++ b/src/app/api/customizations/upload/route.ts
@@ -162,6 +162,42 @@ export async function POST(request: Request) {
     );
   }
 
+  // Read existing config to build images array
+  const { data: existingConfig } = await sb
+    .from("developer_customizations")
+    .select("config")
+    .eq("developer_id", dev.id)
+    .eq("item_id", "billboard")
+    .maybeSingle();
+
+  let images: string[] = [];
+  if (existingConfig) {
+    const cfg = existingConfig.config as Record<string, unknown>;
+    if (Array.isArray(cfg?.images)) {
+      images = [...(cfg.images as string[])];
+    } else if (typeof cfg?.image_url === "string") {
+      // Migrate legacy single image to array
+      images = [cfg.image_url];
+    }
+  }
+
+  // Extend array if needed and set the slot
+  while (images.length <= slotIndex) {
+    images.push("");
+  }
+
+  // If replacing an existing image, delete it first to prevent storage exhaustion
+  if (images[slotIndex]) {
+    try {
+      const oldFileName = images[slotIndex].split("/").pop();
+      if (oldFileName) {
+        await sb.storage.from("billboards").remove([oldFileName]);
+      }
+    } catch (err) {
+      console.warn("Error cleaning up old billboard image:", err);
+    }
+  }
+
   const ext = detectedType.split("/")[1] === "jpeg" ? "jpg" : detectedType.split("/")[1];
   const filePath = `${dev.id}_${slotIndex}.${ext}`;
 
@@ -186,30 +222,6 @@ export async function POST(request: Request) {
     .getPublicUrl(filePath);
 
   const imageUrl = urlData.publicUrl;
-
-  // Read existing config to build images array
-  const { data: existingConfig } = await sb
-    .from("developer_customizations")
-    .select("config")
-    .eq("developer_id", dev.id)
-    .eq("item_id", "billboard")
-    .maybeSingle();
-
-  let images: string[] = [];
-  if (existingConfig) {
-    const cfg = existingConfig.config as Record<string, unknown>;
-    if (Array.isArray(cfg?.images)) {
-      images = [...(cfg.images as string[])];
-    } else if (typeof cfg?.image_url === "string") {
-      // Migrate legacy single image to array
-      images = [cfg.image_url];
-    }
-  }
-
-  // Extend array if needed and set the slot
-  while (images.length <= slotIndex) {
-    images.push("");
-  }
   images[slotIndex] = imageUrl;
 
   // Upsert customization with images array


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite storage exhaustion vulnerability in the billboard upload API. Previously, the endpoint relied solely on `upsert: true` to overwrite old images. However, because file extensions are dynamically generated based on MIME types (`.png` vs `.jpg`), a user uploading alternating file formats to the same slot would bypass the overwrite and indefinitely leak orphaned files in the storage bucket. 

This PR fetches the existing image URL before uploading the new file and explicitly deletes the old file if it exists, ensuring the storage footprint remains strictly bounded regardless of extension changes.

## Related issue

Fixes #952

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
