### PR TITLE
fix: persist building customizations across login sessions (#804)

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -92,6 +92,7 @@ async function fetchLeetCodeUser(username: string) {
       return null;
     }
     const rawText = await res.text();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let json: any;
     try { json = JSON.parse(rawText); } catch (err) { 
       console.error(`[/api/dev] LeetCode non-JSON response for "${username}": ${rawText.substring(0, 200)}`, err);
@@ -188,19 +189,37 @@ export async function GET(
       // LeetCode explicitly says user doesn't exist — return 404 regardless of cache
       return NextResponse.json({ error: "User not found on LeetCode" }, { status: 404 });
     } else {
+      interface SubmissionNum {
+        difficulty: string;
+        count: number;
+      }
+      interface LanguageProblem {
+        languageName: string;
+        problemsSolved: number;
+      }
+      interface Badge {
+        name: string;
+        icon: string;
+        displayName: string;
+      }
+      interface TagCount {
+        tagName: string;
+        problemsSolved: number;
+      }
+
       const user = data.matchedUser;
-      const acNums = user.submitStats?.acSubmissionNum ?? [];
-      const totNums = user.submitStats?.totalSubmissionNum ?? [];
-      const getAC = (d: string) => acNums.find((x: any) => x.difficulty === d)?.count ?? 0;
-      const getTot = (d: string) => totNums.find((x: any) => x.difficulty === d)?.count ?? 1;
+      const acNums = (user.submitStats?.acSubmissionNum ?? []) as SubmissionNum[];
+      const totNums = (user.submitStats?.totalSubmissionNum ?? []) as SubmissionNum[];
+      const getAC = (d: string) => acNums.find((x: SubmissionNum) => x.difficulty === d)?.count ?? 0;
+      const getTot = (d: string) => totNums.find((x: SubmissionNum) => x.difficulty === d)?.count ?? 1;
 
       const totalSolved = getAC("All");
       const totalSub = getTot("All");
       const activeDays = user.userCalendar?.totalActiveDays ?? 0;
       const lcRank = user.profile?.ranking ?? 999999;
-      const languages = user.languageProblemCount ?? [];
+      const languages = (user.languageProblemCount ?? []) as LanguageProblem[];
       const dominantLanguage = languages.length > 0
-        ? [...languages].sort((a: any, b: any) => 
+        ? [...languages].sort((a: LanguageProblem, b: LanguageProblem) => 
         b.problemsSolved - a.problemsSolved)[0].languageName
         : null;
       const litPercentage = Math.min(0.92, Math.max(0.15, activeDays / 365));
@@ -239,7 +258,7 @@ export async function GET(
         contest_badge_name: data.userContestRanking?.badge?.name ?? null,
         // Badges
         lc_badge: (user.badges?.length ?? 0) > 0 ? user.badges[user.badges.length - 1].name : null,
-        lc_badges_all: (user.badges ?? []).map((b: any) => ({ name: b.name, icon: b.icon, displayName: b.displayName })),
+        lc_badges_all: (user.badges ?? []).map((b: Badge) => ({ name: b.name, icon: b.icon, displayName: b.displayName })),
         // Profile metadata
         lc_bio: user.profile?.aboutMe ?? null,
         lc_country_code: user.profile?.countryName ?? null,
@@ -252,13 +271,13 @@ export async function GET(
         primary_language:dominantLanguage,
         // Tag stats
         lc_tag_stats: [
-          ...(user.tagProblemCounts?.advanced ?? []),
-          ...(user.tagProblemCounts?.intermediate ?? []),
-          ...(user.tagProblemCounts?.fundamental ?? []),
+          ...((user.tagProblemCounts?.advanced ?? []) as TagCount[]),
+          ...((user.tagProblemCounts?.intermediate ?? []) as TagCount[]),
+          ...((user.tagProblemCounts?.fundamental ?? []) as TagCount[]),
         ]
-          .sort((a: any, b: any) => b.problemsSolved - a.problemsSolved)
+          .sort((a: TagCount, b: TagCount) => b.problemsSolved - a.problemsSolved)
           .slice(0, 20)
-          .map((t: any) => ({ name: t.tagName, solved: t.problemsSolved })),
+          .map((t: TagCount) => ({ name: t.tagName, solved: t.problemsSolved })),
       };
 
       const newBaseXp = calculateLeetcodeXp({

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -179,115 +179,117 @@ export async function GET(
     const data = await fetchLeetCodeUser(username);
     if (!data) {
       // Network/parsing error — return stale cached if available
-      if (cached) return NextResponse.json(cached);
-      return NextResponse.json({ error: "Failed to fetch LeetCode data" }, { status: 502 });
-    }
-    if (!data.matchedUser) {
+      if (cached) {
+        upserted = cached;
+      } else {
+        return NextResponse.json({ error: "Failed to fetch LeetCode data" }, { status: 502 });
+      }
+    } else if (!data.matchedUser) {
       // LeetCode explicitly says user doesn't exist — return 404 regardless of cache
       return NextResponse.json({ error: "User not found on LeetCode" }, { status: 404 });
+    } else {
+      const user = data.matchedUser;
+      const acNums = user.submitStats?.acSubmissionNum ?? [];
+      const totNums = user.submitStats?.totalSubmissionNum ?? [];
+      const getAC = (d: string) => acNums.find((x: any) => x.difficulty === d)?.count ?? 0;
+      const getTot = (d: string) => totNums.find((x: any) => x.difficulty === d)?.count ?? 1;
+
+      const totalSolved = getAC("All");
+      const totalSub = getTot("All");
+      const activeDays = user.userCalendar?.totalActiveDays ?? 0;
+      const lcRank = user.profile?.ranking ?? 999999;
+      const languages = user.languageProblemCount ?? [];
+      const dominantLanguage = languages.length > 0
+        ? [...languages].sort((a: any, b: any) => 
+        b.problemsSolved - a.problemsSolved)[0].languageName
+        : null;
+      const litPercentage = Math.min(0.92, Math.max(0.15, activeDays / 365));
+
+      // Stable ID from username
+      let hash = 0;
+      for (const ch of username) hash = (Math.imul(31, hash) + ch.charCodeAt(0)) | 0;
+
+      const record = {
+        github_login: username.toLowerCase(),
+        github_id: Math.abs(hash),
+        name: user.profile?.realName || user.username,
+        avatar_url: user.profile?.userAvatar || "",
+        contributions: Math.max(1, totalSolved),
+        contributions_total: Math.round(litPercentage * 1000),
+        total_stars: user.profile?.reputation || 0,
+        public_repos: Math.max(0, 500000 - lcRank),
+        rank: lcRank,
+        lc_global_rank: lcRank, // Populate official rank
+        fetched_at: new Date().toISOString(),
+        // LC-specific
+        easy_solved: getAC("Easy"),
+        medium_solved: getAC("Medium"),
+        hard_solved: getAC("Hard"),
+        acceptance_rate: totalSub > 0 ? Math.round((totalSolved / totalSub) * 100) / 100 : 0,
+        contest_rating: Math.round(data.userContestRanking?.rating ?? 0),
+        contest_rank: data.userContestRanking?.globalRanking ?? null,
+        lc_streak: user.maxStreak ?? user.userCalendar?.streak ?? 0,
+        lc_max_streak: user.maxStreak ?? 0,
+        active_days_last_year: activeDays,
+        total_active_days: activeDays,
+        total_submitted: totalSub,
+        // Contest extended
+        contests_attended: data.userContestRanking?.attendedContestsCount ?? 0,
+        contest_top_percentage: data.userContestRanking?.topPercentage ?? null,
+        contest_badge_name: data.userContestRanking?.badge?.name ?? null,
+        // Badges
+        lc_badge: (user.badges?.length ?? 0) > 0 ? user.badges[user.badges.length - 1].name : null,
+        lc_badges_all: (user.badges ?? []).map((b: any) => ({ name: b.name, icon: b.icon, displayName: b.displayName })),
+        // Profile metadata
+        lc_bio: user.profile?.aboutMe ?? null,
+        lc_country_code: user.profile?.countryName ?? null,
+        lc_school: user.profile?.school ?? null,
+        lc_company: user.profile?.company ?? null,
+        lc_website: user.profile?.websites?.[0] ?? null,
+        lc_twitter: user.profile?.twitterUrl ?? null,
+        lc_linkedin: user.profile?.linkedinUrl ?? null,
+        lc_github: user.profile?.githubUrl ?? null,
+        primary_language:dominantLanguage,
+        // Tag stats
+        lc_tag_stats: [
+          ...(user.tagProblemCounts?.advanced ?? []),
+          ...(user.tagProblemCounts?.intermediate ?? []),
+          ...(user.tagProblemCounts?.fundamental ?? []),
+        ]
+          .sort((a: any, b: any) => b.problemsSolved - a.problemsSolved)
+          .slice(0, 20)
+          .map((t: any) => ({ name: t.tagName, solved: t.problemsSolved })),
+      };
+
+      const newBaseXp = calculateLeetcodeXp({
+        easy_solved: record.easy_solved,
+        medium_solved: record.medium_solved,
+        hard_solved: record.hard_solved,
+        contest_rating: record.contest_rating,
+        lc_streak: record.lc_streak
+      });
+
+      // We must merge new Base XP with existing Base XP safely.
+      // Wait to upsert until we check if the user exists so we know what to append.
+      // mergeBaseXp preserves earned (non-base) XP and never goes negative; for a
+      // brand-new record (no cache) prev values are 0, so it returns newBaseXp.
+      const mergeRecord = {
+        ...record,
+        xp_github: newBaseXp,
+        xp_total: mergeBaseXp(cached?.xp_total, cached?.xp_github, newBaseXp),
+      };
+
+      const { data: upsertedResult, error: upsertError } = await sb
+        .from("developers")
+        .upsert(mergeRecord, { onConflict: "github_login" })
+        .select()
+        .single();
+
+      if (upsertError) {
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+      upserted = upsertedResult;
     }
-
-    const user = data.matchedUser;
-    const acNums = user.submitStats?.acSubmissionNum ?? [];
-    const totNums = user.submitStats?.totalSubmissionNum ?? [];
-    const getAC = (d: string) => acNums.find((x: any) => x.difficulty === d)?.count ?? 0;
-    const getTot = (d: string) => totNums.find((x: any) => x.difficulty === d)?.count ?? 1;
-
-    const totalSolved = getAC("All");
-    const totalSub = getTot("All");
-    const activeDays = user.userCalendar?.totalActiveDays ?? 0;
-    const lcRank = user.profile?.ranking ?? 999999;
-    const languages = user.languageProblemCount ?? [];
-    const dominantLanguage = languages.length > 0
-      ? [...languages].sort((a: any, b: any) => 
-      b.problemsSolved - a.problemsSolved)[0].languageName
-      : null;
-    const litPercentage = Math.min(0.92, Math.max(0.15, activeDays / 365));
-
-    // Stable ID from username
-    let hash = 0;
-    for (const ch of username) hash = (Math.imul(31, hash) + ch.charCodeAt(0)) | 0;
-
-    const record = {
-      github_login: username.toLowerCase(),
-      github_id: Math.abs(hash),
-      name: user.profile?.realName || user.username,
-      avatar_url: user.profile?.userAvatar || "",
-      contributions: Math.max(1, totalSolved),
-      contributions_total: Math.round(litPercentage * 1000),
-      total_stars: user.profile?.reputation || 0,
-      public_repos: Math.max(0, 500000 - lcRank),
-      rank: lcRank,
-      lc_global_rank: lcRank, // Populate official rank
-      fetched_at: new Date().toISOString(),
-      // LC-specific
-      easy_solved: getAC("Easy"),
-      medium_solved: getAC("Medium"),
-      hard_solved: getAC("Hard"),
-      acceptance_rate: totalSub > 0 ? Math.round((totalSolved / totalSub) * 100) / 100 : 0,
-      contest_rating: Math.round(data.userContestRanking?.rating ?? 0),
-      contest_rank: data.userContestRanking?.globalRanking ?? null,
-      lc_streak: user.maxStreak ?? user.userCalendar?.streak ?? 0,
-      lc_max_streak: user.maxStreak ?? 0,
-      active_days_last_year: activeDays,
-      total_active_days: activeDays,
-      total_submitted: totalSub,
-      // Contest extended
-      contests_attended: data.userContestRanking?.attendedContestsCount ?? 0,
-      contest_top_percentage: data.userContestRanking?.topPercentage ?? null,
-      contest_badge_name: data.userContestRanking?.badge?.name ?? null,
-      // Badges
-      lc_badge: (user.badges?.length ?? 0) > 0 ? user.badges[user.badges.length - 1].name : null,
-      lc_badges_all: (user.badges ?? []).map((b: any) => ({ name: b.name, icon: b.icon, displayName: b.displayName })),
-      // Profile metadata
-      lc_bio: user.profile?.aboutMe ?? null,
-      lc_country_code: user.profile?.countryName ?? null,
-      lc_school: user.profile?.school ?? null,
-      lc_company: user.profile?.company ?? null,
-      lc_website: user.profile?.websites?.[0] ?? null,
-      lc_twitter: user.profile?.twitterUrl ?? null,
-      lc_linkedin: user.profile?.linkedinUrl ?? null,
-      lc_github: user.profile?.githubUrl ?? null,
-      primary_language:dominantLanguage,
-      // Tag stats
-      lc_tag_stats: [
-        ...(user.tagProblemCounts?.advanced ?? []),
-        ...(user.tagProblemCounts?.intermediate ?? []),
-        ...(user.tagProblemCounts?.fundamental ?? []),
-      ]
-        .sort((a: any, b: any) => b.problemsSolved - a.problemsSolved)
-        .slice(0, 20)
-        .map((t: any) => ({ name: t.tagName, solved: t.problemsSolved })),
-    };
-
-    const newBaseXp = calculateLeetcodeXp({
-      easy_solved: record.easy_solved,
-      medium_solved: record.medium_solved,
-      hard_solved: record.hard_solved,
-      contest_rating: record.contest_rating,
-      lc_streak: record.lc_streak
-    });
-
-    // We must merge new Base XP with existing Base XP safely.
-    // Wait to upsert until we check if the user exists so we know what to append.
-    // mergeBaseXp preserves earned (non-base) XP and never goes negative; for a
-    // brand-new record (no cache) prev values are 0, so it returns newBaseXp.
-    const mergeRecord = {
-      ...record,
-      xp_github: newBaseXp,
-      xp_total: mergeBaseXp(cached?.xp_total, cached?.xp_github, newBaseXp),
-    };
-
-    const { data: upsertedResult, error: upsertError } = await sb
-      .from("developers")
-      .upsert(mergeRecord, { onConflict: "github_login" })
-      .select()
-      .single();
-
-    if (upsertError) {
-      return NextResponse.json({ error: "Database error" }, { status: 500 });
-    }
-    upserted = upsertedResult;
   }
 
   // Round 2: Fetch customizations and items to return a full building record

--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -1301,11 +1301,11 @@ export function CityProvider({ children }: { children: ReactNode }) {
           rawDevsRef.current[foundIdx] = {
             ...existing,
             ...devData,
-            loadout: devData.loadout ?? existing.loadout ?? null,
-            custom_color: devData.custom_color ?? existing.custom_color ?? null,
-            owned_items: devData.owned_items?.length ? devData.owned_items : existing.owned_items ?? [],
-            billboard_images: devData.billboard_images?.length ? devData.billboard_images : existing.billboard_images ?? [],
-            building_style: devData.building_style ?? existing.building_style ?? "tower",
+            loadout: devData.loadout !== undefined ? devData.loadout : existing.loadout ?? null,
+            custom_color: devData.custom_color !== undefined ? devData.custom_color : existing.custom_color ?? null,
+            owned_items: devData.owned_items !== undefined ? devData.owned_items : existing.owned_items ?? [],
+            billboard_images: devData.billboard_images !== undefined ? devData.billboard_images : existing.billboard_images ?? [],
+            building_style: devData.building_style !== undefined ? devData.building_style : existing.building_style ?? "tower",
           };
           const layout = generateCityLayout(rawDevsRef.current);
           setBuildings(layout.buildings);


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where custom styling on buildings (custom color, billboard images, equipped crowns/aura/roof loadouts) resets to defaults upon logging out and logging back in.

- **Backend (`/api/dev/[username]`)**: Modified the route to assign `upserted = cached` and skip the upsert block when the LeetCode fetch fails (e.g., due to rate-limiting or network issues). This allows the execution to continue to Round 2 and successfully load and return the latest customizations from the `developer_customizations` table rather than returning an incomplete record.
- **Frontend (`CityContext.tsx`)**: Updated the merge logic in `silentRefresh` to use strict `undefined` checks (`!== undefined`) rather than nullish coalescing (`??`). This ensures that if the API explicitly returns `null` or empty values (e.g., when a user intentionally removes/unequips a customization), the client correctly updates to that state instead of falling back to stale values in `existing`.

## Related issue

Fixes #804

## Screenshots

<!-- Before/after if visual changes -->
*No direct visual layout changes; corrects rendering state retrieval upon re-login.*

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
