### PR TITLE
Security: Add CRON_SECRET auth + server-side developer count to milestone-celebration (Fixes #982)

### DIFF
--- a/src/app/api/milestone-celebration/route.ts
+++ b/src/app/api/milestone-celebration/route.ts
@@ -1,28 +1,41 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { sendCommunityMilestoneNotifications } from "@/lib/notification-senders/community-milestone";
+import crypto from "crypto";
 
-// Milestones to celebrate (every 5k after 10k)
 const MILESTONES = [10000, 15000, 20000, 25000, 30000, 40000, 50000, 75000, 100000];
 
-/**
- * @param {import('next/server').NextRequest} req
- */
-export async function POST(req: Request) {
-  const { total_developers } = await req.json().catch(() => ({ total_developers: 0 }));
-  if (!total_developers || typeof total_developers !== "number") {
-    return NextResponse.json({ error: "missing total_developers" }, { status: 400 });
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
   }
 
-  // Find the highest milestone that's been crossed
-  const milestone = [...MILESTONES].reverse().find((m) => total_developers >= m);
-  if (!milestone) {
-    return NextResponse.json({ celebrated: false });
+  const auth = request.headers.get("authorization") ?? "";
+  const expected = `Bearer ${secret}`;
+
+  if (auth.length !== expected.length || !timingSafeEqual(auth, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const sb = getSupabaseAdmin();
 
-  // Idempotent: only insert if this milestone hasn't been recorded yet
+  const { count } = await sb
+    .from("developers")
+    .select("id", { count: "exact", head: true });
+
+  const totalDevelopers = count ?? 0;
+
+  const milestone = [...MILESTONES].reverse().find((m) => totalDevelopers >= m);
+  if (!milestone) {
+    return NextResponse.json({ celebrated: false });
+  }
+
   const { data, error } = await sb
     .from("milestone_celebrations")
     .upsert({ milestone, reached_at: new Date().toISOString() }, { onConflict: "milestone", ignoreDuplicates: true })
@@ -33,7 +46,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  // Send community milestone notifications (fire-and-forget, batch of 50)
   sendCommunityMilestoneNotifications(milestone).catch((err) => {
     console.error("[milestone] Notification send error:", err);
   });
@@ -41,7 +53,6 @@ export async function POST(req: Request) {
   return NextResponse.json({ celebrated: true, milestone, reached_at: data?.reached_at });
 }
 
-// GET: return all celebrated milestones
 export async function GET() {
   const sb = getSupabaseAdmin();
   const { data } = await sb


### PR DESCRIPTION
## What does this PR do?

Adds a `CRON_SECRET` authentication guard to `POST /api/milestone-celebration` and derives `total_developers` server-side from the database instead of trusting the request body. Previously any anonymous client could fabricate milestone records and trigger community-wide notification blasts.

## Related issue

Fixes #982

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes are self-reviewed and tested
- [x] No new warnings or errors introduced
- [x] Security considerations addressed (auth + server-side validation)