### PR TITLE
docs : added JSDoc to cityCache.ts exported functions

### DIFF
--- a/src/lib/cityCache.ts
+++ b/src/lib/cityCache.ts
@@ -25,6 +25,7 @@ let cache: CityCache | null = null;
 
 const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Returns the cached city data if present and not expired, otherwise null. */
 export function getCityCache(): CityCache | null {
   if (!cache) return null;
   if (Date.now() - cache.timestamp > MAX_AGE_MS) {
@@ -34,10 +35,12 @@ export function getCityCache(): CityCache | null {
   return cache;
 }
 
+/** Stores city data in the module-level cache with a fresh timestamp. */
 export function setCityCache(data: Omit<CityCache, "timestamp">) {
   cache = { ...data, timestamp: Date.now() };
 }
 
+/** Invalidates the module-level cache. */
 export function clearCityCache() {
   cache = null;
 }


### PR DESCRIPTION
## Summary of What Has Been Done

Added JSDoc comments to the three exported functions in `src/lib/cityCache.ts`:
- `getCityCache`: returns the cached city data if present and not expired
- `setCityCache`: stores city data in the module-level cache with a fresh timestamp
- `clearCityCache`: invalidates the module-level cache

These comments follow the same single-line style used in `xp.ts` and `supabase-server.ts`.

## Changes Made

- `src/lib/cityCache.ts`: Added JSDoc comments to `getCityCache`, `setCityCache`, and `clearCityCache`.

## Impact it Made

- Improves API discoverability and IDE autocomplete for developers working with the city cache.
- Aligns `cityCache.ts` with the documentation conventions established across the codebase.

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1073
