### PR TITLE
feat: implement dynamic Cyberpunk Neon Grid shader overlay (#220)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,6 +65,7 @@ function HomeContent() {
     endFly,
     themeIndex,
     dayNightCycleActive,
+    neonGridActive,
     weatherMode,
     setHud,
     setPlayerPos,
@@ -175,6 +176,7 @@ function HomeContent() {
         themeIndex={themeIndex}
         dayNightCycleActive={dayNightCycleActive}
         weatherMode={weatherMode}
+        neonGridActive={neonGridActive}
         onHud={(s, a, x, z, yaw) => {
           setHud({ speed: s, altitude: a });
           const mapX = x - Math.sin(yaw) * 40;

--- a/src/components/ActionToolbar.tsx
+++ b/src/components/ActionToolbar.tsx
@@ -12,6 +12,8 @@ interface ActionToolbarProps {
   isMounted: boolean;
   dayNightCycleActive: boolean;
   setDayNightCycleActive: React.Dispatch<React.SetStateAction<boolean>>;
+  neonGridActive: boolean;
+  setNeonGridActive: React.Dispatch<React.SetStateAction<boolean>>;
   weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
   cycleWeather?: () => void;
 }
@@ -25,6 +27,8 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
   isMounted,
   dayNightCycleActive,
   setDayNightCycleActive,
+  neonGridActive,
+  setNeonGridActive,
   weatherMode = "sunny",
   cycleWeather = () => {},
 }) => {
@@ -63,6 +67,30 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
       >
         <span style={{ color: theme.accent }} aria-hidden="true">&#9654;</span>
         <span>{dayNightCycleActive ? "CYCLE ON" : "CYCLE OFF"}</span>
+      </button>
+
+      {/* Cyberpunk Neon Grid Toggle Button */}
+      <button
+        onClick={() => {
+          setNeonGridActive((prev) => {
+            const next = !prev;
+            try {
+              localStorage.setItem("leetcodecity_neongrid_enabled", next ? "1" : "0");
+            } catch (err) {
+              console.warn("[ActionToolbar] Failed to persist grid preference:", err);
+            }
+            return next;
+          });
+        }}
+        className={`btn-press flex items-center gap-1.5 border-[3px] px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors ${
+          neonGridActive
+            ? "border-pink-500/80 bg-pink-500/10 text-pink-400 hover:border-pink-400"
+            : "border-border bg-bg/70 text-cream hover:border-border-light"
+        }`}
+        aria-label={neonGridActive ? "Turn off Neon grid" : "Turn on Neon grid"}
+      >
+        <span style={{ color: theme.accent }} aria-hidden="true">&#9654;</span>
+        <span>GRID: {neonGridActive ? "ON" : "OFF"}</span>
       </button>
  
       {/* Weather Selector Button */}

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -8,6 +8,7 @@ import { OrbitControls, useGLTF, Stats } from "@react-three/drei";
 import * as THREE from "three";
 import CityScene from "./CityScene";
 import type { FocusInfo } from "./CityScene";
+import NeonGridOverlay from "./NeonGridOverlay";
 import type { LiveSession } from "@/lib/useCodingPresence";
 import type { CityBuilding, CityPlaza, CityDecoration, CityRiver, CityBridge, CityCanal } from "@/lib/github";
 import SkyAds from "./SkyAds";
@@ -1188,7 +1189,7 @@ function CameraReset() {
 
 // ─── Ground ──────────────────────────────────────────────────
 
-function Ground({ color, grid1, grid2 }: { color: string; grid1: string; grid2: string }) {
+function Ground({ color, grid1, grid2, showNeonGrid, accentColor }: { color: string; grid1: string; grid2: string; showNeonGrid?: boolean; accentColor?: string }) {
   return (
     <group>
       {/* City ground — compact island */}
@@ -1196,7 +1197,11 @@ function Ground({ color, grid1, grid2 }: { color: string; grid1: string; grid2: 
         <planeGeometry args={[6000, 6000]} />
         <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.15} roughness={0.95} />
       </mesh>
-      <gridHelper args={[4000, 200, grid1, grid2]} position={[0, -0.5, 0]} />
+      {showNeonGrid ? (
+        <NeonGridOverlay accentColor={accentColor ?? "#e040c0"} />
+      ) : (
+        <gridHelper args={[4000, 200, grid1, grid2]} position={[0, -0.5, 0]} />
+      )}
       {/* Ocean — flat infinite water plane surrounding the city */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -2, 0]} renderOrder={-1}>
         <planeGeometry args={[80000, 80000]} />
@@ -2332,6 +2337,7 @@ export interface CityCanvasProps {
   liveByLogin?: Map<string, LiveSession>;
   cityEnergy?: number;
   weatherMode?: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
+  neonGridActive?: boolean;
   relicFocus?: { x: number; y: number; z: number } | null;
   equippedRelicId?: string | null;
   initialFlightPos?: THREE.Vector3 | null;
@@ -2455,6 +2461,7 @@ const CityCanvasSceneContent = memo(function CityCanvasSceneContent({
   liveByLogin,
   cityEnergy,
   weatherMode = "sunny",
+  neonGridActive,
   relicFocus,
   equippedRelicId,
   initialFlightPos,
@@ -2545,7 +2552,14 @@ const CityCanvasSceneContent = memo(function CityCanvasSceneContent({
         </>
       )}
 
-      <Ground key={`ground-${themeIndex}`} color={theme.groundColor} grid1={theme.grid1} grid2={theme.grid2} />
+      <Ground
+        key={`ground-${themeIndex}`}
+        color={theme.groundColor}
+        grid1={theme.grid1}
+        grid2={theme.grid2}
+        showNeonGrid={neonGridActive}
+        accentColor={theme.building.accent}
+      />
 
       <FounderSpire onClick={onLandmarkClick ?? (() => { })} />
       <Suspense fallback={null}>
@@ -2760,6 +2774,7 @@ export default function CityCanvas({
   liveByLogin,
   cityEnergy,
   weatherMode = "sunny",
+  neonGridActive,
   relicFocus,
   equippedRelicId,
   initialFlightPos,
@@ -2989,6 +3004,7 @@ export default function CityCanvas({
         liveByLogin={liveByLogin}
         cityEnergy={cityEnergy}
         weatherMode={weatherMode}
+        neonGridActive={neonGridActive}
         relicFocus={relicFocus}
         equippedRelicId={equippedRelicId}
         initialFlightPos={initialFlightPos}

--- a/src/components/NeonGridOverlay.tsx
+++ b/src/components/NeonGridOverlay.tsx
@@ -80,7 +80,7 @@ export default function NeonGridOverlay({ accentColor }: NeonGridOverlayProps) {
   const uniforms = useMemo(
     () => ({
       uTime: { value: 0 },
-      uColor: { value: new THREE.Color(accentColor) },
+      uColor: { value: new THREE.Color() },
     }),
     []
   );

--- a/src/components/NeonGridOverlay.tsx
+++ b/src/components/NeonGridOverlay.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRef, useMemo } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+interface NeonGridOverlayProps {
+  accentColor: string;
+}
+
+const vertexShader = `
+  varying vec3 vWorldPosition;
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    vWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = `
+  uniform float uTime;
+  uniform vec3 uColor;
+  varying vec3 vWorldPosition;
+  varying vec2 vUv;
+
+  void main() {
+    vec2 pos = vWorldPosition.xz;
+    float dist = length(pos);
+
+    // Fade out at city boundaries (fade completely by 2500 units)
+    float fade = smoothstep(2500.0, 1000.0, dist);
+    if (fade <= 0.0) {
+      discard;
+    }
+
+    // Grid sizes
+    float primarySpacing = 100.0;
+    float secondarySpacing = 20.0;
+
+    // Calculate grid lines using derivatives for infinite resolution and anti-aliasing
+    vec2 grid1 = abs(fract(pos / primarySpacing - 0.5) - 0.5) / (fwidth(pos / primarySpacing) * 1.2);
+    float primaryGrid = 1.0 - min(min(grid1.x, grid1.y), 1.0);
+
+    vec2 grid2 = abs(fract(pos / secondarySpacing - 0.5) - 0.5) / (fwidth(pos / secondarySpacing) * 1.0);
+    float secondaryGrid = 1.0 - min(min(grid2.x, grid2.y), 1.0);
+
+    // Emissive pulsing wave emanating from the center
+    float waveSpeed = 2.5;
+    float waveFreq = 0.008;
+    float wave = sin(dist * waveFreq - uTime * waveSpeed) * 0.5 + 0.5;
+    // Make wave sharp/narrow for a cleaner energy pulse line
+    float pulse = pow(wave, 8.0) * 1.5;
+
+    // Moving data flow pulses along the grid lines
+    float flowSpeed = 15.0;
+    float flowDensity = 80.0;
+    float flowX = step(0.96, primaryGrid) * step(0.85, fract((pos.y - uTime * flowSpeed) / flowDensity));
+    float flowY = step(0.96, primaryGrid) * step(0.85, fract((pos.x - uTime * flowSpeed) / flowDensity));
+    float dataFlow = clamp(flowX + flowY, 0.0, 1.0);
+
+    // Combine neon grid components
+    // Base glow (secondary grid is faint, primary grid is bright)
+    float intensity = primaryGrid * 0.7 + secondaryGrid * 0.15;
+    
+    // Add the energy pulse wave and data flow pulses
+    intensity += pulse * (primaryGrid * 0.6 + 0.15);
+    intensity += dataFlow * 0.8;
+
+    // Final color with cyberpunk emissive style
+    vec3 finalColor = uColor * intensity;
+
+    gl_FragColor = vec4(finalColor, intensity * fade * 0.85);
+  }
+`;
+
+export default function NeonGridOverlay({ accentColor }: NeonGridOverlayProps) {
+  const materialRef = useRef<THREE.ShaderMaterial>(null);
+
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uColor: { value: new THREE.Color(accentColor) },
+    }),
+    []
+  );
+
+  // Keep color in sync with prop updates
+  useMemo(() => {
+    uniforms.uColor.value.set(accentColor);
+  }, [accentColor, uniforms]);
+
+  useFrame((state) => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.uTime.value = state.clock.getElapsedTime();
+    }
+  });
+
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.49, 0]} renderOrder={1}>
+      <planeGeometry args={[6000, 6000]} />
+      <shaderMaterial
+        ref={materialRef}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        uniforms={uniforms}
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+      />
+    </mesh>
+  );
+}

--- a/src/components/hud/SettingsPanel.tsx
+++ b/src/components/hud/SettingsPanel.tsx
@@ -16,6 +16,8 @@ export default function SettingsPanel() {
     cycleTheme,
     dayNightCycleActive,
     setDayNightCycleActive,
+    neonGridActive,
+    setNeonGridActive,
     weatherMode,
     cycleWeather,
     replayIntro,
@@ -59,6 +61,27 @@ export default function SettingsPanel() {
           <span style={{ color: theme.accent }}>&#9654;</span>
           <span>{dayNightCycleActive ? "CYCLE ON" : "CYCLE OFF"}</span>
         </button>
+        <button
+          onClick={() => {
+            setNeonGridActive((prev: boolean) => {
+              const next = !prev;
+              try {
+                localStorage.setItem("leetcodecity_neongrid_enabled", next ? "1" : "0");
+              } catch (err) {
+                console.warn("[neonGridToggle] Failed to persist grid preference:", err);
+              }
+              return next;
+            });
+          }}
+          className={`btn-press flex items-center gap-1.5 border-[3px] px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors ${
+            neonGridActive
+              ? "border-pink-500/80 bg-pink-500/10 text-pink-400 hover:border-pink-400"
+              : "border-border bg-bg/70 text-cream hover:border-border-light"
+          }`}
+        >
+          <span style={{ color: theme.accent }}>&#9654;</span>
+          <span>GRID: {neonGridActive ? "ON" : "OFF"}</span>
+        </button>
         <div id="gc-radio-slot" />
       </div>
     );
@@ -76,6 +99,8 @@ export default function SettingsPanel() {
         isMounted={true}
         dayNightCycleActive={dayNightCycleActive}
         setDayNightCycleActive={setDayNightCycleActive}
+        neonGridActive={neonGridActive}
+        setNeonGridActive={setNeonGridActive}
         weatherMode={weatherMode}
         cycleWeather={cycleWeather}
       />

--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -155,6 +155,8 @@ interface CityContextProps {
   setRelicFocus: React.Dispatch<React.SetStateAction<{ x: number; y: number; z: number } | null>>;
   dayNightCycleActive: boolean;
   setDayNightCycleActive: React.Dispatch<React.SetStateAction<boolean>>;
+  neonGridActive: boolean;
+  setNeonGridActive: React.Dispatch<React.SetStateAction<boolean>>;
   weatherMode: "sunny" | "rainy" | "windy" | "stormy" | "snowy";
   setWeatherMode: React.Dispatch<React.SetStateAction<"sunny" | "rainy" | "windy" | "stormy" | "snowy">>;
   hud: { speed: number; altitude: number };
@@ -430,6 +432,7 @@ export function CityProvider({ children }: { children: ReactNode }) {
   const [relicFocus, setRelicFocus] = useState<{ x: number; y: number; z: number } | null>(null);
 
   const [dayNightCycleActive, setDayNightCycleActive] = useState(true);
+  const [neonGridActive, setNeonGridActive] = useState(false);
   const [weatherMode, setWeatherMode] = useState<"sunny" | "rainy" | "windy" | "stormy" | "snowy">("sunny");
 
   const [hud, setHud] = useState({ speed: 0, altitude: 0 });
@@ -595,6 +598,20 @@ export function CityProvider({ children }: { children: ReactNode }) {
     setThemeIndex((i) => {
       const next = (i + 1) % THEMES.length;
       localStorage.setItem("leetcodecity_theme", String(next));
+      
+      // Auto toggle neon grid overlay state when cycling theme
+      if (next === 2) {
+        setNeonGridActive(true);
+        try {
+          localStorage.setItem("leetcodecity_neongrid_enabled", "1");
+        } catch {}
+      } else {
+        setNeonGridActive(false);
+        try {
+          localStorage.setItem("leetcodecity_neongrid_enabled", "0");
+        } catch {}
+      }
+
       if (session?.user?.id) {
         fetch("/api/preferences/theme", {
           method: "PATCH",
@@ -1388,6 +1405,17 @@ export function CityProvider({ children }: { children: ReactNode }) {
       // Preferences are optional; ignore storage failures and keep defaults.
     }
     try {
+      const savedGrid = localStorage.getItem("leetcodecity_neongrid_enabled");
+      if (savedGrid !== null) {
+        setNeonGridActive(savedGrid === "1");
+      } else {
+        const savedTheme = localStorage.getItem("leetcodecity_theme");
+        if (savedTheme === "2") setNeonGridActive(true);
+      }
+    } catch {
+      // Preferences are optional; ignore storage failures and keep defaults.
+    }
+    try {
       const savedWeather = localStorage.getItem("leetcodecity_weather_mode");
       if (["sunny", "rainy", "windy", "stormy", "snowy"].includes(savedWeather ?? "")) {
         setWeatherMode(savedWeather as any);
@@ -1989,6 +2017,8 @@ export function CityProvider({ children }: { children: ReactNode }) {
         setRelicFocus,
         dayNightCycleActive,
         setDayNightCycleActive,
+        neonGridActive,
+        setNeonGridActive,
         weatherMode,
         setWeatherMode,
         hud,


### PR DESCRIPTION
## What does this PR do?

This PR introduces a highly optimized, GPU-accelerated **Cyberpunk Neon Grid** shader overlay for the city's ground plane. Key changes include:
- **Procedural Custom Shader**: Created `NeonGridOverlay.tsx` utilizing a custom `ShaderMaterial` to render a pulsing, emissive cyberpunk neon grid (with primary/secondary spacing) using world-space coordinates to ensure infinite scaling and clean aliasing. It includes scrolling UV offsets for data flow and radial energy wave pulses emanating from the city center.
- **State & Context Integration**: Added state variables and persistent `localStorage` preference management under `CityContext.tsx`. The grid is enabled automatically when cycling to the "Neon" theme.
- **Ground Integration**: Connected the overlay state down to the `<Ground>` component inside `CityCanvas.tsx`, swapping the standard `<gridHelper>` with `<NeonGridOverlay>` when active.
- **HUD Settings & Toggles**: Added a styled `GRID: ON/OFF` toggle button to the `ActionToolbar.tsx` and `SettingsPanel.tsx` (for both explore and landing layouts).

## Related issue

Fixes #220

## Screenshots

*Note: Since these changes are WebGL shader animations, screenshots represent visual snapshots of the pulsing grid overlay.*
| Before (Theme Neon Grid) | After (Procedural Emissive Neon Grid Overlay) |
|---|---|
| Standard wireframe lines without glow | Glowing, procedural grid lines with dynamic energy pulses and scrolling data flow |

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
