### PR TITLE
🐛 fix: add Bank vault depth and column capitals

### DIFF
--- a/src/components/BankBuilding.tsx
+++ b/src/components/BankBuilding.tsx
@@ -45,6 +45,13 @@ function roundedSquare(size: number, r: number): THREE.Shape {
   return s;
 }
 
+/** Circular vault door profile, extruded along the facade for visible depth. */
+function vaultDoorShape(radius: number): THREE.Shape {
+  const shape = new THREE.Shape();
+  shape.absarc(0, 0, radius, 0, Math.PI * 2, false);
+  return shape;
+}
+
 interface BankBuildingProps {
   onClick?: () => void;
   themeAccent?: string;
@@ -98,6 +105,18 @@ export default function BankBuilding({
     return g;
   }, []);
 
+  const vaultDoorGeo = useMemo(() => {
+    const g = new THREE.ExtrudeGeometry(vaultDoorShape(78), {
+      depth: 24,
+      bevelEnabled: true,
+      bevelThickness: 5,
+      bevelSize: 4,
+      bevelSegments: 3,
+    });
+    g.center();
+    return g;
+  }, []);
+
   const markMat = useMemo(
     () =>
       new THREE.MeshStandardMaterial({
@@ -131,6 +150,19 @@ export default function BankBuilding({
         transparent: true,
         opacity: 0.5,
         side: THREE.DoubleSide,
+        toneMapped: false,
+      }),
+    [],
+  );
+
+  const vaultDoorMat = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: LIME,
+        emissive: LIME,
+        emissiveIntensity: 0.8,
+        roughness: 0.3,
+        metalness: 0.7,
         toneMapped: false,
       }),
     [],
@@ -268,6 +300,35 @@ export default function BankBuilding({
           </mesh>
         )),
       )}
+
+      {/* Front entrance columns and capitals */}
+      {[-1, 1].map((sz) => (
+        <group key={`entry-column${sz}`} position={[D / 2 + 18, BASE_H + 92, sz * 104]}>
+          <mesh castShadow>
+            <cylinderGeometry args={[17, 21, 184, 8]} />
+            <meshStandardMaterial color={LIME} emissive={LIME} emissiveIntensity={0.7} roughness={0.3} metalness={0.5} toneMapped={false} />
+          </mesh>
+          <mesh position={[0, 98, 0]} castShadow>
+            <boxGeometry args={[52, 12, 52]} />
+            <meshStandardMaterial color={LIME_HOT} emissive={LIME_HOT} emissiveIntensity={0.8} roughness={0.3} metalness={0.5} toneMapped={false} />
+          </mesh>
+          <mesh position={[0, 108, 0]} castShadow>
+            <boxGeometry args={[42, 8, 42]} />
+            <meshStandardMaterial color={LIME} emissive={LIME} emissiveIntensity={0.8} roughness={0.3} metalness={0.5} toneMapped={false} />
+          </mesh>
+        </group>
+      ))}
+
+      {/* Deep front vault door with a raised rim and central hub */}
+      <mesh geometry={vaultDoorGeo} material={vaultDoorMat} position={[D / 2 + 18, BASE_H + 154, 0]} rotation={[0, Math.PI / 2, 0]} castShadow />
+      <mesh position={[D / 2 + 34, BASE_H + 154, 0]} rotation={[0, Math.PI / 2, 0]}>
+        <torusGeometry args={[58, 5, 8, 32]} />
+        <meshStandardMaterial color={LIME_HOT} emissive={LIME_HOT} emissiveIntensity={0.9} roughness={0.25} metalness={0.6} toneMapped={false} />
+      </mesh>
+      <mesh position={[D / 2 + 39, BASE_H + 154, 0]} rotation={[0, Math.PI / 2, 0]}>
+        <cylinderGeometry args={[13, 13, 8, 12]} />
+        <meshStandardMaterial color={WHITE} emissive={LIME_HOT} emissiveIntensity={0.5} roughness={0.25} metalness={0.65} toneMapped={false} />
+      </mesh>
 
       {/* Cornice + dark roof slab */}
       <mesh position={[0, CORNICE_Y, 0]} castShadow>


### PR DESCRIPTION
## What does this PR do?
Adds the missing Bank landmark details requested in #940: a shallow extruded and beveled vault door with a raised rim and hub, plus two front entrance columns with layered capitals. The change stays inside src/components/BankBuilding.tsx and preserves the existing materials, scale, and click handling.

## Related issue
Fixes #940

## Checklist
- [x] This PR addresses one scoped issue.
- [x] The change follows the existing React Three Fiber and Three.js patterns.
- [x] No unrelated files or generated assets were changed.
- [x] Visual proof is described below.

## Validation
- npx tsc --noEmit passed.
- git diff --check passed.
- npx eslint src/components/BankBuilding.tsx reports only pre-existing errors on lines 258-259 and existing unused prop warnings.
- npm run lint remains blocked by 291 pre-existing repository errors.
- npm run build reaches the existing Supabase-env prerender failure at /api/dailies/leaderboard.

## Visual proof
The changed component now renders an extruded vault door, front-facing rim and hub, and two layered entrance capitals in the Bank scene.