### PR TITLE
docs : added JSDoc to stripe.ts checkout functions

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -16,6 +16,20 @@ export function getStripe(): Stripe {
   return stripeInstance;
 }
 
+/**
+ * Create a Stripe Checkout session for a shop item purchase.
+ *
+ * @param itemId          Active item ID from the items table
+ * @param developerId     Database ID of the purchasing developer
+ * @param githubLogin     GitHub login of the purchasing developer
+ * @param currency        Billing currency; defaults to "usd"
+ * @param customerEmail   Optional billing email; Stripe infers from existing customer if omitted
+ * @param giftedToDevId   If gifting, the DB ID of the recipient developer
+ * @param giftedToLogin   If gifting, the GitHub login of the recipient
+ * @param idempotencyKey  Optional Stripe idempotency key to safely retry without double-charging
+ * @returns               Redirect URL to the Stripe-hosted checkout page
+ * @throws                Error if the item does not exist or is not active
+ */
 export async function createCheckoutSession(
   itemId: string,
   developerId: number,
@@ -80,6 +94,17 @@ export async function createCheckoutSession(
   return { url: session.url! };
 }
 
+/**
+ * Create a Stripe Checkout session for a pixel package purchase.
+ *
+ * @param packageId     Active pixel package ID from the pixel_packages table
+ * @param developerId   Database ID of the purchasing developer
+ * @param githubLogin   GitHub login of the purchasing developer
+ * @param currency      Billing currency; defaults to "usd"
+ * @param customerEmail Optional billing email
+ * @returns             Redirect URL and the Stripe session ID
+ * @throws              Error if the package does not exist or is not active
+ */
 export async function createPixelCheckoutSession(
   packageId: string,
   developerId: number,


### PR DESCRIPTION
## Summary of What Has Been Done

Added JSDoc documentation to the two exported checkout functions in `src/lib/stripe.ts`:
- `createCheckoutSession`: documents all parameters, return type, and thrown error conditions
- `createPixelCheckoutSession`: documents all parameters, return type, and thrown error conditions

## Changes Made

- Added JSDoc block to `createCheckoutSession` covering itemId, developerId, githubLogin, currency, customerEmail, giftedToDevId, giftedToLogin, idempotencyKey parameters, return value, and error conditions
- Added JSDoc block to `createPixelCheckoutSession` covering packageId, developerId, githubLogin, currency, customerEmail parameters, return value, and error conditions
- Follows the JSDoc style used in other lib files in the project

## Impact it Made

- Improves IDE autocomplete for contributors working with Stripe checkout
- Documents parameter constraints and expected types
- Makes the codebase more consistent

Closes #1048

## Note: please assign this PR to the `tmdeveloper007` account.