### PR TITLE
fix : added try/catch error handling around sendNotificationAsync in streak.ts

### DIFF
--- a/src/lib/notification-senders/streak.ts
+++ b/src/lib/notification-senders/streak.ts
@@ -24,27 +24,33 @@ export function sendStreakMilestoneNotification(
     ? `<p style="color: #ffa116; font-size: 14px;">Reward unlocked: <strong>${rewardItemName}</strong></p>`
     : "";
 
-  sendNotificationAsync({
-    type: "streak_milestone",
-    category: "social",
-    developerId: devId,
-    dedupKey: `streak_milestone:${devId}:${streak}`,
-    title: `${streak}-day streak! ${milestoneInfo.tagline}`,
-    body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
-    html: `
-      <div style="text-align: center;">
-        <p style="font-size: 40px; margin: 0;">${milestoneInfo.emoji}</p>
-        <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">${streak}-day streak!</p>
-        <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">${milestoneInfo.tagline}</p>
-      </div>
-      ${rewardHtml}
-      <p style="color: #666; font-size: 13px; text-align: center;">
-        Longest streak: ${longestStreak} days
-      </p>
-      ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
-    `,
-    actionUrl: `${BASE_URL}/?user=${login}`,
-    priority: "high", // Streak milestones are celebratory, send immediately
-    channels: ["email"],
-  });
+  void (async () => {
+    try {
+      await sendNotificationAsync({
+        type: "streak_milestone",
+        category: "social",
+        developerId: devId,
+        dedupKey: `streak_milestone:${devId}:${streak}`,
+        title: `${streak}-day streak! ${milestoneInfo.tagline}`,
+        body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
+        html: `
+          <div style="text-align: center;">
+            <p style="font-size: 40px; margin: 0;">${milestoneInfo.emoji}</p>
+            <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">${streak}-day streak!</p>
+            <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">${milestoneInfo.tagline}</p>
+          </div>
+          ${rewardHtml}
+          <p style="color: #666; font-size: 13px; text-align: center;">
+            Longest streak: ${longestStreak} days
+          </p>
+          ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
+        `,
+        actionUrl: `${BASE_URL}/?user=${login}`,
+        priority: "high", // Streak milestones are celebratory, send immediately
+        channels: ["email"],
+      });
+    } catch (err: unknown) {
+      console.error("[streak] notification failed", err);
+    }
+  })();
 }


### PR DESCRIPTION
## Summary of What Has Been Done

Wrapped the `sendNotificationAsync` call in `sendStreakMilestoneNotification` inside an async IIFE with a try/catch block, following the same defensive pattern used in `src/lib/achievements.ts`.

## Changes Made

- `src/lib/notification-senders/streak.ts`: Wrapped the `sendNotificationAsync` call in `void (async () => { try { ... } catch (err) { console.error(...) } })()` to prevent unhandled rejections and log failures with context.

## Impact it Made

- Prevents unhandled promise rejections from propagating in edge cases.
- Provides structured error visibility for streak notification delivery failures.

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1074
