### PR TITLE
fix: use safe delimiter in achievement dedup key to avoid collisions-#1060

### DIFF
--- a/src/lib/__tests__/achievement-notification.test.ts
+++ b/src/lib/__tests__/achievement-notification.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendAchievementNotification } from "../notification-senders/achievement";
+import { sendNotificationAsync } from "../notifications";
+
+// Mock the notifications module
+vi.mock("../notifications", () => ({
+  sendNotificationAsync: vi.fn(),
+}));
+
+describe("sendAchievementNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should generate correct dedupKey for a single notable achievement", () => {
+    sendAchievementNotification(42, "test_user", [
+      { id: "gold_ach", name: "Gold Achievement", tier: "gold" },
+      { id: "bronze_ach", name: "Bronze Achievement", tier: "bronze" }, // filtered out
+    ]);
+
+    expect(sendNotificationAsync).toHaveBeenCalledTimes(1);
+    expect(sendNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupKey: "achievement:42:gold_ach",
+        title: "Achievement Unlocked: Gold Achievement (gold)",
+      })
+    );
+  });
+
+  it("should generate correct dedupKey using pipe delimiter for batch notable achievements", () => {
+    sendAchievementNotification(42, "test_user", [
+      { id: "gold_ach", name: "Gold Achievement", tier: "gold" },
+      { id: "diamond_ach", name: "Diamond Achievement", tier: "diamond" },
+      { id: "silver_ach", name: "Silver Achievement", tier: "silver" }, // filtered out
+    ]);
+
+    expect(sendNotificationAsync).toHaveBeenCalledTimes(1);
+    expect(sendNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupKey: "achievement_batch:42:diamond_ach|gold_ach",
+        title: "2 Achievements Unlocked!",
+      })
+    );
+  });
+});

--- a/src/lib/notification-senders/achievement.ts
+++ b/src/lib/notification-senders/achievement.ts
@@ -26,7 +26,7 @@ export function sendAchievementNotification(
 
   const dedupKey = notable.length === 1
     ? `achievement:${devId}:${notable[0].id}`
-    : `achievement_batch:${devId}:${notable.map((a) => a.id).sort().join(",")}`;
+    : `achievement_batch:${devId}:${notable.map((a) => a.id).sort().join("|")}`;
 
   const isSingle = notable.length === 1;
   const first = notable[0];


### PR DESCRIPTION
## What does this PR do?

Changes the achievement batch deduplication key generation in [achievement.ts](file:///d:/GSSoC/Ixotic27/The-Leetcode-City/src/lib/notification-senders/achievement.ts) to use the pipe character (`|`) instead of a comma (`,`) as the delimiter. This avoids deduplication key collisions in cases where achievement IDs or developer IDs contain commas.

Also adds a unit test suite under [achievement-notification.test.ts](file:///d:/GSSoC/Ixotic27/The-Leetcode-City/src/lib/__tests__/achievement-notification.test.ts) to verify the correct generation of deduplication keys for single and batch achievement notifications.

## Related issue

Fixes #1060

## Screenshots

N/A (Backend logic update)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
