### PR TITLE
feat : added GET /api/stats public endpoint for aggregate city statistics

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+/** Returns aggregate platform statistics without authentication. */
+export async function GET() {
+  const sb = getSupabaseAdmin();
+
+  const [{ data: devs, error: devsError }, { data: topDevs, error: topError }] = await Promise.all([
+    sb
+      .from("developers")
+      .select("contributions", { count: "exact", head: true }),
+    sb
+      .from("developers")
+      .select("github_login, contributions, total_stars")
+      .order("contributions", { ascending: false })
+      .limit(10),
+  ]);
+
+  if (devsError) {
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
+  }
+
+  return NextResponse.json(
+    {
+      total_developers: devs?.count ?? 0,
+      top_contributors: topDevs ?? [],
+      fetched_at: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": "public, s-maxage=300" } },
+  );
+}


### PR DESCRIPTION
## Summary of What Has Been Done

Created a new public API endpoint `GET /api/stats` that returns aggregate platform statistics including total developer count and top contributors by contributions and stars.

## Changes Made

- Added `src/app/api/stats/route.ts` with a `GET` handler that queries the `developers` table for aggregate stats and top-10 contributors.
- Response is cacheable for 5 minutes (s-maxage=300) to reduce database load.

## Impact it Made

- Enables public dashboards and third-party tools to display platform-level statistics without authentication.
- Improves platform transparency and visibility of community growth.

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1081
