### PR TITLE
Add shared env parsing/validation utility (remove repeated parseInt(process.env...))

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { checkAchievements, countGifts } from "@/lib/achievements";
-
+import { getEnvNumber } from "@/lib/env";
 export const dynamic = "force-dynamic";
 
 interface LeetCodeProfile {
@@ -70,8 +70,7 @@ async function hashKey(key: string): Promise<string> {
 }
 
 async function isRateLimited(key: string): Promise<boolean> {
-  const rateLimitEnv = process.env.RATE_LIMIT_PER_HOUR ?? "15";
-  const RATE_LIMIT = parseInt(rateLimitEnv);
+  const RATE_LIMIT = getEnvNumber("RATE_LIMIT_PER_HOUR", 15, { min: 1 });
   const sb = getSupabaseAdmin();
   const ipHash = await hashKey(key);
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
@@ -195,15 +194,13 @@ export async function GET(
     .ilike("github_login", username)
     .single();
 
-  if (cached) {
-    const cacheTtlHours = process.env.CACHE_TTL_HOURS ?? "12";
-    const CACHE_TTL_MS = parseInt(cacheTtlHours) * 3600000;
-    const age = Date.now() - new Date(cached.fetched_at).getTime();
-    if (!forceRefresh && age < CACHE_TTL_MS) {
-      cachedRecord = cached;
-    }
+ if (cached) {
+  const CACHE_TTL_MS = getEnvNumber("CACHE_TTL_HOURS", 12, { min: 1 }) * 3600000;
+  const age = Date.now() - new Date(cached.fetched_at).getTime();
+  if (!forceRefresh && age < CACHE_TTL_MS) {
+    cachedRecord = cached;
   }
-
+}
   
   let rateLimitKey: string | null = null;
   let isAuthenticatedUser = false;

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,47 @@
+import { getEnvNumber } from "@/lib/env";
+
+describe("getEnvNumber", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.TEST_ENV_NUM;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns valid numeric value", () => {
+    process.env.TEST_ENV_NUM = "42";
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(42);
+  });
+
+  it("returns fallback when env var is missing", () => {
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(10);
+  });
+
+  it("returns fallback for invalid numeric input", () => {
+    process.env.TEST_ENV_NUM = "abc";
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(10);
+  });
+
+  it("returns fallback when below min (fallback mode)", () => {
+    process.env.TEST_ENV_NUM = "0";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1 })).toBe(10);
+  });
+
+  it("returns fallback when above max (fallback mode)", () => {
+    process.env.TEST_ENV_NUM = "100";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { max: 50 })).toBe(10);
+  });
+
+  it("clamps to min/max in clamp mode", () => {
+    process.env.TEST_ENV_NUM = "0";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1, max: 50, outOfRange: "clamp" })).toBe(1);
+
+    process.env.TEST_ENV_NUM = "100";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1, max: 50, outOfRange: "clamp" })).toBe(50);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,48 @@
+type EnvNumberOptions = {
+  min?: number;
+  max?: number;
+  outOfRange?: "fallback" | "clamp";
+};
+
+export function getEnvString(name: string, fallback = ""): string {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+  return raw;
+}
+
+export function getEnvBoolean(name: string, fallback = false): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+
+  return fallback;
+}
+
+export function getEnvNumber(
+  name: string,
+  fallback: number,
+  options: EnvNumberOptions = {}
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+
+  const { min, max, outOfRange = "fallback" } = options;
+
+  if (outOfRange === "clamp") {
+    let value = parsed;
+    if (typeof min === "number") value = Math.max(min, value);
+    if (typeof max === "number") value = Math.min(max, value);
+    return value;
+  }
+
+  if (typeof min === "number" && parsed < min) return fallback;
+  if (typeof max === "number" && parsed > max) return fallback;
+
+  return parsed;
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Introduce a centralized, typed environment variable parsing utility and migrate API routes to use it instead of inline parseInt(process.env...) logic.
This should ensure all operational config values (rate limits, TTLs, timeouts, pagination caps, etc.) are parsed safely, validated, and consistently defaulted. -->

## Related issue

<!-- Link to issue: Fixes #1093 -->
## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
