### PR TITLE
docs : added JSDoc to rate-limit.ts helper functions

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -71,6 +71,10 @@ function rateLimitLocal(
 
 let redis: Redis | null = null;
 
+/**
+ * Return the cached Upstash Redis client, or null when credentials are absent.
+ * The instance is lazily created on first call and reused for all subsequent calls.
+ */
 function getRedis(): Redis | null {
   if (redis) return redis;
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -84,6 +88,10 @@ function getRedis(): Redis | null {
 // creating a new instance on every request (each carries its own Redis conn).
 const limiterCache = new Map<string, Ratelimit>();
 
+/**
+ * Return a cached Ratelimit instance for the given window config, or null when Redis is unavailable.
+ * Instances are keyed by `${limit}:${windowMs}` so callers with different configs each get their own limiter.
+ */
 function getLimiter(limit: number, windowMs: number): Ratelimit | null {
   const r = getRedis();
   if (!r) return null;


### PR DESCRIPTION
## Summary of What Has Been Done

Added JSDoc documentation to the two helper functions in `src/lib/rate-limit.ts`:
- `getRedis()`: documents the lazy caching behavior and null return when credentials are absent
- `getLimiter()`: documents the per-config caching behavior and null return when Redis is unavailable

## Changes Made

- Added JSDoc block to `getRedis()` explaining the lazy singleton pattern and credential requirements
- Added JSDoc block to `getLimiter()` explaining the `${limit}:${windowMs}` cache key and Redis availability requirement

## Impact it Made

- Documents the internal caching mechanism for future contributors
- Consistent with the JSDoc already present on the main `rateLimit()` function

Closes #1050

## Note: please assign this PR to the `tmdeveloper007` account.