### PR TITLE
fix(nowpayments): accurately update purchase status on refund or failure

### DIFF
--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -178,10 +178,11 @@ export async function POST(request: Request) {
       case "failed":
       case "refunded": {
         const newStatus = paymentStatus === "refunded" ? "refunded" : "expired";
+        const txIds = [orderId, paymentId].filter(Boolean) as string[];
         await sb
           .from("purchases")
           .update({ status: newStatus })
-          .eq("provider_tx_id", orderId)
+          .in("provider_tx_id", txIds)
           .in("status", ["pending", "completed", "delivered", "processing"])
           .eq("provider", "nowpayments");
         break;

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -182,7 +182,7 @@ export async function POST(request: Request) {
           .from("purchases")
           .update({ status: newStatus })
           .eq("provider_tx_id", orderId)
-          .eq("status", "pending")
+          .in("status", ["pending", "completed", "delivered", "processing"])
           .eq("provider", "nowpayments");
         break;
       }


### PR DESCRIPTION
## What does this PR do?

Expands the NOWPayments webhook query constraints to properly track refund/failed events. The previous implementation explicitly caught `refunded` and `failed` events but erroneously used an `.eq("status", "pending")` check when updating the database. 

Since successful purchases had already been transitioned to `completed` or `delivered` during checkout fulfillment, this caused the webhook to ignore the refund event. Users kept the in-game items while receiving a full refund. This fixes the constraint to allow status transitions from `completed`, `delivered`, and `processing` back to `refunded`/`expired`.

## Related issue

Fixes #977

## Screenshots

N/A - backend logic change.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
