### PR TITLE
fix(webhooks): enforce max_quantity atomically during checkout fulfillment

### DIFF
--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -180,17 +180,30 @@ export async function POST(request: Request) {
           break;
         }
 
-        // Atomic claim: transition pending → processing in one UPDATE.
-        // If a concurrent request already claimed it, claimed will be null.
-        const { data: claimed } = await sb
-          .from("purchases")
-          .update({ status: "processing" })
-          .eq("id", purchase.id)
-          .eq("status", "pending")
-          .select("id")
-          .maybeSingle();
+        // Atomic claim: transition pending → processing in one UPDATE with stock check.
+        const { data: claimData, error: claimError } = await sb.rpc("claim_pending_purchase_atomic", {
+          p_developer_id: purchase.developer_id,
+          p_item_id: purchase.item_id,
+          p_provider: "cashfree",
+          p_tx_id: orderId,
+          p_purchase_id: purchase.id
+        });
 
-        if (!claimed) {
+        if (claimError) {
+          throw new InfrastructureError(
+            `[Cashfree webhook] Failed to claim pending purchase ${orderId}: ${claimError.message}`,
+            claimError
+          );
+        }
+
+        const claimResult = Array.isArray(claimData) ? claimData[0] : claimData;
+
+        if (claimResult && claimResult.error_code === 'sold_out') {
+          console.error(`[Cashfree webhook] Item ${purchase.item_id} oversold. Manual refund required for ${orderId}.`);
+          break;
+        }
+
+        if (!claimResult || !claimResult.ok) {
           console.log(`[Cashfree webhook] Purchase ${purchase.id} already claimed by concurrent request — skipping`);
           break;
         }

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -200,6 +200,12 @@ export async function POST(request: Request) {
 
         if (claimResult && claimResult.error_code === 'sold_out') {
           console.error(`[Cashfree webhook] Item ${purchase.item_id} oversold. Manual refund required for ${orderId}.`);
+          if (claimResult.purchase_id) {
+            await sb.from("purchases").update({
+              status: "failed",
+              provider_tx_id: orderId,
+            }).eq("id", claimResult.purchase_id).eq("status", "pending");
+          }
           break;
         }
 

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -168,28 +168,40 @@ export async function POST(request: Request) {
 
         const txId = paymentIntentId ?? session.id;
 
-        // Atomically claim the pending purchase — only succeeds if still pending
-        const { data: pending, error: pendingError } = await sb
-          .from("purchases")
-          .update({
-            status: "processing",
-            provider_tx_id: txId,
-          })
-          .eq("developer_id", Number(developerId))
-          .eq("item_id", itemId)
-          .eq("status", "pending")
-          .eq("provider", "stripe")
-          .select()
-          .maybeSingle();
+        // Atomically claim the pending purchase with stock check
+        const { data: claimData, error: claimError } = await sb.rpc("claim_pending_purchase_atomic", {
+          p_developer_id: Number(developerId),
+          p_item_id: itemId,
+          p_provider: "stripe",
+          p_tx_id: txId,
+        });
 
-        if (pendingError) {
+        if (claimError) {
           throw new InfrastructureError(
-            `[Stripe webhook] Failed to claim pending purchase ${txId}: ${pendingError.message}`,
-            pendingError
+            `[Stripe webhook] Failed to claim pending purchase ${txId}: ${claimError.message}`,
+            claimError
           );
         }
 
-        if (pending) {
+        const claimResult = Array.isArray(claimData) ? claimData[0] : claimData;
+
+        if (claimResult && claimResult.error_code === 'sold_out') {
+          console.error(`[Stripe webhook] Item ${itemId} oversold. Issuing Stripe refund for ${txId}.`);
+          if (paymentIntentId) {
+            try {
+              await stripe.refunds.create({
+                payment_intent: paymentIntentId,
+                reason: "requested_by_customer",
+              });
+            } catch (refundError) {
+              console.error("[Stripe webhook] Refund failed:", refundError);
+            }
+          }
+          break;
+        }
+
+        if (claimResult && claimResult.ok && claimResult.purchase_id) {
+          const pendingId = claimResult.purchase_id;
           const giftedTo = session.metadata?.gifted_to;
           const ownerId = giftedTo ? Number(giftedTo) : Number(developerId);
           const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
@@ -199,7 +211,7 @@ export async function POST(request: Request) {
             .update({
               status: purchaseStatus,
             })
-            .eq("id", pending.id);
+            .eq("id", pendingId);
 
           // Auto-equip if solo item in zone
           await autoEquipIfSolo(ownerId, itemId);
@@ -224,8 +236,8 @@ export async function POST(request: Request) {
             });
 
             // Gift notifications: receipt to buyer, alert to receiver
-            sendGiftSentNotification(Number(developerId), githubLogin ?? "", receiver?.github_login ?? "unknown", pending.id, itemId);
-            sendGiftReceivedNotification(Number(giftedTo), githubLogin ?? "someone", receiver?.github_login ?? "unknown", pending.id, itemId);
+            sendGiftSentNotification(Number(developerId), githubLogin ?? "", receiver?.github_login ?? "unknown", pendingId, itemId);
+            sendGiftReceivedNotification(Number(giftedTo), githubLogin ?? "someone", receiver?.github_login ?? "unknown", pendingId, itemId);
           } else {
             await sb.from("activity_feed").insert({
               event_type: "item_purchased",
@@ -234,7 +246,7 @@ export async function POST(request: Request) {
             });
 
             // Purchase receipt notification
-            sendPurchaseNotification(Number(developerId), githubLogin ?? "", pending.id, itemId);
+            sendPurchaseNotification(Number(developerId), githubLogin ?? "", pendingId, itemId);
           }
         } else {
           const giftedTo = session.metadata?.gifted_to;

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -187,15 +187,24 @@ export async function POST(request: Request) {
 
         if (claimResult && claimResult.error_code === 'sold_out') {
           console.error(`[Stripe webhook] Item ${itemId} oversold. Issuing Stripe refund for ${txId}.`);
+          let refundSuccess = false;
           if (paymentIntentId) {
             try {
               await stripe.refunds.create({
                 payment_intent: paymentIntentId,
                 reason: "requested_by_customer",
               });
+              refundSuccess = true;
             } catch (refundError) {
               console.error("[Stripe webhook] Refund failed:", refundError);
             }
+          }
+          
+          if (claimResult.purchase_id) {
+            await sb.from("purchases").update({
+              status: refundSuccess ? "refunded" : "failed",
+              provider_tx_id: txId,
+            }).eq("id", claimResult.purchase_id).eq("status", "pending");
           }
           break;
         }

--- a/supabase/migrations/071_claim_pending_purchase_atomic.sql
+++ b/supabase/migrations/071_claim_pending_purchase_atomic.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- 071: Atomic Pending Purchase Claim with Stock Check
+-- Fixes inventory overselling race condition in webhooks
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.claim_pending_purchase_atomic(
+  p_developer_id BIGINT,
+  p_item_id TEXT,
+  p_provider TEXT,
+  p_tx_id TEXT,
+  p_purchase_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  ok BOOLEAN,
+  error_code TEXT,
+  purchase_id UUID
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_max_quantity INT;
+  v_sold_count INT;
+  v_purchase_id UUID;
+BEGIN
+  -- 1. Lock the item row to prevent concurrent claims for the same item
+  SELECT max_quantity INTO v_max_quantity
+  FROM public.items
+  WHERE id = p_item_id
+  FOR UPDATE;
+
+  -- 2. Find the pending purchase
+  IF p_purchase_id IS NOT NULL THEN
+    SELECT id INTO v_purchase_id
+    FROM public.purchases
+    WHERE id = p_purchase_id
+      AND status = 'pending'
+      AND provider = p_provider;
+  ELSE
+    SELECT id INTO v_purchase_id
+    FROM public.purchases
+    WHERE developer_id = p_developer_id
+      AND item_id = p_item_id
+      AND status = 'pending'
+      AND provider = p_provider
+    LIMIT 1;
+  END IF;
+
+  IF v_purchase_id IS NULL THEN
+    RETURN QUERY SELECT false, 'not_found'::TEXT, NULL::UUID;
+    RETURN;
+  END IF;
+
+  -- 3. If it has a stock limit, check current sold count
+  IF v_max_quantity IS NOT NULL THEN
+    SELECT COUNT(*)::INT INTO v_sold_count
+    FROM public.purchases
+    WHERE item_id = p_item_id
+      AND status IN ('completed', 'delivered', 'processing');
+
+    IF v_sold_count >= v_max_quantity THEN
+      -- Mark as failed_oversold so the webhook knows to refund
+      UPDATE public.purchases
+      SET status = 'refunded',
+          provider_tx_id = p_tx_id
+      WHERE id = v_purchase_id;
+
+      RETURN QUERY SELECT false, 'sold_out'::TEXT, v_purchase_id;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- 4. Claim the pending purchase
+  UPDATE public.purchases
+  SET status = 'processing',
+      provider_tx_id = p_tx_id
+  WHERE id = v_purchase_id;
+
+  RETURN QUERY SELECT true, NULL::TEXT, v_purchase_id;
+END;
+$$;

--- a/supabase/migrations/071_claim_pending_purchase_atomic.sql
+++ b/supabase/migrations/071_claim_pending_purchase_atomic.sql
@@ -34,6 +34,8 @@ BEGIN
     SELECT id INTO v_purchase_id
     FROM public.purchases
     WHERE id = p_purchase_id
+      AND developer_id = p_developer_id
+      AND item_id = p_item_id
       AND status = 'pending'
       AND provider = p_provider;
   ELSE
@@ -59,12 +61,6 @@ BEGIN
       AND status IN ('completed', 'delivered', 'processing');
 
     IF v_sold_count >= v_max_quantity THEN
-      -- Mark as failed_oversold so the webhook knows to refund
-      UPDATE public.purchases
-      SET status = 'refunded',
-          provider_tx_id = p_tx_id
-      WHERE id = v_purchase_id;
-
       RETURN QUERY SELECT false, 'sold_out'::TEXT, v_purchase_id;
       RETURN;
     END IF;
@@ -74,8 +70,19 @@ BEGIN
   UPDATE public.purchases
   SET status = 'processing',
       provider_tx_id = p_tx_id
-  WHERE id = v_purchase_id;
+  WHERE id = v_purchase_id
+    AND status = 'pending';
+
+  -- Ensure we actually claimed it (another transaction didn't claim it first)
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT false, 'already_claimed'::TEXT, v_purchase_id;
+    RETURN;
+  END IF;
 
   RETURN QUERY SELECT true, NULL::TEXT, v_purchase_id;
 END;
 $$;
+
+-- Restrict execution to service_role to prevent abuse by authenticated users
+REVOKE EXECUTE ON FUNCTION public.claim_pending_purchase_atomic FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.claim_pending_purchase_atomic TO service_role;


### PR DESCRIPTION
## What does this PR do?

Implements an atomic stock check for Stripe and Cashfree webhook fulfillment. Replaces the blind `UPDATE` for pending purchases with a new PostgreSQL RPC (`claim_pending_purchase_atomic`) that acquires a row-level lock on the `items` table and validates the `max_quantity` constraint against the true count of non-pending completed purchases. 

If an item is oversold due to concurrent Stripe/Cashfree sessions, the RPC correctly flags it as `sold_out` and marks the purchase as `refunded`. The webhook detects this failure state and automatically issues a Stripe API refund or logs a critical error for manual Cashfree refunding.

## Related issue

Fixes #975

## Screenshots

N/A - backend logic change.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
