### PR TITLE
fix: consolidate and align getTodaySeed to UTC to fix client-server leaderboard mismatch (#989)

### DIFF
--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -4,14 +4,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
 import { trackDailyMission } from "@/lib/dailies";
 import { buildFlyLeaderboard, type FlyScoreRow } from "@/lib/fly-leaderboard";
-
-function getTodaySeed() {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 0);
-  const diff = now.getTime() - start.getTime();
-  const dayOfYear = Math.floor(diff / 86400000);
-  return `${now.getFullYear()}-${dayOfYear}`;
-}
+import { getTodaySeed } from "@/lib/fly-seed";
 
 function maxScoreForCollected(collected: number): number {
   if (collected <= 0) return 0;

--- a/src/components/FlyLeaderboard.tsx
+++ b/src/components/FlyLeaderboard.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLeaderboardAuth } from "@/components/LeaderboardYouBadge";
 import Skeleton from "@/components/Skeleton";
+import { getTodaySeed, seedToDate, getSeedForDate } from "@/lib/fly-seed";
 
 const ACCENT = "#ffa116";
 const FIRST_SEED = "2026-1";
@@ -30,24 +31,10 @@ export interface FlyHistory {
 
 // ── Seed utilities ─────────────────────────────────────────────────────
 
-function getTodaySeed(): string {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 0);
-  const diff = now.getTime() - start.getTime();
-  const dayOfYear = Math.floor(diff / 86400000);
-  return `${now.getFullYear()}-${dayOfYear}`;
-}
-
-function seedToDate(seed: string): Date {
-  const [year, day] = seed.split("-").map(Number);
-  const d = new Date(year, 0);
-  d.setDate(day);
-  return d;
-}
-
 function formatSeedDate(seed: string): string {
   return seedToDate(seed)
     .toLocaleDateString("en-US", {
+      timeZone: "UTC",
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -58,11 +45,8 @@ function formatSeedDate(seed: string): string {
 function prevSeed(seed: string): string | null {
   if (seed === FIRST_SEED) return null;
   const d = seedToDate(seed);
-  d.setDate(d.getDate() - 1);
-  const start = new Date(d.getFullYear(), 0, 0);
-  const diff = d.getTime() - start.getTime();
-  const dayOfYear = Math.floor(diff / 86400000);
-  const result = `${d.getFullYear()}-${dayOfYear}`;
+  d.setUTCDate(d.getUTCDate() - 1);
+  const result = getSeedForDate(d);
   if (seedToDate(result) < seedToDate(FIRST_SEED)) return null;
   return result;
 }
@@ -71,11 +55,8 @@ function nextSeed(seed: string): string | null {
   const today = getTodaySeed();
   if (seed === today) return null;
   const d = seedToDate(seed);
-  d.setDate(d.getDate() + 1);
-  const start = new Date(d.getFullYear(), 0, 0);
-  const diff = d.getTime() - start.getTime();
-  const dayOfYear = Math.floor(diff / 86400000);
-  const result = `${d.getFullYear()}-${dayOfYear}`;
+  d.setUTCDate(d.getUTCDate() + 1);
+  const result = getSeedForDate(d);
   if (seedToDate(result) > seedToDate(today)) return null;
   return result;
 }

--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/lib/himetrica";
 import { applyLocalStorageOverrides } from "@/lib/cityOverrides";
 import { getCityCache, setCityCache, clearCityCache } from "@/lib/cityCache";
+import { getTodaySeed, seedToDate, getSeedForDate } from "@/lib/fly-seed";
 
 export type CityDeveloperRecord = DeveloperRecord & {
   loadout?: unknown;
@@ -823,10 +824,7 @@ export function CityProvider({ children }: { children: ReactNode }) {
 
       if (finalScore > 0) {
         try {
-          const now = new Date();
-          const start = new Date(now.getFullYear(), 0, 0);
-          const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000);
-          const currentSeed = `${now.getFullYear()}-${dayOfYear}`;
+          const currentSeed = getTodaySeed();
           const raw = localStorage.getItem("leetcodecity_fly_history");
           const hist = raw
             ? JSON.parse(raw)
@@ -837,8 +835,9 @@ export function CityProvider({ children }: { children: ReactNode }) {
             playCount: (prev?.playCount ?? 0) + 1,
           };
           if (hist.lastPlayedSeed !== currentSeed) {
-            const yesterdayDay = dayOfYear - 1;
-            const yesterdaySeed = yesterdayDay >= 1 ? `${now.getFullYear()}-${yesterdayDay}` : `${now.getFullYear() - 1}-365`;
+            const curDate = seedToDate(currentSeed);
+            curDate.setUTCDate(curDate.getUTCDate() - 1);
+            const yesterdaySeed = getSeedForDate(curDate);
             if (hist.lastPlayedSeed === yesterdaySeed) {
               hist.currentStreak = (hist.currentStreak || 0) + 1;
             } else {
@@ -1636,10 +1635,7 @@ export function CityProvider({ children }: { children: ReactNode }) {
         if (!raw) return;
         const hist = JSON.parse(raw);
         if (!hist.seeds || Object.keys(hist.seeds).length === 0) return;
-        const now = new Date();
-        const start = new Date(now.getFullYear(), 0, 0);
-        const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000);
-        const currentSeed = `${now.getFullYear()}-${dayOfYear}`;
+        const currentSeed = getTodaySeed();
         if (hist.seeds[currentSeed]) return;
         setShowDailyNudge(true);
         const autoDismiss = setTimeout(() => setShowDailyNudge(false), 15000);

--- a/src/lib/__tests__/fly-seed.test.ts
+++ b/src/lib/__tests__/fly-seed.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getTodaySeed, getSeedForDate, seedToDate } from "../fly-seed";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function mockUtcDate(isoString: string) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(isoString));
+}
+
+describe("fly-seed utilities", () => {
+  describe("getSeedForDate & getTodaySeed", () => {
+    it("returns correct seed format on a standard day", () => {
+      mockUtcDate("2026-07-22T11:00:00.000Z");
+      const seed = getTodaySeed();
+      // July 22 is the 203rd day of 2026 (non-leap year: 31+28+31+30+31+30+22 = 203)
+      expect(seed).toBe("2026-203");
+    });
+
+    it("returns correct seed on Jan 1st", () => {
+      mockUtcDate("2026-01-01T00:00:00.001Z");
+      expect(getTodaySeed()).toBe("2026-1");
+    });
+
+    it("returns correct seed on Dec 31st of non-leap year", () => {
+      mockUtcDate("2025-12-31T23:59:59.999Z");
+      expect(getTodaySeed()).toBe("2025-365");
+    });
+
+    it("returns correct seed on Dec 31st of leap year", () => {
+      mockUtcDate("2024-12-31T23:59:59.999Z");
+      expect(getTodaySeed()).toBe("2024-366");
+    });
+
+    it("is timezone-independent using UTC time", () => {
+      // 23:30 UTC on June 4 -> should calculate seed based on UTC date June 4 (day 155),
+      // even if local timezone is ahead (e.g. UTC+9 making it June 5 locally)
+      const date = new Date("2025-06-04T23:30:00.000Z");
+      const seed = getSeedForDate(date);
+      expect(seed).toBe("2025-155");
+    });
+  });
+
+  describe("seedToDate", () => {
+    it("converts Jan 1st seed to UTC Date object", () => {
+      const date = seedToDate("2026-1");
+      expect(date.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("converts mid-year seed to correct UTC Date object", () => {
+      const date = seedToDate("2026-203");
+      expect(date.toISOString()).toBe("2026-07-22T00:00:00.000Z");
+    });
+
+    it("converts Dec 31st seed of leap year to correct UTC Date", () => {
+      const date = seedToDate("2024-366");
+      expect(date.toISOString()).toBe("2024-12-31T00:00:00.000Z");
+    });
+  });
+});

--- a/src/lib/fly-seed.ts
+++ b/src/lib/fly-seed.ts
@@ -1,0 +1,28 @@
+/**
+ * Calculates a timezone-agnostic seed based on UTC date.
+ * Formatted as `${year}-${dayOfYear}` (e.g. "2026-203").
+ */
+export function getSeedForDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const start = new Date(Date.UTC(year, 0, 0));
+  const diff = date.getTime() - start.getTime();
+  const dayOfYear = Math.floor(diff / 86400000);
+  return `${year}-${dayOfYear}`;
+}
+
+/**
+ * Returns the seed for the current UTC date.
+ */
+export function getTodaySeed(): string {
+  return getSeedForDate(new Date());
+}
+
+/**
+ * Parses a UTC seed back into a UTC Date object representing 00:00:00 UTC of that day.
+ */
+export function seedToDate(seed: string): Date {
+  const [year, day] = seed.split("-").map(Number);
+  const d = new Date(Date.UTC(year, 0, 1));
+  d.setUTCDate(day);
+  return d;
+}


### PR DESCRIPTION
## What does this PR do?

Consolidates the duplicated daily seed generation logic (`getTodaySeed()`) into a single, timezone-agnostic helper `src/lib/fly-seed.ts`. 

Previously, `src/app/api/fly-scores/route.ts`, `src/components/FlyLeaderboard.tsx`, and `src/context/CityContext.tsx` calculated the seed string (representing the current day) using local time. Around midnight, the server (running in UTC) and the client (running in the local browser timezone) would calculate different seeds, causing new leaderboard submissions to disappear or show inconsistencies.

Changes in this PR:
- Created a shared helper `src/lib/fly-seed.ts` providing UTC-based seed calculation routines (`getSeedForDate`, `getTodaySeed`, `seedToDate`).
- Replaced the duplicate local implementations in the API route, leaderboard component, and `CityContext` to use the unified helper.
- Configured date formatting in `FlyLeaderboard` with `{ timeZone: 'UTC' }` to display local dates correctly according to the UTC seed values rather than local wall-clock time.
- Added comprehensive unit tests in `src/lib/__tests__/fly-seed.test.ts` verifying UTC alignment, year roll-overs, and leap-year compliance.

## Related issue

Fixes #989

## Screenshots

N/A (Behavioral and date alignment fix; no structural UI changes were made).

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
