### PR TITLE
docs : added JSDoc to rate-limit.ts helper functions

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -71,6 +71,7 @@ function rateLimitLocal(
 
 let redis: Redis | null = null;
 
+/** Returns the cached Upstash Redis client, or null if credentials are not configured. */
 function getRedis(): Redis | null {
   if (redis) return redis;
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -84,6 +85,7 @@ function getRedis(): Redis | null {
 // creating a new instance on every request (each carries its own Redis conn).
 const limiterCache = new Map<string, Ratelimit>();
 
+/** Returns a cached Ratelimit instance for the given limit/window config, or null if Redis is unavailable. */
 function getLimiter(limit: number, windowMs: number): Ratelimit | null {
   const r = getRedis();
   if (!r) return null;


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc type annotations to the `getRedis` and `getLimiter` helper functions in `src/lib/rate-limit.ts` to improve API discoverability and align with the documentation standard of the main `rateLimit` function.

## Related issue

Fixes #1050

## Screenshots

N/A (non-visual change)

## Checklist

- [x] npm run lint passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] I have starred this repository!

## Note: please assign this PR to the `tmdeveloper007` account.
