### PR TITLE
fix: add catch handler to touchLastActive promise chain-#1058

### DIFF
--- a/src/app/dungeon/page.tsx
+++ b/src/app/dungeon/page.tsx
@@ -526,7 +526,7 @@ export default function DungeonPage() {
     const bossStats = BOSS_MAP[problem.difficulty] ?? BOSS_MAP["Medium"];
     
     let playerDamage = 0;
-    let bossDamage = Math.floor(Math.random() * 5) + bossStats.baseDmg;
+    const bossDamage = Math.floor(Math.random() * 5) + bossStats.baseDmg;
     
     // Player's turn
     if (action === "attack") {

--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -1,5 +1,5 @@
 "use client";
-/* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/refs, react-hooks/immutability, react-hooks/purity, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/immutability, react-hooks/purity, @typescript-eslint/no-unused-vars */
 
 import * as THREE from "three";
 import { useRef, useMemo, useEffect } from "react";

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -2935,7 +2935,7 @@ export default function CityCanvas({
           requestAnimationFrame(runner);
         } catch (e) {
           // Best-effort only — surface warnings to make issues diagnosable in dev
-          // eslint-disable-next-line no-console
+           
           console.warn("CityCanvas: failed to enforce nearest filtering", e);
         }
 

--- a/src/components/RaidSequence3D.tsx
+++ b/src/components/RaidSequence3D.tsx
@@ -807,7 +807,7 @@ function SmokeTrail({ vehicleRef, active }: {
   if (!active) {
     particles.current = [];
   }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   }, [active]);
 
   useFrame((_, delta) => {
@@ -1780,7 +1780,7 @@ export default function RaidSequence3D({ phase, attacker, defender, raidData, on
           let vehicleX = topX;
           let vehicleY = topY + ORBIT_HEIGHT;
           let vehicleZ = topZ;
-          let lookAtTarget = defenderTopPos.clone();
+          const lookAtTarget = defenderTopPos.clone();
           let extraRotateZ = 0;
           let extraRotateX = 0;
 

--- a/src/components/weather/RainParticles.tsx
+++ b/src/components/weather/RainParticles.tsx
@@ -21,7 +21,7 @@ export function RainParticles({
 }: RainParticlesProps) {
   const pointsRef = useRef<THREE.Points>(null);
   const shaderMaterialRef = useRef<THREE.ShaderMaterial>(null);
-  // eslint-disable-next-line react-hooks/purity
+   
   const positions = useMemo(() => {
     const pos = new Float32Array(dropCount * 3);
 

--- a/src/lib/__tests__/notification-helpers.test.ts
+++ b/src/lib/__tests__/notification-helpers.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { touchLastActive } from "../notification-helpers";
+import { getSupabaseAdmin } from "../supabase";
+
+// Mock the getSupabaseAdmin client to intercept and inspect Supabase calls
+vi.mock("../supabase", () => {
+  const mockUpdate = vi.fn();
+  const mockEq = vi.fn();
+
+  const mockFrom = vi.fn(() => ({
+    update: mockUpdate,
+  }));
+
+  mockUpdate.mockReturnValue({
+    eq: mockEq,
+  });
+
+  const mockAdminClient = {
+    from: mockFrom,
+  };
+
+  return {
+    getSupabaseAdmin: () => mockAdminClient,
+  };
+});
+
+describe("touchLastActive", () => {
+  let consoleErrorSpy: { mockRestore: () => void };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("successfully updates last_active_at and calls then()", async () => {
+    const sbAdmin = getSupabaseAdmin();
+
+    // We stub eq to return an object with then() and catch()
+    const mockEqResult = {
+      then: function (resolve?: (value: { data: Record<string, unknown>; error: null }) => void) {
+        if (resolve) resolve({ data: {}, error: null });
+        return this;
+      },
+      catch: function () {
+        return this;
+      },
+    };
+    const mockUpdate = sbAdmin.from("developers").update as unknown as () => {
+      eq: { mockReturnValue: (val: unknown) => void };
+    };
+    mockUpdate().eq.mockReturnValue(mockEqResult);
+
+    touchLastActive(123);
+
+    expect(sbAdmin.from).toHaveBeenCalledWith("developers");
+    expect(sbAdmin.from("developers").update).toHaveBeenCalledWith(
+      expect.objectContaining({ last_active_at: expect.any(String) })
+    );
+    expect(mockUpdate().eq).toHaveBeenCalledWith("id", 123);
+  });
+
+  it("catches promise rejection/errors gracefully and logs them via console.error", async () => {
+    const sbAdmin = getSupabaseAdmin();
+    const error = new Error("Database connection timed out");
+
+    // We stub eq to return an object with then() and catch() that simulates a failure/rejection
+    const mockEqResult = {
+      then: function (_resolve?: unknown, reject?: (reason: unknown) => void) {
+        if (reject) reject(error);
+        return this;
+      },
+      catch: function (reject?: (reason: unknown) => void) {
+        if (reject) reject(error);
+        return this;
+      },
+    };
+    const mockUpdate = sbAdmin.from("developers").update as unknown as () => {
+      eq: { mockReturnValue: (val: unknown) => void };
+    };
+    mockUpdate().eq.mockReturnValue(mockEqResult);
+
+    touchLastActive(456);
+
+    // Wait for the Promise.resolve microtask to run
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error updating last active time for developer 456:",
+      error
+    );
+  });
+});

--- a/src/lib/notification-helpers.ts
+++ b/src/lib/notification-helpers.ts
@@ -81,11 +81,17 @@ export async function getPushTokens(devId: number): Promise<{ token: string; pla
  * Update last_active_at for a developer. Fire-and-forget.
  */
 export function touchLastActive(devId: number): void {
-  const sb = getSupabaseAdmin();
-  sb.from("developers")
-    .update({ last_active_at: new Date().toISOString() })
-    .eq("id", devId)
-    .then();
+  void (async () => {
+    try {
+      const sb = getSupabaseAdmin();
+      await sb
+        .from("developers")
+        .update({ last_active_at: new Date().toISOString() })
+        .eq("id", devId);
+    } catch (err: unknown) {
+      console.error(`Error updating last active time for developer ${devId}:`, err);
+    }
+  })();
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Adds a `.catch` handler to the `touchLastActive` Supabase update promise chain in `src/lib/notification-helpers.ts`. This ensures that any background database errors are logged gracefully instead of triggering an unhandled promise rejection, which is deprecated in Node.js and could cause process crashes. 

It also adds a unit test suite under `src/lib/__tests__/notification-helpers.test.ts` to verify success and failure paths.

## Related issue

Fixes #1058

## Screenshots

<!-- Before/after if visual changes -->
N/A (Backend logic improvement)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
