### PR TITLE
docs: add JSDoc to exported functions in cityCache.ts-#1061

### DIFF
--- a/src/lib/cityCache.ts
+++ b/src/lib/cityCache.ts
@@ -25,6 +25,16 @@ let cache: CityCache | null = null;
 
 const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Retrieve the current in-memory city cache, if it exists and has not expired.
+ *
+ * The cache is considered stale after {@link MAX_AGE_MS} milliseconds (5 minutes)
+ * from the time it was last populated. A stale cache is cleared automatically
+ * before returning so subsequent writes start fresh.
+ *
+ * @returns The cached {@link CityCache} object, or `null` if the cache is empty
+ *          or has expired.
+ */
 export function getCityCache(): CityCache | null {
   if (!cache) return null;
   if (Date.now() - cache.timestamp > MAX_AGE_MS) {
@@ -34,10 +44,27 @@ export function getCityCache(): CityCache | null {
   return cache;
 }
 
+/**
+ * Populate the in-memory city cache with fresh data.
+ *
+ * Automatically stamps the entry with the current time so that
+ * {@link getCityCache} can enforce the 5-minute TTL. Any previously
+ * cached value is overwritten.
+ *
+ * @param data - All {@link CityCache} fields except `timestamp`, which is
+ *               set internally to `Date.now()`.
+ */
 export function setCityCache(data: Omit<CityCache, "timestamp">) {
   cache = { ...data, timestamp: Date.now() };
 }
 
+/**
+ * Immediately invalidate the in-memory city cache.
+ *
+ * After this call, {@link getCityCache} will return `null` until
+ * {@link setCityCache} is called again. Useful when data is known to be
+ * stale (e.g. after a mutation) without waiting for the TTL to expire.
+ */
 export function clearCityCache() {
   cache = null;
 }


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc comments to the three exported functions in `src/lib/cityCache.ts`:

- **`getCityCache`** — Documents the return type (`CityCache | null`), the 5-minute TTL expiry behaviour, and automatic cache invalidation on stale reads.
- **`setCityCache`** — Documents the `data` parameter (all `CityCache` fields except `timestamp`), the auto-stamping side-effect, and cache overwrite behaviour.
- **`clearCityCache`** — Documents immediate cache invalidation and the recommended use-case (forcing a refresh after a mutation).

All comments follow the existing JSDoc style used in `src/lib/rate-limit.ts` and `src/lib/xp.ts`, including `{@link}` cross-references to related symbols and descriptive `@param` / `@returns` tags.

## Related issue

Fixes #1061

## Screenshots

N/A — documentation-only change, no visual impact.

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
