### PR TITLE
fix : added structured error logging to broadcastToChannel

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -156,7 +156,11 @@ export async function broadcastToChannel(
     });
   } catch (err) {
     // Fire and forget: broadcast failure should never block the API response.
-    console.warn("[supabase.ts] failed to broadcast realtime message:", err);
+    // Structured log includes topic and event for easier debugging in production.
+    console.error(
+      "[supabase.ts] failed to broadcast realtime message:",
+      { topic, event, error: err instanceof Error ? err.message : String(err) }
+    );
   }
 }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Improved the error logging in the `broadcastToChannel` function in `src/lib/supabase.ts` to use `console.error` with a structured object instead of `console.warn` with an unstructured argument.

## Changes Made

In the catch block of `broadcastToChannel`:
- Changed `console.warn` to `console.error` to reflect the severity of a broadcast failure
- Added structured context object: `{ topic, event, error: err.message }` so log aggregation tools can filter and search by topic/event
- Added explanatory comment about the fire-and-forget pattern

## Impact it Made

- Broadcast failures are now visible as errors (not warnings) in log aggregation
- Structured logging enables filtering by topic and event in production dashboards
- No behavioral change to API responses (still fire-and-forget)

Closes #1052

## Note: please assign this PR to the `tmdeveloper007` account.