### PR TITLE
fix: level 25 shows 'LeetCode Legend' instead of 'Legend'

### DIFF
--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -119,7 +119,7 @@ export function tierFromLevel(level: number): XpTier {
 
 /** Get rank info (title + tier) for a given level. */
 export function rankFromLevel(level: number): XpRank {
-  if (level >= 25) {
+  if (level > 25) {
     return { level, title: "Legend", tier: XP_TIERS[5] };
   }
   const rank = XP_RANKS.find((r) => r.level === level);


### PR DESCRIPTION
rankFromLevel had `>= 25` which caught level 25 before it could match 'LeetCode Legend' from RANK_TITLES. Changed to `> 25` so level 25 shows its proper title.