### PR TITLE
feat : added E.Arcade custom map CRUD endpoints

### DIFF
--- a/src/app/api/arcade/maps/[id]/route.ts
+++ b/src/app/api/arcade/maps/[id]/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { ArcadeMapService } from "@/services/arcadeMapService";
+
+const UpdateBodySchema = z.object({
+  name: z.string().min(1).max(128).optional(),
+  description: z.string().max(500).optional(),
+  category: z.string().min(1).max(64).optional(),
+  visibility: z.enum(["public", "unlisted"]).optional(),
+  map_json: z.record(z.unknown()).optional(),
+});
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const service = new ArcadeMapService();
+  const map = await service.getById(id);
+
+  if (!map) {
+    return NextResponse.json({ error: "Map not found" }, { status: 404 });
+  }
+
+  service.incrementPlayCount(id).catch(() => {});
+  return NextResponse.json({ map });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = UpdateBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", detail: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  let userId: number;
+  try {
+    const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
+    const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+    if (!auth.ok || !auth.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    userId = auth.user.id;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const service = new ArcadeMapService();
+  try {
+    const map = await service.update(
+      id,
+      {
+        name: parsed.data.name,
+        description: parsed.data.description,
+        category: parsed.data.category,
+        visibility: parsed.data.visibility,
+        mapJson: parsed.data.map_json,
+      },
+      userId,
+    );
+    return NextResponse.json({ map });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "Update failed";
+    if (msg.includes("not found")) return NextResponse.json({ error: msg }, { status: 404 });
+    if (msg.includes("Forbidden")) return NextResponse.json({ error: msg }, { status: 403 });
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  let userId: number;
+  try {
+    const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
+    const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+    if (!auth.ok || !auth.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    userId = auth.user.id;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const service = new ArcadeMapService();
+  try {
+    await service.delete(id, userId);
+    return new NextResponse(null, { status: 204 });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "Delete failed";
+    if (msg.includes("not found")) return NextResponse.json({ error: msg }, { status: 404 });
+    if (msg.includes("Forbidden")) return NextResponse.json({ error: msg }, { status: 403 });
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/arcade/maps/route.ts
+++ b/src/app/api/arcade/maps/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { ArcadeMapService } from "@/services/arcadeMapService";
+
+const ListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  category: z.string().optional(),
+  creator_id: z.coerce.number().int().optional(),
+});
+
+// GET /api/arcade/maps — list public maps
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const parsed = ListQuerySchema.safeParse({
+    page: url.searchParams.get("page") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+    category: url.searchParams.get("category") ?? undefined,
+    creator_id: url.searchParams.get("creator_id") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid query parameters", detail: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { page, limit, category, creator_id } = parsed.data;
+  const service = new ArcadeMapService();
+  const result = await service.list({ page, limit, category, creatorId: creator_id });
+  return NextResponse.json({ ...result, page, limit });
+}
+
+const CreateBodySchema = z.object({
+  slug: z.string().min(1).max(64).regex(/^[a-z0-9-]+$/),
+  name: z.string().min(1).max(128),
+  category: z.string().min(1).max(64),
+  description: z.string().max(500).optional(),
+  visibility: z.enum(["public", "unlisted"]).default("public"),
+  map_json: z.record(z.unknown()),
+});
+
+// POST /api/arcade/maps — create a new map
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = CreateBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", detail: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  let userId: number;
+  try {
+    const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
+    const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+    if (!auth.ok || !auth.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    userId = auth.user.id;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const service = new ArcadeMapService();
+  try {
+    const map = await service.create({
+      slug: parsed.data.slug,
+      name: parsed.data.name,
+      creatorId: userId,
+      category: parsed.data.category,
+      description: parsed.data.description,
+      visibility: parsed.data.visibility,
+      mapJson: parsed.data.map_json,
+    });
+    return NextResponse.json({ map }, { status: 201 });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "Failed to create map";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/services/arcadeMapService.ts
+++ b/src/services/arcadeMapService.ts
@@ -1,0 +1,140 @@
+/**
+ * Service for E.Arcade custom map CRUD operations.
+ */
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+export interface ArcadeMap {
+  id: string;
+  slug: string;
+  name: string;
+  creator_id: number;
+  category: string;
+  visibility: "public" | "unlisted";
+  map_json: Record<string, unknown>;
+  description: string | null;
+  play_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export class ArcadeMapService {
+  private sb = getSupabaseAdmin();
+
+  async list(params: {
+    page?: number;
+    limit?: number;
+    category?: string;
+    creatorId?: number;
+  }): Promise<{ maps: ArcadeMap[]; total: number }> {
+    const page = Math.max(1, params.page ?? 1);
+    const limit = Math.min(50, Math.max(1, params.limit ?? 20));
+    const offset = (page - 1) * limit;
+
+    let query = this.sb
+      .from("arcade_maps")
+      .select("id, slug, name, creator_id, category, visibility, description, play_count, created_at, updated_at", { count: "exact" })
+      .eq("visibility", "public")
+      .order("play_count", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (params.category) query = query.eq("category", params.category);
+    if (params.creatorId) query = query.eq("creator_id", params.creatorId);
+
+    const { data, error, count } = await query;
+    if (error) {
+      console.error("[arcadeMapService] list error:", error.message);
+      return { maps: [], total: 0 };
+    }
+    return { maps: (data ?? []) as ArcadeMap[], total: count ?? 0 };
+  }
+
+  async getById(id: string): Promise<ArcadeMap | null> {
+    const { data, error } = await this.sb
+      .from("arcade_maps")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (error || !data) return null;
+    return data as ArcadeMap;
+  }
+
+  async create(input: {
+    slug: string;
+    name: string;
+    creatorId: number;
+    category: string;
+    mapJson: Record<string, unknown>;
+    description?: string;
+    visibility?: "public" | "unlisted";
+  }): Promise<ArcadeMap> {
+    const { data, error } = await this.sb
+      .from("arcade_maps")
+      .insert({
+        slug: input.slug,
+        name: input.name,
+        creator_id: input.creatorId,
+        category: input.category,
+        visibility: input.visibility ?? "public",
+        description: input.description ?? null,
+        map_json: input.mapJson,
+        play_count: 0,
+      })
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to create map: ${error.message}`);
+    return data as ArcadeMap;
+  }
+
+  async update(
+    id: string,
+    input: Partial<{
+      name: string;
+      description: string;
+      category: string;
+      mapJson: Record<string, unknown>;
+      visibility: "public" | "unlisted";
+    }>,
+    requesterId: number,
+  ): Promise<ArcadeMap> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error("Map not found");
+    if (existing.creator_id !== requesterId) throw new Error("Forbidden: not the map creator");
+
+    const updates: Record<string, unknown> = {};
+    if (input.name !== undefined) updates.name = input.name;
+    if (input.description !== undefined) updates.description = input.description;
+    if (input.category !== undefined) updates.category = input.category;
+    if (input.mapJson !== undefined) updates.map_json = input.mapJson;
+    if (input.visibility !== undefined) updates.visibility = input.visibility;
+    updates.updated_at = new Date().toISOString();
+
+    const { data, error } = await this.sb
+      .from("arcade_maps")
+      .update(updates)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to update map: ${error.message}`);
+    return data as ArcadeMap;
+  }
+
+  async delete(id: string, requesterId: number): Promise<void> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error("Map not found");
+    if (existing.creator_id !== requesterId) throw new Error("Forbidden: not the map creator");
+
+    const { error } = await this.sb.from("arcade_maps").delete().eq("id", id);
+    if (error) throw new Error(`Failed to delete map: ${error.message}`);
+  }
+
+  async incrementPlayCount(id: string): Promise<void> {
+    this.sb
+      .from("arcade_maps")
+      .update({ play_count: this.sb.rpc("increment_arcade_map_play_count", { map_id: id }) })
+      .eq("id", id)
+      .then(() => {})
+      .catch(() => {});
+  }
+}


### PR DESCRIPTION
## Summary of What Has Been Done
- Created `ArcadeMapService` for map CRUD operations backed by Supabase
- Added REST endpoints for listing, creating, reading, updating, and deleting custom arcade maps

## Changes Made
New files:
- `src/services/arcadeMapService.ts` - service class with list, get, create, update, delete, incrementPlayCount methods
- `src/app/api/arcade/maps/route.ts` - GET (list with pagination/category/creator filters) + POST (create, auth required)
- `src/app/api/arcade/maps/[id]/route.ts` - GET (get by id, increment play count) + PATCH (update, auth required, creator only) + DELETE (auth required, creator only)

## Impact it Made
- Enables custom map creation and sharing in the E.Arcade
- Each map tracks play count for popularity sorting
- Creator-only update/delete prevents unauthorized modifications

Closes #1102

## Note: Please assign this PR to the `tmdeveloper007` account.