### PR TITLE
fix : used safe delimiter in achievement dedup key to avoid collisions

### DIFF
--- a/src/lib/notification-senders/achievement.ts
+++ b/src/lib/notification-senders/achievement.ts
@@ -26,7 +26,7 @@ export function sendAchievementNotification(
 
   const dedupKey = notable.length === 1
     ? `achievement:${devId}:${notable[0].id}`
-    : `achievement_batch:${devId}:${notable.map((a) => a.id).sort().join(",")}`;
+    : `achievement_batch:${devId}:${notable.map((a) => a.id).sort().join("|")}`;
 
   const isSingle = notable.length === 1;
   const first = notable[0];


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/lib/notification-senders/achievement.ts`, the dedup key for batch achievements used commas to join multiple achievement IDs, which could create collisions if IDs contain commas. Changed the delimiter from `,` to `|`.

## Changes Made

- Changed `.join(",")` to `.join("|")` in the batch dedup key construction
- The pipe character is unlikely to appear in achievement IDs, preventing collision

## Impact it Made

- Prevents accidental dedup key collisions with IDs containing commas
- More robust deduplication for achievement notification emails
- Prevents potential duplicate emails to users in edge cases

Closes #1060

## Note

Please assign this PR to the `tmdeveloper007` account.
