### PR TITLE
docs : added JSDoc to cashfree.ts exported functions

### DIFF
--- a/src/lib/cashfree.ts
+++ b/src/lib/cashfree.ts
@@ -37,6 +37,7 @@ interface CashfreeOrderResponse {
   order_status: string;
 }
 
+/** Creates a Cashfree order and returns the payment session ID and Cashfree order ID. */
 export async function createCashfreeOrder(opts: {
   orderId: string;
   amountINR: number; // in rupees (NOT paise)
@@ -109,6 +110,7 @@ export async function createCashfreeOrder(opts: {
 // ---------------------------------------------------------------------------
 // Verify Cashfree order status (called after return or from webhook)
 // ---------------------------------------------------------------------------
+/** Returns the current status of a Cashfree order including payment status and amount. */
 export async function getCashfreeOrderStatus(orderId: string): Promise<{
   orderStatus: string;
   paymentStatus: string;
@@ -143,6 +145,7 @@ export async function getCashfreeOrderStatus(orderId: string): Promise<{
 // Webhook signature verification
 // Signature = Base64(HMAC-SHA256(timestamp + rawBody, secretKey))
 // ---------------------------------------------------------------------------
+/** Verifies the HMAC-SHA256 signature of an incoming Cashfree webhook payload. */
 export function verifyCashfreeWebhook(
   signature: string,
   rawBody: string,
@@ -161,6 +164,7 @@ export function verifyCashfreeWebhook(
 // ---------------------------------------------------------------------------
 // Helper: Create a full checkout flow for shop items
 // ---------------------------------------------------------------------------
+/** Creates a full Cashfree checkout flow for a shop item, including order creation and session ID generation. */
 export async function createCashfreeCheckout(
   itemId: string,
   developerId: number,


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc type annotations to the four exported functions in `src/lib/cashfree.ts` (`createCashfreeOrder`, `getCashfreeOrderStatus`, `verifyCashfreeWebhook`, `createCashfreeCheckout`) to improve API discoverability and IDE support.

## Related issue

Fixes #1049

## Screenshots

N/A (non-visual change)

## Checklist

- [x] npm run lint passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] I have starred this repository!

## Note: please assign this PR to the `tmdeveloper007` account.
