### PR TITLE
feat: add building search with autocomplete on the city page-#993

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  if (!q || q.length < 2) {
+    return NextResponse.json([]);
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("developers")
+    .select("github_login, easy_solved, medium_solved, hard_solved, lc_global_rank")
+    .ilike("github_login", `%${q}%`)
+    .limit(8);
+
+  if (error) {
+    console.error("Search API error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data ?? [], {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/components/hud/SearchBar.tsx
+++ b/src/components/hud/SearchBar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/set-state-in-effect, @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Skeleton from "@/components/Skeleton";
 import { useCity } from "@/context/CityContext";
 import { generateCityLayout } from "@/lib/github";
@@ -229,8 +229,65 @@ export default function SearchBar() {
     exploreMode,
   } = useCity();
 
-  const searchUser = async () => {
-    const trimmed = username.trim().toLowerCase();
+  const [results, setResults] = useState<any[]>([]);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const trimmed = username.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(trimmed)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setResults(data);
+          setOpen(true);
+          setActiveIdx(-1);
+        }
+      } catch (err) {
+        console.error("Autocomplete fetch error:", err);
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [username]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter" && activeIdx >= 0) {
+      e.preventDefault();
+      const selected = results[activeIdx].github_login;
+      setUsername(selected);
+      setOpen(false);
+      searchUser(selected);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const searchUser = async (overrideUsername?: string) => {
+    const target = overrideUsername ?? username;
+    const trimmed = target.trim().toLowerCase();
     if (!trimmed) return;
 
     // Track search event dynamically
@@ -390,7 +447,7 @@ export default function SearchBar() {
   if (!exploreMode || compareBuilding || comparePair) return null;
 
   return (
-    <div className="pointer-events-auto absolute top-3 left-32 right-3 z-[31] sm:left-36 sm:right-auto sm:top-4 sm:w-72">
+    <div ref={containerRef} className="pointer-events-auto absolute top-3 left-32 right-3 z-[31] sm:left-36 sm:right-auto sm:top-4 sm:w-72">
       <form id="search-bar-form" onSubmit={handleSubmit} className="flex items-center gap-2">
         <input
           type="text"
@@ -399,6 +456,7 @@ export default function SearchBar() {
             setUsername(e.target.value);
             if (feedback?.type === "error") setFeedback(null);
           }}
+          onKeyDown={handleKeyDown}
           aria-label="Search a LeetCode username and fly to their building"
           placeholder="search a username"
           className="min-w-0 flex-1 border-[3px] border-border bg-bg/70 px-3 py-1.5 text-base text-cream outline-none backdrop-blur-sm transition-colors placeholder:text-dim normal-case sm:text-[11px]"
@@ -414,6 +472,34 @@ export default function SearchBar() {
           {loading ? <span className="blink-dot inline-block">_</span> : "Go"}
         </button>
       </form>
+      {open && results.length > 0 && (
+        <div className="absolute left-0 right-0 mt-1 max-h-60 overflow-y-auto border-[3px] border-border bg-bg/95 backdrop-blur-md shadow-lg z-[32]">
+          {results.map((dev, idx) => {
+            const totalSolved = (dev.easy_solved ?? 0) + (dev.medium_solved ?? 0) + (dev.hard_solved ?? 0);
+            return (
+              <div
+                key={dev.github_login}
+                onClick={() => {
+                  setUsername(dev.github_login);
+                  setOpen(false);
+                  searchUser(dev.github_login);
+                }}
+                className={`flex items-center justify-between px-3 py-2 cursor-pointer text-xs transition-colors font-pixel uppercase ${
+                  idx === activeIdx
+                    ? "bg-white/10 text-white"
+                    : "text-cream/90 hover:bg-white/5 hover:text-white"
+                }`}
+                style={{
+                  borderLeft: idx === activeIdx ? `3px solid ${theme.accent}` : "3px solid transparent",
+                }}
+              >
+                <span>{dev.github_login}</span>
+                <span className="text-[10px] text-muted normal-case">{totalSolved} solved</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
       {feedback && (
         <div className="mt-1.5">
           <SearchFeedback


### PR DESCRIPTION
## What does this PR do?

Introduces autocomplete search capability for existing developer buildings on the city page:
- **Backend Route**: Added `GET /api/search?q=<query>` endpoint querying Supabase `developers` table for matching `github_login` values. Returns matching developers with their solved question counts.
- **Frontend Autocomplete**: Enhanced [SearchBar.tsx](file:///d:/GSSoC/Ixotic27/The-Leetcode-City/src/components/hud/SearchBar.tsx) with a debounced autocomplete dropdown, supporting full keyboard navigation (`ArrowUp`, `ArrowDown`, `Enter`, `Escape`) and a mouse click-outside dismiss handler. Selecting a user automatically triggers fly-to focus on the corresponding building.

## Related issue

Fixes #993

## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
