### PR TITLE
fix : upgraded broadcastToChannel error log severity from warn to error

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -156,7 +156,7 @@ export async function broadcastToChannel(
     });
   } catch (err) {
     // Fire and forget: broadcast failure should never block the API response.
-    console.warn("[supabase.ts] failed to broadcast realtime message:", err);
+    console.error("[supabase.ts] failed to broadcast realtime message:", err);
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Changes the error log level in `broadcastToChannel` from `console.warn` to `console.error` in `src/lib/supabase.ts` so that broadcast failures surface as actual errors in production monitoring systems rather than being silently logged as warnings.

## Related issue

Fixes #1052

## Screenshots

N/A (non-visual change)

## Checklist

- [x] npm run lint passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] I have starred this repository!

## Note: please assign this PR to the `tmdeveloper007` account.
