### PR TITLE
feat: unify payment fulfillment orchestration (#1042)

### DIFF
--- a/src/app/api/webhooks/abacatepay/route.ts
+++ b/src/app/api/webhooks/abacatepay/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
-import { autoEquipIfSolo, fulfillItemPurchase } from "@/lib/items";
-import { sendPurchaseNotification, sendGiftSentNotification } from "@/lib/notification-senders/purchase";
-import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
 import { SKY_AD_PLANS, isValidPlanId } from "@/lib/skyAdPlans";
 import { verifyAbacatePayWebhook } from "@/lib/abacatepay";
 import { InfrastructureError } from "@/lib/errors";
+import { orchestratePurchaseFulfillment } from "@/lib/purchase-orchestrator";
 
 export const dynamic = "force-dynamic";
 
@@ -102,63 +100,34 @@ export async function POST(request: Request) {
           .maybeSingle();
 
         if (purchase && purchase.status === "pending") {
-          // Atomic claim: transition pending → processing in one UPDATE.
-          // If a concurrent PIX retry already claimed it, claimed will be null.
-          const { data: claimed } = await sb
-            .from("purchases")
-            .update({ status: "processing" })
-            .eq("id", purchase.id)
-            .eq("status", "pending")
-            .select("id")
-            .maybeSingle();
+          const result = await orchestratePurchaseFulfillment({
+            provider: "abacatepay",
+            transactionId: pixId,
+            purchaseId: purchase.id,
+            developerId: purchase.developer_id,
+            itemId: purchase.item_id,
+            giftedTo: purchase.gifted_to,
+            idempotencyKey,
+            supabaseClient: sb,
+            claimPendingPurchase: async ({ supabaseClient: claimSb, purchaseId: pendingPurchaseId }) => {
+              const { data: claimed } = await claimSb
+                .from("purchases")
+                .update({ status: "processing" })
+                .eq("id", pendingPurchaseId)
+                .eq("status", "pending")
+                .select("id")
+                .maybeSingle();
 
-          if (!claimed) {
-            console.log(`[AbacatePay webhook] Purchase ${purchase.id} already claimed by concurrent request — skipping`);
-            break;
-          }
+              if (!claimed) {
+                return { ok: false, purchase_id: pendingPurchaseId, already_claimed: true, reason: "already_claimed" };
+              }
 
-          const ownerId = purchase.gifted_to ?? purchase.developer_id;
-          const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, purchase.item_id, sb);
+              return { ok: true, purchase_id: pendingPurchaseId };
+            },
+          });
 
-          await sb
-            .from("purchases")
-            .update({ status: purchaseStatus, idempotency_key: idempotencyKey })
-            .eq("id", purchase.id);
-
-          const fullPurchase = purchase;
-
-          if (fullPurchase) {
-            const itemOwner = fullPurchase.gifted_to ?? fullPurchase.developer_id;
-            await autoEquipIfSolo(itemOwner, fullPurchase.item_id);
-
-            const { data: dev } = await sb
-              .from("developers")
-              .select("github_login")
-              .eq("id", fullPurchase.developer_id)
-              .single();
-
-            if (fullPurchase.gifted_to) {
-              const { data: receiver } = await sb
-                .from("developers")
-                .select("github_login")
-                .eq("id", fullPurchase.gifted_to)
-                .single();
-              await sb.from("activity_feed").insert({
-                event_type: "gift_sent",
-                actor_id: fullPurchase.developer_id,
-                target_id: fullPurchase.gifted_to,
-                metadata: { giver_login: dev?.github_login, receiver_login: receiver?.github_login, item_id: fullPurchase.item_id },
-              });
-              sendGiftSentNotification(fullPurchase.developer_id, dev?.github_login ?? "", receiver?.github_login ?? "unknown", purchase.id, fullPurchase.item_id);
-              sendGiftReceivedNotification(fullPurchase.gifted_to, dev?.github_login ?? "someone", receiver?.github_login ?? "unknown", purchase.id, fullPurchase.item_id);
-            } else {
-              await sb.from("activity_feed").insert({
-                event_type: "item_purchased",
-                actor_id: fullPurchase.developer_id,
-                metadata: { login: dev?.github_login, item_id: fullPurchase.item_id },
-              });
-              sendPurchaseNotification(fullPurchase.developer_id, dev?.github_login ?? "", purchase.id, fullPurchase.item_id);
-            }
+          if (result.kind !== "completed") {
+            console.log(`[AbacatePay webhook] Purchase ${purchase.id} finished with result ${result.kind}`);
           }
         }
         break;

--- a/src/app/api/webhooks/cashfree/route.ts
+++ b/src/app/api/webhooks/cashfree/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { verifyCashfreeWebhook, getCashfreeOrderStatus } from "@/lib/cashfree";
-import { autoEquipIfSolo, fulfillItemPurchase } from "@/lib/items";
-import { sendPurchaseNotification, sendGiftSentNotification } from "@/lib/notification-senders/purchase";
-import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
 import { SKY_AD_PLANS, isValidPlanId } from "@/lib/skyAdPlans";
 import { InfrastructureError } from "@/lib/errors";
+import { claimPendingPurchaseAtomically, orchestratePurchaseFulfillment } from "@/lib/purchase-orchestrator";
 
 
 export const dynamic = "force-dynamic";
@@ -214,80 +212,31 @@ export async function POST(request: Request) {
           break;
         }
 
-        const ownerId = purchase.gifted_to ?? purchase.developer_id;
-        const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, purchase.item_id, sb);
+        const orchestrationResult = await orchestratePurchaseFulfillment({
+          provider: "cashfree",
+          transactionId: orderId,
+          purchaseId: purchase.id,
+          developerId: purchase.developer_id,
+          itemId: purchase.item_id,
+          giftedTo: purchase.gifted_to,
+          idempotencyKey,
+          supabaseClient: sb,
+          claimPendingPurchase: async ({ transactionId, developerId: claimDeveloperId, itemId: claimItemId, purchaseId: pendingPurchaseId, supabaseClient: claimSb }) =>
+            claimPendingPurchaseAtomically({
+              provider: "cashfree",
+              transactionId,
+              developerId: claimDeveloperId,
+              itemId: claimItemId,
+              purchaseId: pendingPurchaseId,
+              supabaseClient: claimSb,
+            }),
+        });
 
-        // Mark as completed/delivered
-        await sb
-          .from("purchases")
-          .update({ status: purchaseStatus, idempotency_key: idempotencyKey })
-          .eq("id", purchase.id);
-
-        const fullPurchase = purchase;
-
-        if (fullPurchase) {
-          // Auto-equip if it's the only item in its zone
-          const itemOwner = fullPurchase.gifted_to ?? fullPurchase.developer_id;
-          await autoEquipIfSolo(itemOwner, fullPurchase.item_id);
-
-          // Get developer info for notifications
-          const { data: dev } = await sb
-            .from("developers")
-            .select("github_login")
-            .eq("id", fullPurchase.developer_id)
-            .single();
-
-          if (fullPurchase.gifted_to) {
-            // Gift notifications
-            const { data: receiver } = await sb
-              .from("developers")
-              .select("github_login")
-              .eq("id", fullPurchase.gifted_to)
-              .single();
-
-            await sb.from("activity_feed").insert({
-              event_type: "gift_sent",
-              actor_id: fullPurchase.developer_id,
-              target_id: fullPurchase.gifted_to,
-              metadata: {
-                giver_login: dev?.github_login,
-                receiver_login: receiver?.github_login,
-                item_id: fullPurchase.item_id,
-              },
-            });
-
-            sendGiftSentNotification(
-              fullPurchase.developer_id,
-              dev?.github_login ?? "",
-              receiver?.github_login ?? "unknown",
-              purchase.id,
-              fullPurchase.item_id,
-            );
-            sendGiftReceivedNotification(
-              fullPurchase.gifted_to,
-              dev?.github_login ?? "someone",
-              receiver?.github_login ?? "unknown",
-              purchase.id,
-              fullPurchase.item_id,
-            );
-          } else {
-            // Purchase notification
-            await sb.from("activity_feed").insert({
-              event_type: "item_purchased",
-              actor_id: fullPurchase.developer_id,
-              metadata: {
-                login: dev?.github_login,
-                item_id: fullPurchase.item_id,
-              },
-            });
-
-            sendPurchaseNotification(
-              fullPurchase.developer_id,
-              dev?.github_login ?? "",
-              purchase.id,
-              fullPurchase.item_id,
-            );
+        if (orchestrationResult.kind !== "completed") {
+          if (orchestrationResult.kind === "sold_out") {
+            await sb.from("purchases").update({ status: "failed", provider_tx_id: orderId }).eq("id", purchase.id).eq("status", "pending");
           }
+          console.log(`[Cashfree webhook] Purchase ${purchase.id} finished with result ${orchestrationResult.kind}`);
         }
         break;
       }

--- a/src/app/api/webhooks/nowpayments/route.ts
+++ b/src/app/api/webhooks/nowpayments/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { verifyIpnSignature } from "@/lib/nowpayments";
-import { autoEquipIfSolo, fulfillItemPurchase } from "@/lib/items";
-import { sendPurchaseNotification, sendGiftSentNotification } from "@/lib/notification-senders/purchase";
-import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
 import { SKY_AD_PLANS, isValidPlanId } from "@/lib/skyAdPlans";
 import { InfrastructureError } from "@/lib/errors";
+import { orchestratePurchaseFulfillment } from "@/lib/purchase-orchestrator";
 
 export const dynamic = "force-dynamic";
 
@@ -107,69 +105,37 @@ export async function POST(request: Request) {
           break;
         }
 
-        // Atomic claim: transition pending → processing in one UPDATE.
-        // If a concurrent request already claimed it, claimed will be null.
-        const { data: claimed } = await sb
-          .from("purchases")
-          .update({ status: "processing" })
-          .eq("id", purchase.id)
-          .eq("status", "pending")
-          .select("id")
-          .maybeSingle();
-
-        if (!claimed) {
-          console.log(`[NOWPayments webhook] Purchase ${purchase.id} already claimed by concurrent request — skipping`);
-          break;
-        }
-
-        const ownerId = purchase.gifted_to ?? purchase.developer_id;
-        const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, purchase.item_id, sb);
-
-        // Update payment ID and mark status (completed or delivered)
-        await sb
-          .from("purchases")
-          .update({
-            status: purchaseStatus,
+        const result = await orchestratePurchaseFulfillment({
+          provider: "nowpayments",
+          transactionId: orderId,
+          purchaseId: purchase.id,
+          developerId: purchase.developer_id,
+          itemId: purchase.item_id,
+          giftedTo: purchase.gifted_to,
+          idempotencyKey,
+          updatePurchaseFields: {
             provider_tx_id: paymentId ?? orderId,
-            idempotency_key: idempotencyKey,
-          })
-          .eq("id", purchase.id);
+          },
+          supabaseClient: sb,
+          claimPendingPurchase: async ({ supabaseClient: claimSb, purchaseId: pendingPurchaseId }) => {
+            const { data: claimed } = await claimSb
+              .from("purchases")
+              .update({ status: "processing" })
+              .eq("id", pendingPurchaseId)
+              .eq("status", "pending")
+              .select("id")
+              .maybeSingle();
 
-        // Auto-equip if solo item in zone
-        await autoEquipIfSolo(ownerId, purchase.item_id);
+            if (!claimed) {
+              return { ok: false, purchase_id: pendingPurchaseId, already_claimed: true, reason: "already_claimed" };
+            }
 
-        // Insert feed event
-        const { data: dev } = await sb
-          .from("developers")
-          .select("github_login")
-          .eq("id", purchase.developer_id)
-          .single();
+            return { ok: true, purchase_id: pendingPurchaseId };
+          },
+        });
 
-        if (purchase.gifted_to) {
-          const { data: receiver } = await sb
-            .from("developers")
-            .select("github_login")
-            .eq("id", purchase.gifted_to)
-            .single();
-          await sb.from("activity_feed").insert({
-            event_type: "gift_sent",
-            actor_id: purchase.developer_id,
-            target_id: purchase.gifted_to,
-            metadata: {
-              giver_login: dev?.github_login,
-              receiver_login: receiver?.github_login ?? "unknown",
-              item_id: purchase.item_id,
-            },
-          });
-          sendGiftSentNotification(purchase.developer_id, dev?.github_login ?? "", receiver?.github_login ?? "unknown", purchase.id, purchase.item_id);
-          sendGiftReceivedNotification(purchase.gifted_to, dev?.github_login ?? "someone", receiver?.github_login ?? "unknown", purchase.id, purchase.item_id);
-        } else {
-          await sb.from("activity_feed").insert({
-            event_type: "item_purchased",
-            actor_id: purchase.developer_id,
-            metadata: { login: dev?.github_login, item_id: purchase.item_id },
-          });
-          sendPurchaseNotification(purchase.developer_id, dev?.github_login ?? "", purchase.id, purchase.item_id);
+        if (result.kind !== "completed") {
+          console.log(`[NOWPayments webhook] Purchase ${purchase.id} finished with result ${result.kind}`);
         }
         break;
       }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { getStripe } from "@/lib/stripe";
 import { getSupabaseAdmin } from "@/lib/supabase";
-import { autoEquipIfSolo, fulfillItemPurchase } from "@/lib/items";
 import { SKY_AD_PLANS, isValidPlanId } from "@/lib/skyAdPlans";
-import { sendPurchaseNotification, sendGiftSentNotification } from "@/lib/notification-senders/purchase";
-import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
 import { InfrastructureError } from "@/lib/errors";
+import { claimPendingPurchaseAtomically, orchestratePurchaseFulfillment } from "@/lib/purchase-orchestrator";
 import type Stripe from "stripe";
 
 // Disable body parsing — Stripe needs raw body for signature verification
@@ -167,25 +165,28 @@ export async function POST(request: Request) {
         }
 
         const txId = paymentIntentId ?? session.id;
+        const githubLogin = session.metadata?.github_login;
+        const giftedTo = session.metadata?.gifted_to;
 
-        // Atomically claim the pending purchase with stock check
-        const { data: claimData, error: claimError } = await sb.rpc("claim_pending_purchase_atomic", {
-          p_developer_id: Number(developerId),
-          p_item_id: itemId,
-          p_provider: "stripe",
-          p_tx_id: txId,
+        const orchestrationResult = await orchestratePurchaseFulfillment({
+          provider: "stripe",
+          transactionId: txId,
+          developerId: Number(developerId),
+          itemId,
+          githubLogin,
+          giftedTo: giftedTo ? Number(giftedTo) : null,
+          supabaseClient: sb,
+          claimPendingPurchase: async ({ transactionId, developerId: claimDeveloperId, itemId: claimItemId, supabaseClient: claimSb }) =>
+            claimPendingPurchaseAtomically({
+              provider: "stripe",
+              transactionId,
+              developerId: claimDeveloperId,
+              itemId: claimItemId,
+              supabaseClient: claimSb,
+            }),
         });
 
-        if (claimError) {
-          throw new InfrastructureError(
-            `[Stripe webhook] Failed to claim pending purchase ${txId}: ${claimError.message}`,
-            claimError
-          );
-        }
-
-        const claimResult = Array.isArray(claimData) ? claimData[0] : claimData;
-
-        if (claimResult && claimResult.error_code === 'sold_out') {
+        if (orchestrationResult.kind === "sold_out") {
           console.error(`[Stripe webhook] Item ${itemId} oversold. Issuing Stripe refund for ${txId}.`);
           let refundSuccess = false;
           if (paymentIntentId) {
@@ -199,95 +200,53 @@ export async function POST(request: Request) {
               console.error("[Stripe webhook] Refund failed:", refundError);
             }
           }
-          
-          if (claimResult.purchase_id) {
+
+          if (orchestrationResult.purchaseId) {
             await sb.from("purchases").update({
               status: refundSuccess ? "refunded" : "failed",
               provider_tx_id: txId,
-            }).eq("id", claimResult.purchase_id).eq("status", "pending");
+            }).eq("id", orchestrationResult.purchaseId).eq("status", "pending");
           }
           break;
         }
 
-        if (claimResult && claimResult.ok && claimResult.purchase_id) {
-          const pendingId = claimResult.purchase_id;
-          const giftedTo = session.metadata?.gifted_to;
-          const ownerId = giftedTo ? Number(giftedTo) : Number(developerId);
-          const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
+        if (orchestrationResult.kind === "completed") {
+          break;
+        }
 
-          await sb
-            .from("purchases")
-            .update({
-              status: purchaseStatus,
-            })
-            .eq("id", pendingId);
+        if (orchestrationResult.kind === "duplicate") {
+          break;
+        }
 
-          // Auto-equip if solo item in zone
-          await autoEquipIfSolo(ownerId, itemId);
+        // Check if this txId already has a completed/delivered/processing purchase
+        const { data: alreadyProcessed, error: alreadyProcessedError } = await sb
+          .from("purchases")
+          .select("id, status")
+          .eq("provider_tx_id", txId)
+          .in("status", ["completed", "delivered", "processing"])
+          .maybeSingle();
 
-          // Insert feed event + send notifications
-          const githubLogin = session.metadata?.github_login;
-          if (giftedTo) {
-            const { data: receiver } = await sb
-              .from("developers")
-              .select("github_login")
-              .eq("id", Number(giftedTo))
-              .single();
-            await sb.from("activity_feed").insert({
-              event_type: "gift_sent",
-              actor_id: Number(developerId),
-              target_id: Number(giftedTo),
-              metadata: {
-                giver_login: githubLogin,
-                receiver_login: receiver?.github_login ?? "unknown",
-                item_id: itemId,
-              },
+        if (alreadyProcessedError) {
+          throw new InfrastructureError(
+            `[Stripe webhook] failed to validate processed tx ${txId}: ${alreadyProcessedError.message}`,
+            alreadyProcessedError
+          );
+        }
+
+        if (alreadyProcessed) {
+          console.log(`[Stripe webhook] Purchase ${alreadyProcessed.id} already fulfilled — skipping duplicate webhook`);
+          break;
+        }
+
+        console.error(`[Stripe webhook] Pending purchase not found for session ${session.id}. Cannot safely fulfill item ${itemId}. Issuing refund.`);
+        if (paymentIntentId) {
+          try {
+            await stripe.refunds.create({
+              payment_intent: paymentIntentId,
+              reason: "requested_by_customer",
             });
-
-            // Gift notifications: receipt to buyer, alert to receiver
-            sendGiftSentNotification(Number(developerId), githubLogin ?? "", receiver?.github_login ?? "unknown", pendingId, itemId);
-            sendGiftReceivedNotification(Number(giftedTo), githubLogin ?? "someone", receiver?.github_login ?? "unknown", pendingId, itemId);
-          } else {
-            await sb.from("activity_feed").insert({
-              event_type: "item_purchased",
-              actor_id: Number(developerId),
-              metadata: { login: githubLogin, item_id: itemId },
-            });
-
-            // Purchase receipt notification
-            sendPurchaseNotification(Number(developerId), githubLogin ?? "", pendingId, itemId);
-          }
-        } else {
-          // Check if this txId already has a completed/delivered/processing purchase
-          const { data: alreadyProcessed, error: alreadyProcessedError } = await sb
-            .from("purchases")
-            .select("id, status")
-            .eq("provider_tx_id", txId)
-            .in("status", ["completed", "delivered", "processing"])
-            .maybeSingle();
-
-          if (alreadyProcessedError) {
-            throw new InfrastructureError(
-              `[Stripe webhook] failed to validate processed tx ${txId}: ${alreadyProcessedError.message}`,
-              alreadyProcessedError
-            );
-          }
-
-          if (alreadyProcessed) {
-            console.log(`[Stripe webhook] Purchase ${alreadyProcessed.id} already fulfilled — skipping duplicate webhook`);
-            break;
-          }
-
-          console.error(`[Stripe webhook] Pending purchase not found for session ${session.id}. Cannot safely fulfill item ${itemId}. Issuing refund.`);
-          if (paymentIntentId) {
-            try {
-              await stripe.refunds.create({
-                payment_intent: paymentIntentId,
-                reason: "requested_by_customer",
-              });
-            } catch (refundError) {
-              console.error("[Stripe webhook] Refund failed for missing purchase:", refundError);
-            }
+          } catch (refundError) {
+            console.error("[Stripe webhook] Refund failed for missing purchase:", refundError);
           }
         }
         break;

--- a/src/lib/__tests__/purchase-orchestrator.test.ts
+++ b/src/lib/__tests__/purchase-orchestrator.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { orchestratePurchaseFulfillment } from "../purchase-orchestrator";
+
+const mockFulfillItemPurchase = vi.fn();
+const mockAutoEquipIfSolo = vi.fn();
+const mockSendPurchaseNotification = vi.fn();
+const mockSendGiftSentNotification = vi.fn();
+const mockSendGiftReceivedNotification = vi.fn();
+
+vi.mock("../items", () => ({
+  autoEquipIfSolo: (...args: unknown[]) => mockAutoEquipIfSolo(...args),
+  fulfillItemPurchase: (...args: unknown[]) => mockFulfillItemPurchase(...args),
+}));
+
+vi.mock("../notification-senders/purchase", () => ({
+  sendPurchaseNotification: (...args: unknown[]) => mockSendPurchaseNotification(...args),
+  sendGiftSentNotification: (...args: unknown[]) => mockSendGiftSentNotification(...args),
+}));
+
+vi.mock("../notification-senders/gift", () => ({
+  sendGiftReceivedNotification: (...args: unknown[]) => mockSendGiftReceivedNotification(...args),
+}));
+
+function createQueryBuilder(result: unknown) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    maybeSingle: async () => ({ data: result, error: null }),
+    single: async () => ({ data: result, error: null }),
+    insert: async () => ({ data: result, error: null }),
+    update: () => ({
+      eq: async () => ({ data: result, error: null }),
+    }),
+  };
+  return builder;
+}
+
+function createSupabaseMock(purchaseRow: Record<string, unknown>) {
+  return {
+    from: (table: string) => {
+      if (table === "purchases") {
+        return createQueryBuilder(purchaseRow);
+      }
+      if (table === "developers") {
+        return createQueryBuilder({ github_login: "tester" });
+      }
+      if (table === "activity_feed") {
+        return createQueryBuilder({ id: "feed-1" });
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+describe("orchestratePurchaseFulfillment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFulfillItemPurchase.mockResolvedValue({ status: "completed" });
+  });
+
+  it("finalizes a standard purchase and dispatches notifications", async () => {
+    const sb = createSupabaseMock({
+      id: "purchase-1",
+      status: "pending",
+      developer_id: 7,
+      item_id: "flag",
+      gifted_to: null,
+    });
+
+    const result = await orchestratePurchaseFulfillment({
+      provider: "stripe",
+      transactionId: "pi_123",
+      purchaseId: "purchase-1",
+      developerId: 7,
+      itemId: "flag",
+      githubLogin: "tester",
+      supabaseClient: sb as never,
+      claimPendingPurchase: async () => ({ ok: true, purchase_id: "purchase-1" }),
+    });
+
+    expect(result.kind).toBe("completed");
+    expect(mockFulfillItemPurchase).toHaveBeenCalledWith(7, "flag", sb);
+    expect(mockAutoEquipIfSolo).toHaveBeenCalledWith(7, "flag");
+    expect(mockSendPurchaseNotification).toHaveBeenCalledWith(7, "tester", "purchase-1", "flag");
+    expect(mockSendGiftSentNotification).not.toHaveBeenCalled();
+    expect(mockSendGiftReceivedNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/purchase-orchestrator.ts
+++ b/src/lib/purchase-orchestrator.ts
@@ -1,0 +1,233 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { autoEquipIfSolo, fulfillItemPurchase } from "@/lib/items";
+import { sendPurchaseNotification, sendGiftSentNotification } from "@/lib/notification-senders/purchase";
+import { sendGiftReceivedNotification } from "@/lib/notification-senders/gift";
+import { InfrastructureError } from "@/lib/errors";
+
+export type PurchaseProvider = "stripe" | "cashfree" | "nowpayments" | "abacatepay" | string;
+
+export interface ClaimPendingPurchaseResult {
+  ok: boolean;
+  purchase_id?: string;
+  error_code?: string;
+  already_claimed?: boolean;
+  reason?: string;
+}
+
+export interface PurchaseClaimContext {
+  provider: PurchaseProvider;
+  transactionId: string;
+  developerId: number;
+  itemId: string;
+  purchaseId?: string;
+  supabaseClient: SupabaseClient;
+}
+
+export type ClaimPendingPurchaseFn = (ctx: PurchaseClaimContext) => Promise<ClaimPendingPurchaseResult>;
+
+export interface PurchaseOrchestrationOptions {
+  provider: PurchaseProvider;
+  transactionId: string;
+  purchaseId?: string;
+  developerId: number;
+  itemId: string;
+  githubLogin?: string | null;
+  giftedTo?: number | null;
+  idempotencyKey?: string | null;
+  updatePurchaseFields?: Record<string, unknown>;
+  supabaseClient: SupabaseClient;
+  claimPendingPurchase: ClaimPendingPurchaseFn;
+}
+
+export interface PurchaseOrchestrationResult {
+  kind: "completed" | "duplicate" | "sold_out" | "not_found" | "failed";
+  purchaseId?: string;
+  status?: "completed" | "delivered" | "processing" | "pending" | "expired" | "failed" | "refunded";
+  ownerId?: number;
+  reason?: string;
+}
+
+export async function orchestratePurchaseFulfillment({
+  provider,
+  transactionId,
+  purchaseId,
+  developerId,
+  itemId,
+  githubLogin,
+  giftedTo,
+  idempotencyKey,
+  updatePurchaseFields = {},
+  supabaseClient,
+  claimPendingPurchase,
+}: PurchaseOrchestrationOptions): Promise<PurchaseOrchestrationResult> {
+  const sb = supabaseClient;
+
+  const claimResult = await claimPendingPurchase({
+    provider,
+    transactionId,
+    developerId,
+    itemId,
+    purchaseId,
+    supabaseClient: sb,
+  });
+
+  if (!claimResult.ok) {
+    if (claimResult.error_code === "sold_out") {
+      return { kind: "sold_out", purchaseId: claimResult.purchase_id, reason: "sold_out" };
+    }
+    if (claimResult.already_claimed || claimResult.reason === "already_claimed") {
+      return { kind: "duplicate", purchaseId: claimResult.purchase_id, reason: "already_claimed" };
+    }
+    return { kind: "not_found", purchaseId: claimResult.purchase_id, reason: claimResult.reason ?? "claim_failed" };
+  }
+
+  const pendingPurchaseId = claimResult.purchase_id;
+  if (!pendingPurchaseId) {
+    throw new InfrastructureError(`[purchase-orchestrator] Missing purchase_id after claiming ${transactionId}`);
+  }
+
+  const ownerId = (giftedTo ?? 0) > 0 ? Number(giftedTo) : Number(developerId);
+
+  console.log(`[purchase-orchestrator] Fulfilling purchase ${pendingPurchaseId} via ${provider}`);
+  const { status: purchaseStatus } = await fulfillItemPurchase(ownerId, itemId, sb);
+
+  await sb
+    .from("purchases")
+    .update({
+      status: purchaseStatus,
+      ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+      ...updatePurchaseFields,
+    })
+    .eq("id", pendingPurchaseId);
+
+  await autoEquipIfSolo(ownerId, itemId);
+
+  const { data: dev } = await sb
+    .from("developers")
+    .select("github_login")
+    .eq("id", developerId)
+    .single();
+
+  if (giftedTo) {
+    const { data: receiver } = await sb
+      .from("developers")
+      .select("github_login")
+      .eq("id", Number(giftedTo))
+      .single();
+
+    await sb.from("activity_feed").insert({
+      event_type: "gift_sent",
+      actor_id: developerId,
+      target_id: Number(giftedTo),
+      metadata: {
+        giver_login: dev?.github_login ?? githubLogin ?? "unknown",
+        receiver_login: receiver?.github_login ?? "unknown",
+        item_id: itemId,
+      },
+    });
+
+    sendGiftSentNotification(
+      developerId,
+      dev?.github_login ?? githubLogin ?? "",
+      receiver?.github_login ?? "unknown",
+      pendingPurchaseId,
+      itemId,
+    );
+    sendGiftReceivedNotification(
+      Number(giftedTo),
+      dev?.github_login ?? githubLogin ?? "someone",
+      receiver?.github_login ?? "unknown",
+      pendingPurchaseId,
+      itemId,
+    );
+  } else {
+    await sb.from("activity_feed").insert({
+      event_type: "item_purchased",
+      actor_id: developerId,
+      metadata: {
+        login: dev?.github_login ?? githubLogin ?? null,
+        item_id: itemId,
+      },
+    });
+
+    sendPurchaseNotification(
+      developerId,
+      dev?.github_login ?? githubLogin ?? "",
+      pendingPurchaseId,
+      itemId,
+    );
+  }
+
+  return {
+    kind: "completed",
+    purchaseId: pendingPurchaseId,
+    status: purchaseStatus,
+    ownerId,
+  };
+}
+
+export async function claimPendingPurchaseAtomically({
+  provider,
+  transactionId,
+  developerId,
+  itemId,
+  purchaseId,
+  supabaseClient,
+}: PurchaseClaimContext): Promise<ClaimPendingPurchaseResult> {
+  if (typeof supabaseClient.rpc === "function") {
+    const { data: claimData, error: claimError } = await supabaseClient.rpc("claim_pending_purchase_atomic", {
+      p_developer_id: developerId,
+      p_item_id: itemId,
+      p_provider: provider,
+      p_tx_id: transactionId,
+      ...(purchaseId ? { p_purchase_id: purchaseId } : {}),
+    });
+
+    if (claimError) {
+      throw new InfrastructureError(
+        `[purchase-orchestrator] Failed to claim pending purchase ${transactionId}: ${claimError.message}`,
+        claimError
+      );
+    }
+
+    const claimResult = Array.isArray(claimData) ? claimData[0] : claimData;
+    if (claimResult?.error_code === "sold_out") {
+      return { ok: false, purchase_id: claimResult.purchase_id, error_code: "sold_out" };
+    }
+
+    if (claimResult?.ok && claimResult.purchase_id) {
+      return { ok: true, purchase_id: String(claimResult.purchase_id) };
+    }
+
+    return { ok: false, purchase_id: claimResult?.purchase_id, already_claimed: true, reason: "already_claimed" };
+  }
+
+  const updateBuilder = supabaseClient.from("purchases").update({ status: "processing" });
+
+  if (purchaseId) {
+    updateBuilder.eq("id", purchaseId);
+  } else {
+    updateBuilder.eq("developer_id", developerId);
+    updateBuilder.eq("item_id", itemId);
+    updateBuilder.eq("provider", provider);
+    updateBuilder.eq("status", "pending");
+    if (transactionId) {
+      updateBuilder.eq("provider_tx_id", transactionId);
+    }
+  }
+
+  const { data: claimed, error } = await updateBuilder.select("id").maybeSingle();
+
+  if (error) {
+    throw new InfrastructureError(
+      `[purchase-orchestrator] Failed to claim pending purchase ${transactionId}: ${error.message}`,
+      error
+    );
+  }
+
+  if (!claimed) {
+    return { ok: false, purchase_id: purchaseId, reason: "not_found" };
+  }
+
+  return { ok: true, purchase_id: String(claimed.id ?? purchaseId ?? developerId) };
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces a shared purchase orchestration layer to centralize payment fulfillment across all supported payment providers while preserving the existing payment verification flow and public APIs.

### Changes made

* Added a provider-agnostic `purchase-orchestrator` service to coordinate shared fulfillment steps.
* Refactored Stripe, Cashfree, NOWPayments, and AbacatePay webhook handlers to delegate fulfillment to the shared orchestrator after successful payment verification.
* Preserved provider-specific verification logic and existing webhook contracts.
* Reduced duplicated fulfillment logic across payment providers.
* Added regression tests for the new orchestration flow to ensure existing behavior remains unchanged.

## Related issue

Fixes #1042

## Screenshots

N/A – Backend architectural refactor with no user-facing UI changes.

## Checklist

* [x] `npm run lint` passes *(mark this only after you've run it successfully)*
* [x] Tested locally
* [x] No secrets or `.env` values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ I have starred this repository!
