### PR TITLE
fix(stripe): remove insecure fallback insertion from webhook

### DIFF
--- a/src/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { POST } from "../route";
 
 const mockGetSupabaseAdmin = vi.fn();
 const mockGetStripe = vi.fn();
+const mockStripeRefundsCreate = vi.fn();
 const mockFulfillItemPurchase = vi.fn();
 const mockAutoEquipIfSolo = vi.fn();
 const mockSendPurchaseNotification = vi.fn();
@@ -120,6 +121,7 @@ function makeRequest(body: string) {
 describe("Stripe webhook route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStripeRefundsCreate.mockResolvedValue({});
   });
 
   it("skips duplicate Stripe events before processing", async () => {
@@ -128,6 +130,7 @@ describe("Stripe webhook route", () => {
       from: (table: string) => createMockQuery(table, { callLog, stripeProcessedEventExists: true, processedEventInsertCount: { count: 0 } }),
     });
     mockGetStripe.mockReturnValue({
+      refunds: { create: (...args: unknown[]) => mockStripeRefundsCreate(...args) },
       webhooks: {
         constructEvent: vi.fn(() => ({ type: "checkout.session.expired", data: { object: { metadata: { type: "sky_ad" }, id: "sess_123" } } })),
       },
@@ -152,6 +155,7 @@ describe("Stripe webhook route", () => {
     });
     mockFulfillItemPurchase.mockRejectedValueOnce(new InfrastructureError("DB timeout", { code: "PGRST_TIMEOUT" }));
     mockGetStripe.mockReturnValue({
+      refunds: { create: (...args: unknown[]) => mockStripeRefundsCreate(...args) },
       webhooks: {
         constructEvent: vi.fn(() => ({
           type: "checkout.session.completed",
@@ -185,6 +189,7 @@ describe("Stripe webhook route", () => {
     });
     mockFulfillItemPurchase.mockRejectedValueOnce(new BusinessLogicError("Item already owned"));
     mockGetStripe.mockReturnValue({
+      refunds: { create: (...args: unknown[]) => mockStripeRefundsCreate(...args) },
       webhooks: {
         constructEvent: vi.fn(() => ({
           type: "checkout.session.completed",
@@ -203,5 +208,88 @@ describe("Stripe webhook route", () => {
     const response = await POST(makeRequest(JSON.stringify({} as unknown)));
     expect(response.status).toBe(200);
     expect(processedEventInsertCount.count).toBe(1);
+  });
+
+  it("issues a refund when no pending purchase is found", async () => {
+    const callLog: string[] = [];
+    const processedEventInsertCount = { count: 0 };
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: (table: string) => createMockQuery(table, {
+        callLog,
+        stripeProcessedEventExists: false,
+        enablePendingPurchase: false,
+        processedEventInsertCount,
+      }),
+    });
+    mockGetStripe.mockReturnValue({
+      refunds: { create: (...args: unknown[]) => mockStripeRefundsCreate(...args) },
+      webhooks: {
+        constructEvent: vi.fn(() => ({
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              metadata: { developer_id: "1", item_id: "consumable" },
+              payment_intent: "pi_missing_purchase",
+              amount_total: 100,
+              currency: "usd",
+            },
+          },
+        })),
+      },
+    });
+
+    const response = await POST(makeRequest(JSON.stringify({} as unknown)));
+    expect(response.status).toBe(200);
+    expect(mockStripeRefundsCreate).toHaveBeenCalledWith({
+      payment_intent: "pi_missing_purchase",
+      reason: "requested_by_customer",
+    });
+  });
+
+  it("does not issue a refund when a processed purchase exists for the same txId", async () => {
+    const callLog: string[] = [];
+    const processedEventInsertCount = { count: 0 };
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: (table: string) => {
+        const query = createMockQuery(table, {
+          callLog,
+          stripeProcessedEventExists: false,
+          enablePendingPurchase: false,
+          processedEventInsertCount,
+        });
+        if (table === "purchases") {
+          const originalMaybeSingle = query.maybeSingle;
+          query.maybeSingle = async () => {
+            const res = await originalMaybeSingle.call(query);
+            if (callLog[callLog.length - 1].includes("provider_tx_id") && callLog[callLog.length - 1].includes("completed")) {
+              return { data: { id: "purchase_already_processed", status: "completed" }, error: null };
+            }
+            return res;
+          };
+        }
+        return query;
+      }
+    });
+    
+    mockGetStripe.mockReturnValue({
+      refunds: { create: (...args: unknown[]) => mockStripeRefundsCreate(...args) },
+      webhooks: {
+        constructEvent: vi.fn(() => ({
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              metadata: { developer_id: "1", item_id: "consumable" },
+              payment_intent: "pi_already_processed",
+              amount_total: 100,
+              currency: "usd",
+            },
+          },
+        })),
+      },
+    });
+
+    const response = await POST(makeRequest(JSON.stringify({} as unknown)));
+    expect(response.status).toBe(200);
+    expect(mockStripeRefundsCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -237,77 +237,16 @@ export async function POST(request: Request) {
             sendPurchaseNotification(Number(developerId), githubLogin ?? "", pending.id, itemId);
           }
         } else {
-          const giftedTo = session.metadata?.gifted_to;
-          const ownerId = giftedTo ? Number(giftedTo) : Number(developerId);
-
-          // Verify amount and currency match the item's expected price
-          const expectedItem = await sb
-            .from("items")
-            .select("price_usd_cents, price_brl_cents")
-            .eq("id", itemId)
-            .single();
-          if (expectedItem.data) {
-            const expectedCents = session.currency === "brl"
-              ? expectedItem.data.price_brl_cents
-              : expectedItem.data.price_usd_cents;
-            if (Number(session.amount_total) !== expectedCents) {
-              console.error(
-                `Price mismatch for item ${itemId}: expected ${expectedCents} ${session.currency}, ` +
-                `got ${session.amount_total}`
-              );
-              break;
+          console.error(`[Stripe webhook] Pending purchase not found for session ${session.id}. Cannot safely fulfill item ${itemId}. Issuing refund.`);
+          if (paymentIntentId) {
+            try {
+              await stripe.refunds.create({
+                payment_intent: paymentIntentId,
+                reason: "requested_by_customer",
+              });
+            } catch (refundError) {
+              console.error("[Stripe webhook] Refund failed for missing purchase:", refundError);
             }
-          }
-
-          // Check if this txId already has a completed/delivered purchase
-          const { data: alreadyProcessed, error: alreadyProcessedError } = await sb
-            .from("purchases")
-            .select("id, status")
-            .eq("provider_tx_id", txId)
-            .in("status", ["completed", "delivered"])
-            .maybeSingle();
-          if (alreadyProcessedError) {
-            throw new InfrastructureError(
-              `[Stripe webhook] failed to validate processed tx ${txId}: ${alreadyProcessedError.message}`,
-              alreadyProcessedError
-            );
-          }
-          if (alreadyProcessed) {
-            console.log(`Purchase ${alreadyProcessed.id} already fulfilled — skipping duplicate webhook`);
-            break;
-          }
-
-          // Use the UNIQUE constraint on provider_tx_id to guard against
-          // concurrent insert — only the first webhook wins
-          const { data: inserted, error: insertError } = await sb
-            .from("purchases")
-            .insert({
-              developer_id: Number(developerId),
-              item_id: itemId,
-              provider: "stripe",
-              provider_tx_id: txId,
-              idempotency_key: idempotencyKey ?? null,
-              amount_cents: session.amount_total ?? 0,
-              currency: session.currency ?? "usd",
-              status: "processing",
-              ...(giftedTo ? { gifted_to: Number(giftedTo) } : {}),
-            })
-            .select("id")
-            .maybeSingle();
-          if (insertError && insertError.code !== "23505") {
-            throw new InfrastructureError(
-              `[Stripe webhook] Failed to insert purchase for tx ${txId}: ${insertError.message}`,
-              insertError
-            );
-          }
-
-          if (inserted) {
-            const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
-            await sb
-              .from("purchases")
-              .update({ status: purchaseStatus })
-              .eq("id", inserted.id);
-            await autoEquipIfSolo(ownerId, itemId);
           }
         }
         break;

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -237,6 +237,26 @@ export async function POST(request: Request) {
             sendPurchaseNotification(Number(developerId), githubLogin ?? "", pending.id, itemId);
           }
         } else {
+          // Check if this txId already has a completed/delivered/processing purchase
+          const { data: alreadyProcessed, error: alreadyProcessedError } = await sb
+            .from("purchases")
+            .select("id, status")
+            .eq("provider_tx_id", txId)
+            .in("status", ["completed", "delivered", "processing"])
+            .maybeSingle();
+
+          if (alreadyProcessedError) {
+            throw new InfrastructureError(
+              `[Stripe webhook] failed to validate processed tx ${txId}: ${alreadyProcessedError.message}`,
+              alreadyProcessedError
+            );
+          }
+
+          if (alreadyProcessed) {
+            console.log(`[Stripe webhook] Purchase ${alreadyProcessed.id} already fulfilled — skipping duplicate webhook`);
+            break;
+          }
+
           console.error(`[Stripe webhook] Pending purchase not found for session ${session.id}. Cannot safely fulfill item ${itemId}. Issuing refund.`);
           if (paymentIntentId) {
             try {


### PR DESCRIPTION
## What does this PR do?

Removes the insecure fallback insertion logic from the Stripe webhook to strictly enforce checkout business constraints. Previously, if a webhook arrived but the `pending` purchase could not be found, the system would forcibly grant the item based solely on a price check. 

This bypassed crucial `api/checkout/route.ts` safeguards, allowing attackers with old checkout session links to bypass scarcity (`max_quantity`), temporal limits (`available_until`), and item active status checks. The webhook now requires a valid pending purchase; missing or expired checkouts are caught and automatically refunded via the Stripe API.

## Related issue

Fixes #976

## Screenshots

N/A - security logic change.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
