### PR TITLE
fix(3d): resolve React Concurrent Mode violation in CameraFocus

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -411,7 +411,10 @@ function CameraFocus({
 
   // Use ref for buildings to avoid re-triggering animation on array changes
   const buildingsRef = useRef(buildings);
-  buildingsRef.current = buildings;
+  
+  useEffect(() => {
+    buildingsRef.current = buildings;
+  }, [buildings]);
 
   useEffect(() => {
     if (relicFocus) {


### PR DESCRIPTION
## What does this PR do?

Fixes a strict React Concurrent Mode violation inside the `CameraFocus` component in `CityCanvas.tsx`. Mutating a `useRef` directly in the render body (`buildingsRef.current = buildings;`) can lead to visual tearing and inconsistent camera state if a render is interrupted by React Fiber's concurrent renderer (used heavily by `@react-three/fiber`). 

This PR moves the ref mutation into a passive `useEffect`, adhering to React's pure render constraints and ensuring stable camera logic.

## Related issue

Fixes #953

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
