### PR TITLE
fix: add error handling to sendNotificationAsync call in streak.ts-#1059

### DIFF
--- a/src/lib/notification-senders/streak.ts
+++ b/src/lib/notification-senders/streak.ts
@@ -24,27 +24,31 @@ export function sendStreakMilestoneNotification(
     ? `<p style="color: #ffa116; font-size: 14px;">Reward unlocked: <strong>${rewardItemName}</strong></p>`
     : "";
 
-  sendNotificationAsync({
-    type: "streak_milestone",
-    category: "social",
-    developerId: devId,
-    dedupKey: `streak_milestone:${devId}:${streak}`,
-    title: `${streak}-day streak! ${milestoneInfo.tagline}`,
-    body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
-    html: `
-      <div style="text-align: center;">
-        <p style="font-size: 40px; margin: 0;">${milestoneInfo.emoji}</p>
-        <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">${streak}-day streak!</p>
-        <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">${milestoneInfo.tagline}</p>
-      </div>
-      ${rewardHtml}
-      <p style="color: #666; font-size: 13px; text-align: center;">
-        Longest streak: ${longestStreak} days
-      </p>
-      ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
-    `,
-    actionUrl: `${BASE_URL}/?user=${login}`,
-    priority: "high", // Streak milestones are celebratory, send immediately
-    channels: ["email"],
-  });
+  try {
+    sendNotificationAsync({
+      type: "streak_milestone",
+      category: "social",
+      developerId: devId,
+      dedupKey: `streak_milestone:${devId}:${streak}`,
+      title: `${streak}-day streak! ${milestoneInfo.tagline}`,
+      body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
+      html: `
+        <div style="text-align: center;">
+          <p style="font-size: 40px; margin: 0;">${milestoneInfo.emoji}</p>
+          <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">${streak}-day streak!</p>
+          <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">${milestoneInfo.tagline}</p>
+        </div>
+        ${rewardHtml}
+        <p style="color: #666; font-size: 13px; text-align: center;">
+          Longest streak: ${longestStreak} days
+        </p>
+        ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
+      `,
+      actionUrl: `${BASE_URL}/?user=${login}`,
+      priority: "high", // Streak milestones are celebratory, send immediately
+      channels: ["email"],
+    });
+  } catch (err: unknown) {
+    console.error("[streak] notification failed", err);
+  }
 }


### PR DESCRIPTION
Fixes #1059


## What does this PR do?

Wraps the `sendNotificationAsync` call in `src/lib/notification-senders/streak.ts` inside a `try/catch` block. This prevents silent failures or unhandled promise rejections if email/push notification sending fails, ensuring consistent error handling similar to `src/lib/achievements.ts`.

## Screenshots

N/A (No visual changes)

## Checklist

- [x] `npm run lint` passes (no new lint errors introduced in modified files)
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
