### PR TITLE
docs : added structured logging helpers for API route error tracking

### DIFF
--- a/src/lib/api-logger.ts
+++ b/src/lib/api-logger.ts
@@ -1,0 +1,58 @@
+/**
+ * Structured logging helper for API routes.
+ * Outputs consistent JSON to stdout for log aggregation tools.
+ */
+
+export interface ApiLogContext {
+  route: string;
+  reqId?: string;
+  userId?: number;
+  error?: unknown;
+  extra?: Record<string, unknown>;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err);
+}
+
+export function apiError(ctx: ApiLogContext): void {
+  const entry = {
+    level: "error",
+    route: ctx.route,
+    ...(ctx.reqId && { reqId: ctx.reqId }),
+    ...(ctx.userId && { userId: ctx.userId }),
+    message: ctx.error ? formatError(ctx.error) : undefined,
+    ...ctx.extra,
+    ts: new Date().toISOString(),
+  };
+  console.error(JSON.stringify(entry));
+}
+
+export function apiWarn(ctx: ApiLogContext): void {
+  const entry = {
+    level: "warn",
+    route: ctx.route,
+    ...(ctx.reqId && { reqId: ctx.reqId }),
+    ...(ctx.userId && { userId: ctx.userId }),
+    message: ctx.error ? formatError(ctx.error) : undefined,
+    ...ctx.extra,
+    ts: new Date().toISOString(),
+  };
+  // console.warn is not captured in all log aggregators, use stderr for consistency
+  console.error(JSON.stringify(entry));
+}
+
+export function apiInfo(ctx: ApiLogContext & { message: string }): void {
+  const entry = {
+    level: "info",
+    route: ctx.route,
+    ...(ctx.reqId && { reqId: ctx.reqId }),
+    ...(ctx.userId && { userId: ctx.userId }),
+    message: ctx.message,
+    ...ctx.extra,
+    ts: new Date().toISOString(),
+  };
+  console.log(JSON.stringify(entry));
+}


### PR DESCRIPTION
## Summary of What Has Been Done
- Created `src/lib/api-logger.ts` with structured logging functions for API routes
- Outputs consistent JSON to stdout/stderr for log aggregation tool compatibility

## Changes Made
New file: `src/lib/api-logger.ts`
- `apiError(ctx)` - logs errors with route, reqId, userId, and extra context
- `apiWarn(ctx)` - logs warnings with same structured context
- `apiInfo(ctx)` - logs informational messages with structured context
- All entries include a `ts` ISO timestamp and `level` field

## Impact it Made
- Structured JSON logs are easier to parse and analyze in log aggregation tools (Datadog, Loki, ELK)
- Consistent error context across all API routes
- Reduces noise in logs by standardizing format

Closes #1104

## Note: Please assign this PR to the `tmdeveloper007` account.