### PR TITLE
[GSSoC'26] fix: preserve original created_at timestamp on relic equip/track upserts

### DIFF
--- a/src/app/api/relics/equip/route.ts
+++ b/src/app/api/relics/equip/route.ts
@@ -77,20 +77,15 @@ export async function POST(request: Request) {
             .select("id")
             .eq("developer_id", dev.id)
             .eq("status", "completed");
-
           const hasPurchases = !!(dbPurchases && dbPurchases.length > 0);
 
           const staticRelic = STATIC_RELICS.find((r) => r.id === relicId);
-
           if (staticRelic) {
             if (relicId === "relic_lith_dawnstone") {
               const lcStreak = dev.lc_streak ?? 0;
               const appStreak = dev.app_streak ?? 0;
               const dailiesStreak = dev.dailies_streak ?? 0;
-              isUnlocked =
-                lcStreak >= 7 ||
-                appStreak >= 7 ||
-                dailiesStreak >= 7;
+              isUnlocked = lcStreak >= 7 || appStreak >= 7 || dailiesStreak >= 7;
             } else if (relicId === "relic_lith_harbor_key") {
               isUnlocked = (trackerProgress.docks_visits ?? 0) >= 5;
             } else if (relicId === "relic_meso_core_oscillator") {
@@ -115,21 +110,13 @@ export async function POST(request: Request) {
               const dailiesStreak = dev.dailies_streak ?? 0;
               const lcStreak = dev.lc_streak ?? 0;
               const dailiesCompleted = dev.dailies_completed ?? 0;
-
-              isUnlocked =
-                appStreak >= 365 ||
-                dailiesStreak >= 365 ||
-                lcStreak >= 365 ||
-                dailiesCompleted >= 182;
+              isUnlocked = appStreak >= 365 || dailiesStreak >= 365 || lcStreak >= 365 || dailiesCompleted >= 182;
             }
           }
         }
 
         if (!isUnlocked) {
-          return NextResponse.json(
-            { error: "Relic is locked" },
-            { status: 403 }
-          );
+          return NextResponse.json({ error: "Relic is locked" }, { status: 403 });
         }
       }
     }
@@ -149,11 +136,8 @@ export async function POST(request: Request) {
             developer_id: dev.id,
             relic_id: relicId,
             is_equipped: true,
-            created_at: new Date().toISOString(),
           },
-          {
-            onConflict: "developer_id,relic_id",
-          }
+          { onConflict: "developer_id,relic_id" }
         );
     }
   }

--- a/src/app/api/relics/route.ts
+++ b/src/app/api/relics/route.ts
@@ -178,7 +178,8 @@ export async function GET() {
         toInsert.push({
           developer_id: devRecord.id,
           relic_id: relic.id,
-          is_equipped: false
+          is_equipped: false,
+          created_at: new Date().toISOString(),
         });
       }
     }

--- a/src/app/api/relics/track/route.ts
+++ b/src/app/api/relics/track/route.ts
@@ -93,13 +93,13 @@ export async function POST(request: Request) {
   );
 
   // 5. If we unlocked a relic, upsert it into developer_relics
+  //    created_at is intentionally excluded from upsert to preserve original unlock timestamp
   if (unlockedRelicId) {
     await admin.from("developer_relics").upsert(
       {
         developer_id: dev.id,
         relic_id: unlockedRelicId,
         is_equipped: false,
-        created_at: new Date().toISOString(),
       },
       { onConflict: "developer_id,relic_id" }
     );


### PR DESCRIPTION
## What does this PR do?

Preserve the original unlock timestamp on relic equip/track upserts so it is not overwritten on every operation.

- Removed `created_at` from the equip and track upsert payloads so only the original unlock timestamp is preserved.
- Added `created_at: new Date().toISOString()` to the GET route's auto-insert so newly unlocked relics get a proper creation timestamp.

## Related issue

Fixes #945

## Screenshots

N/A (backend logic change, no UI impact)

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)