### PR TITLE
fix: apply missing 150 Z-axis offset to plaza positions

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -777,7 +777,7 @@ export function generateCityLayout(devs: DeveloperRecord[]): {
     // Plaza at center of the district [0, 0] relative
     if (addPlaza) {
       const px = origin[0];
-      const pcz = origin[2];
+      const pcz = origin[2]+150;
       plazas.push({
         position: [px, 0, pcz],
         size: Math.min(BLOCK_FOOTPRINT_X, BLOCK_FOOTPRINT_Z) * 0.8,


### PR DESCRIPTION
## What does this PR do?
Applies the missing 150-unit Z-axis layout offset to the district plaza positions in the city generator function, fixing the Vitest assertion errors.

## Related issue
Fixes #1010

## Screenshots
N/A (Logic/Backend fix)

## Checklist
- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**