### PR TITLE
[GSSoC'26] fix: filter free/zero-amount purchases from relic_neo_cyber_sigil unlock check

### DIFF
--- a/src/app/api/relics/equip/route.ts
+++ b/src/app/api/relics/equip/route.ts
@@ -71,12 +71,15 @@ export async function POST(request: Request) {
 
           const trackerProgress = custom?.config ?? {};
 
-          // 3. Check completed purchases
+          // 3. Check completed purchases (for relic_neo_cyber_sigil)
+          // Exclude free/zero-amount purchases from streak rewards and free claim items
           const { data: dbPurchases } = await admin
             .from("purchases")
             .select("id")
             .eq("developer_id", dev.id)
-            .eq("status", "completed");
+            .eq("status", "completed")
+            .not("provider", "eq", "free")
+            .gt("amount_cents", 0);
           const hasPurchases = !!(dbPurchases && dbPurchases.length > 0);
 
           const staticRelic = STATIC_RELICS.find((r) => r.id === relicId);

--- a/src/app/api/relics/route.ts
+++ b/src/app/api/relics/route.ts
@@ -77,11 +77,14 @@ export async function GET() {
       }
 
       // Check for completed purchases (for relic_neo_cyber_sigil)
+      // Exclude free/zero-amount purchases from streak rewards and free claim items
       const { data: dbPurchases } = await admin
         .from("purchases")
         .select("id")
         .eq("developer_id", dev.id)
-        .eq("status", "completed");
+        .eq("status", "completed")
+        .not("provider", "eq", "free")
+        .gt("amount_cents", 0);
       hasPurchases = !!(dbPurchases && dbPurchases.length > 0);
     }
   }


### PR DESCRIPTION
## What does this PR do?

Filter free/zero-amount purchases from the `relic_neo_cyber_sigil` financial-supporter badge unlock check so the badge only unlocks on genuine financial transactions.

- Added `.not("provider", "eq", "free")` and `.gt("amount_cents", 0)` filters to the purchase queries in both the relics GET route and the equip route.
- Free purchases from streak rewards (`src/app/api/checkin/route.ts`) and the free building claim item (`src/lib/items.ts:grantFreeClaimItem`) are now correctly excluded from the purchase count.
- Matches the existing filtering pattern in `getOwnedItems()` (`src/lib/items.ts:40-43`).

## Related issue

Fixes #944

## Screenshots

N/A (backend logic change, no UI impact)

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)