### PR TITLE
fix: prevent Battle button from rendering on user's own building-#798

### DIFF
--- a/src/components/hud/ProfileCard.tsx
+++ b/src/components/hud/ProfileCard.tsx
@@ -232,8 +232,10 @@ export default function ProfileCard() {
 
   const isOwnBuilding =
     !!selectedBuilding &&
-    !!linkedLeetCodeUsername &&
-    selectedBuilding.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase();
+    (
+      (!!linkedLeetCodeUsername && selectedBuilding.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase()) ||
+      (!!authLogin && selectedBuilding.login.toLowerCase() === authLogin)
+    );
 
   return (
     <>

--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -621,12 +621,12 @@ export function CityProvider({ children }: { children: ReactNode }) {
   const identityResolved = sessionResolved && (!session || linkStatusResolved);
 
   const isOwnBuilding = useMemo(() => {
-    return (
-      !!selectedBuilding &&
-      !!linkedLeetCodeUsername &&
-      selectedBuilding.login.toLowerCase() === linkedLeetCodeUsername.toLowerCase()
-    );
-  }, [selectedBuilding, linkedLeetCodeUsername]);
+    if (!selectedBuilding) return false;
+    const buildingLogin = selectedBuilding.login.toLowerCase();
+    const matchesAuth = !!authLogin && buildingLogin === authLogin;
+    const matchesLinked = !!linkedLeetCodeUsername && buildingLogin === linkedLeetCodeUsername.toLowerCase();
+    return matchesAuth || matchesLinked;
+  }, [selectedBuilding, authLogin, linkedLeetCodeUsername]);
 
   const myBuilding = useMemo(() => {
     return linkedLeetCodeUsername


### PR DESCRIPTION
## What does this PR do?

Eagerly matches the selected building's owner username (`selectedBuilding.login`) against the GitHub OAuth username (`authLogin`) in addition to the asynchronous `linkedLeetCodeUsername` check. 

This ensures that:
- Even before the async `/api/me` fetch finishes loading `linkedLeetCodeUsername`, the `isOwnBuilding` state is accurately resolved if usernames match.
- Action buttons like Kudos, Gift, and Battle are correctly hidden on the user's own building on initial page load / render, avoiding a "Cannot raid yourself" API error.

## Related issue

Fixes #798

## Screenshots

<!-- Before/after if visual changes -->
| Before | After |
|--------|-------|
| Kudos, Gift, and Battle buttons appeared on user's own building card. | Only "Copy Invite Link", "Loadout", and "Profile" appear on own building card. |

## Checklist

- [x] `npm run lint` passes (Specifically verified on modified files `CityContext.tsx` and `ProfileCard.tsx`)
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
