### PR TITLE
test: add unit tests for ComparisonPanel helpers

### DIFF
--- a/src/components/hud/ComparisonPanel.test.ts
+++ b/src/components/hud/ComparisonPanel.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { CityBuilding } from "@/lib/github";
+
+import {
+  DEV_CLASSES,
+  getDevClass,
+  buildComparisonRows,
+  getComparisonSummary,
+} from "./ComparisonPanel";
+
+describe("getDevClass", () => {
+  it("returns the same developer class for the same login", () => {
+    expect(getDevClass("octocat")).toBe(getDevClass("octocat"));
+  });
+
+  it("always returns one of the predefined developer classes", () => {
+    expect(DEV_CLASSES).toContain(getDevClass("octocat"));
+    expect(DEV_CLASSES).toContain(getDevClass("torvalds"));
+    expect(DEV_CLASSES).toContain(getDevClass(""));
+  });
+});
+
+const devA = {
+  login: "alice",
+  rank: 10,
+  contributions: 400,
+  total_stars: 200,
+  public_repos: 15,
+  kudos_count: 50,
+} as CityBuilding;
+
+const devB = {
+  login: "bob",
+  rank: 20,
+  contributions: 300,
+  total_stars: 100,
+  public_repos: 25,
+  kudos_count: 30,
+} as CityBuilding;
+
+
+describe("buildComparisonRows", () => {
+  it("calculates comparison rows correctly", () => {
+    const { cmpRows, totalAWins, totalBWins } =
+      buildComparisonRows([
+        devA as CityBuilding,
+        devB as CityBuilding,
+      ]);
+
+    expect(cmpRows).toHaveLength(5);
+
+    expect(totalAWins).toBeGreaterThan(totalBWins);
+  });
+});
+
+describe("getComparisonSummary", () => {
+  it("returns winner summary", () => {
+    expect(
+      getComparisonSummary([devA, devB], 4, 1)
+    ).toBe("@alice wins 4-1");
+  });
+
+  it("returns tie summary", () => {
+    expect(
+      getComparisonSummary([devA, devB], 2, 2)
+    ).toBe("Tie 2-2");
+  });
+});

--- a/src/components/hud/ComparisonPanel.tsx
+++ b/src/components/hud/ComparisonPanel.tsx
@@ -8,7 +8,7 @@ import { SearchFeedback } from "./SearchBar";
 import SearchBar from "@/components/SearchBar";
 import { CityBuilding } from "@/lib/github";
 
-const DEV_CLASSES = [
+export const DEV_CLASSES = [
   "Vibe Coder",
   "Stack Overflow Tourist",
   "Console.log Debugger",
@@ -41,13 +41,85 @@ const DEV_CLASSES = [
   "Sudo Make Me A Sandwich",
 ];
 
-function getDevClass(login: string) {
+export function getDevClass(login: string) {
   let h = 0;
   for (let i = 0; i < login.length; i++)
     h = ((h << 5) - h + login.charCodeAt(i)) | 0;
   return DEV_CLASSES[
     ((h % DEV_CLASSES.length) + DEV_CLASSES.length) % DEV_CLASSES.length
   ];
+}
+
+export function buildComparisonRows(
+  comparePair: CityBuilding[]
+) {
+  const compareStatDefs: {
+    label: string;
+    key: keyof CityBuilding;
+    invert?: boolean;
+  }[] = [
+      { label: "City Rank", key: "rank", invert: true },
+      { label: "Solved", key: "contributions" },
+      { label: "Reputation", key: "total_stars" },
+      { label: "LC Rank", key: "public_repos", invert: true },
+      { label: "Kudos", key: "kudos_count" },
+    ];
+
+  let totalAWins = 0;
+  let totalBWins = 0;
+
+  const cmpRows = compareStatDefs.map((s) => {
+    const a = (comparePair[0][s.key] as number) ?? 0;
+    const b = (comparePair[1][s.key] as number) ?? 0;
+
+    let aW = false;
+    let bW = false;
+
+    if (s.invert) {
+      aW = a > 0 && (a < b || b === 0);
+      bW = b > 0 && (b < a || a === 0);
+    } else {
+      aW = a > b;
+      bW = b > a;
+    }
+
+    if (aW) totalAWins++;
+    if (bW) totalBWins++;
+
+    return {
+      ...s,
+      a,
+      b,
+      aW,
+      bW,
+    };
+  });
+
+  return {
+    cmpRows,
+    totalAWins,
+    totalBWins,
+  };
+}
+
+export function getComparisonSummary(
+  comparePair: CityBuilding[],
+  totalAWins: number,
+  totalBWins: number
+) {
+  const cmpTie = totalAWins === totalBWins;
+
+  const cmpWinner =
+    totalAWins > totalBWins
+      ? comparePair[0].login
+      : comparePair[1].login;
+
+  return cmpTie
+    ? `Tie ${totalAWins}-${totalBWins}`
+    : `@${cmpWinner} wins ${Math.max(
+      totalAWins,
+      totalBWins
+    )}-${Math.min(totalAWins, totalBWins)}`;
 }
 
 export default function ComparisonPanel() {
@@ -177,41 +249,17 @@ export default function ComparisonPanel() {
 
   // ─── Case 2: Comparison stats panel is active ───
   if (comparePair && !flyMode) {
-    const compareStatDefs: {
-      label: string;
-      key: keyof CityBuilding;
-      invert?: boolean;
-    }[] = [
-      { label: "City Rank", key: "rank", invert: true },
-      { label: "Solved", key: "contributions" },
-      { label: "Reputation", key: "total_stars" },
-      { label: "LC Rank", key: "public_repos", invert: true },
-      { label: "Kudos", key: "kudos_count" },
-    ];
-    let totalAWins = 0;
-    let totalBWins = 0;
-    const cmpRows = compareStatDefs.map((s) => {
-      const a = (comparePair[0][s.key] as number) ?? 0;
-      const b = (comparePair[1][s.key] as number) ?? 0;
-      let aW = false,
-        bW = false;
-      if (s.invert) {
-        aW = a > 0 && (a < b || b === 0);
-        bW = b > 0 && (b < a || a === 0);
-      } else {
-        aW = a > b;
-        bW = b > a;
-      }
-      if (aW) totalAWins++;
-      if (bW) totalBWins++;
-      return { ...s, a, b, aW, bW };
-    });
-    const cmpTie = totalAWins === totalBWins;
-    const cmpWinner = totalAWins > totalBWins ? comparePair[0].login : comparePair[1].login;
-    const cmpSummary = cmpTie
-      ? `Tie ${totalAWins}-${totalBWins}`
-      : `@${cmpWinner} wins ${Math.max(totalAWins, totalBWins)}-${Math.min(totalAWins, totalBWins)}`;
+    const {
+      cmpRows,
+      totalAWins,
+      totalBWins,
+    } = buildComparisonRows(comparePair);
 
+    const cmpSummary = getComparisonSummary(
+      comparePair,
+      totalAWins,
+      totalBWins
+    );
     return (
       <div
         className="pointer-events-auto fixed z-40


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->

Refactored the comparison logic in `ComparisonPanel` into reusable helper functions to improve testability without changing UI behavior.

### Changes made

- Exported `DEV_CLASSES`
- Exported `getDevClass()`
- Extracted `buildComparisonRows()`
- Extracted `getComparisonSummary()`
- Added dedicated unit tests for:
  - Developer class generation
  - Comparison row calculations
  - Winner and tie summary generation

This approach improves coverage for the comparison logic while keeping the existing component behavior unchanged and avoiding additional testing dependencies.


## Related issue

<!-- Link to issue: Fixes #ISSUE_NUMBER -->
Fixes #1039 

## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

## Testing Notes

- [x] Tests added for extracted helper functions
- [x] `npx vitest run src/components/hud/ComparisonPanel.test.ts` passes
- [x] `npx tsc --noEmit` passes