### PR TITLE
docs : added JSDoc to exported functions in cityCache.ts

### DIFF
--- a/src/lib/cityCache.ts
+++ b/src/lib/cityCache.ts
@@ -25,6 +25,12 @@ let cache: CityCache | null = null;
 
 const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Returns the current city cache if it exists and has not expired.
+ * Cache expires after MAX_AGE_MS (5 minutes).
+ *
+ * @returns The cached CityCache object, or null if cache is absent or expired.
+ */
 export function getCityCache(): CityCache | null {
   if (!cache) return null;
   if (Date.now() - cache.timestamp > MAX_AGE_MS) {
@@ -34,10 +40,20 @@ export function getCityCache(): CityCache | null {
   return cache;
 }
 
+/**
+ * Stores city data in the module-level cache singleton.
+ * Automatically stamps the entry with the current timestamp.
+ *
+ * @param data - City data to cache (timestamp is added automatically).
+ */
 export function setCityCache(data: Omit<CityCache, "timestamp">) {
   cache = { ...data, timestamp: Date.now() };
 }
 
+/**
+ * Clears the city cache singleton, forcing the next read to fetch fresh data.
+ * Primarily useful in tests to reset state between test cases.
+ */
 export function clearCityCache() {
   cache = null;
 }


### PR DESCRIPTION
## Summary of What Has Been Done

The three exported functions in `src/lib/cityCache.ts` (`getCityCache`, `setCityCache`, `clearCityCache`) lacked JSDoc type annotations. Added comprehensive JSDoc comments following the same documentation style used in other lib files like `supabase.ts`, `rate-limit.ts`, and `xp.ts`.

## Changes Made

- Added JSDoc to `getCityCache()`: documents purpose, return type, and cache expiration behavior
- Added JSDoc to `setCityCache()`: documents the automatic timestamp injection
- Added JSDoc to `clearCityCache()`: documents purpose and use case

## Impact it Made

- Consistent documentation style across all lib files
- Better developer experience when using these cache functions
- Easier onboarding for new contributors

Closes #1061

## Note

Please assign this PR to the `tmdeveloper007` account.
