### PR TITLE
Add shared env parsing/validation utility (remove repeated parseInt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "three": "^0.183.0",
         "viem": "^2.54.3",
         "wagmi": "^3.6.21",
-        "web-push": "^3.6.7"
+        "web-push": "^3.6.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@emnapi/core": "^1.10.0",
@@ -13674,10 +13675,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "devOptional": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "three": "^0.183.0",
     "viem": "^2.54.3",
     "wagmi": "^3.6.21",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@emnapi/core": "^1.10.0",

--- a/src/app/api/achievements/[developerId]/route.ts
+++ b/src/app/api/achievements/[developerId]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { validateParams } from "@/lib/validation";
+import { developerIdParamSchema } from "@/lib/validation/schemas";
 
 /**
  * @param {{ params: any }} context
@@ -8,11 +10,11 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ developerId: string }> }
 ) {
-  const { developerId: devIdStr } = await params;
-  const developerId = parseInt(devIdStr, 10);
-  if (isNaN(developerId)) {
-    return NextResponse.json({ error: "Invalid developer ID" }, { status: 400 });
+  const paramValidation = validateParams(developerIdParamSchema, await params);
+  if (!paramValidation.success) {
+    return paramValidation.response;
   }
+  const { developerId } = paramValidation.data;
 
   const sb = getSupabaseAdmin();
 

--- a/src/app/api/arcade/rooms/__tests__/route.validation.test.ts
+++ b/src/app/api/arcade/rooms/__tests__/route.validation.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "../route";
+
+const { mockGetSupabaseAdmin } = vi.hoisted(() => ({
+  mockGetSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: mockGetSupabaseAdmin,
+}));
+
+describe("/api/arcade/rooms validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for out-of-range pagination query values", async () => {
+    const response = await GET(
+      new Request("https://theleetcodecity.tech/api/arcade/rooms?page=0&limit=200") as never,
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json).toMatchObject({
+      error: "Validation failed",
+      details: expect.arrayContaining([
+        expect.objectContaining({ field: "query.page" }),
+        expect.objectContaining({ field: "query.limit" }),
+      ]),
+    });
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/arcade/rooms/route.ts
+++ b/src/app/api/arcade/rooms/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { validateQuery } from "@/lib/validation";
+import { arcadeRoomsQuerySchema } from "@/lib/validation/schemas";
 
 // GET /api/arcade/rooms — list rooms with search, category, pagination
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
-  const search = url.searchParams.get("q")?.trim();
-  const category = url.searchParams.get("category");
-  const featured = url.searchParams.get("featured");
-  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
-  const limit = Math.min(50, Math.max(1, parseInt(url.searchParams.get("limit") ?? "20", 10)));
+  const queryValidation = validateQuery(arcadeRoomsQuerySchema, url.searchParams);
+  if (!queryValidation.success) {
+    return queryValidation.response;
+  }
+
+  const { q: search, category, featured, page, limit } = queryValidation.data;
   const offset = (page - 1) * limit;
 
   const sb = getSupabaseAdmin();
@@ -41,7 +44,7 @@ export async function GET(req: NextRequest) {
     query = query.eq("category", category);
   }
 
-  if (featured === "true") {
+  if (featured === true) {
     query = query.eq("is_featured", true);
   }
 

--- a/src/app/api/arena/stats/[username]/route.ts
+++ b/src/app/api/arena/stats/[username]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { validateParams } from "@/lib/validation";
+import { usernameParamSchema } from "@/lib/validation/schemas";
 
 import { getAuthenticatedDeveloper } from "@/lib/arena";
 
@@ -16,8 +18,12 @@ export async function GET(
   request: NextRequest,
   props: { params: Promise<{ username: string }> }
 ) {
-  const params = await props.params;
-  const username = params.username.toLowerCase();
+  const paramValidation = validateParams(usernameParamSchema, await props.params);
+  if (!paramValidation.success) {
+    return paramValidation.response;
+  }
+
+  const username = paramValidation.data.username.toLowerCase();
   const sb = getSupabaseAdmin();
 
   // 1. Fetch developer by username

--- a/src/app/api/dev/[username]/__tests__/route.validation.test.ts
+++ b/src/app/api/dev/[username]/__tests__/route.validation.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "../route";
+
+const { mockGetSupabaseAdmin } = vi.hoisted(() => ({
+  mockGetSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: mockGetSupabaseAdmin,
+}));
+
+describe("/api/dev/[username] validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for invalid username params before running business logic", async () => {
+    const response = await GET(
+      new Request("https://theleetcodecity.tech/api/dev/bad%20name"),
+      { params: Promise.resolve({ username: "bad name" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json).toMatchObject({
+      error: "Validation failed",
+      details: [
+        expect.objectContaining({
+          field: "params.username",
+        }),
+      ],
+    });
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid refresh query values", async () => {
+    const response = await GET(
+      new Request("https://theleetcodecity.tech/api/dev/rajdeep?refresh=maybe"),
+      { params: Promise.resolve({ username: "rajdeep" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json).toMatchObject({
+      error: "Validation failed",
+      details: [
+        expect.objectContaining({
+          field: "query.refresh",
+        }),
+      ],
+    });
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { checkAchievements, countGifts } from "@/lib/achievements";
 import { getEnvNumber } from "@/lib/env";
+import { validateParams, validateQuery } from "@/lib/validation";
+import { devQuerySchema, usernameParamSchema } from "@/lib/validation/schemas";
 export const dynamic = "force-dynamic";
 
 interface LeetCodeProfile {
@@ -182,9 +184,18 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ username: string }> }
 ) {
-  const { username } = await params;
+  const paramValidation = validateParams(usernameParamSchema, await params);
+  if (!paramValidation.success) {
+    return paramValidation.response;
+  }
+
+  const { username } = paramValidation.data;
   const { searchParams } = new URL(request.url);
-  const forceRefresh = searchParams.get("refresh") === "true";
+  const queryValidation = validateQuery(devQuerySchema, searchParams);
+  if (!queryValidation.success) {
+    return queryValidation.response;
+  }
+  const { refresh: forceRefresh } = queryValidation.data;
   const sb = getSupabaseAdmin();
 
   let cachedRecord = null;

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { checkAchievements, countGifts } from "@/lib/achievements";
-
+import { getEnvNumber } from "@/lib/env";
 export const dynamic = "force-dynamic";
 
 interface LeetCodeProfile {
@@ -70,8 +70,7 @@ async function hashKey(key: string): Promise<string> {
 }
 
 async function isRateLimited(key: string): Promise<boolean> {
-  const rateLimitEnv = process.env.RATE_LIMIT_PER_HOUR ?? "15";
-  const RATE_LIMIT = parseInt(rateLimitEnv);
+  const RATE_LIMIT = getEnvNumber("RATE_LIMIT_PER_HOUR", 15, { min: 1 });
   const sb = getSupabaseAdmin();
   const ipHash = await hashKey(key);
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
@@ -195,15 +194,13 @@ export async function GET(
     .ilike("github_login", username)
     .single();
 
-  if (cached) {
-    const cacheTtlHours = process.env.CACHE_TTL_HOURS ?? "12";
-    const CACHE_TTL_MS = parseInt(cacheTtlHours) * 3600000;
-    const age = Date.now() - new Date(cached.fetched_at).getTime();
-    if (!forceRefresh && age < CACHE_TTL_MS) {
-      cachedRecord = cached;
-    }
+ if (cached) {
+  const CACHE_TTL_MS = getEnvNumber("CACHE_TTL_HOURS", 12, { min: 1 }) * 3600000;
+  const age = Date.now() - new Date(cached.fetched_at).getTime();
+  if (!forceRefresh && age < CACHE_TTL_MS) {
+    cachedRecord = cached;
   }
-
+}
   
   let rateLimitKey: string | null = null;
   let isAuthenticatedUser = false;

--- a/src/app/api/github/[username]/__tests__/route.test.ts
+++ b/src/app/api/github/[username]/__tests__/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "../route";
+
+describe("/api/github/[username] validation", () => {
+  it("redirects valid usernames to /api/dev", async () => {
+    const response = await GET(
+      new Request("https://theleetcodecity.tech/api/github/rajdeep"),
+      { params: Promise.resolve({ username: "rajdeep" }) },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://theleetcodecity.tech/api/dev/rajdeep",
+    );
+  });
+
+  it("returns 400 with field-level errors for invalid usernames", async () => {
+    const response = await GET(
+      new Request("https://theleetcodecity.tech/api/github/bad%20name"),
+      { params: Promise.resolve({ username: "bad name" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json).toMatchObject({
+      error: "Validation failed",
+      details: [
+        expect.objectContaining({
+          field: "params.username",
+        }),
+      ],
+    });
+  });
+});

--- a/src/app/api/github/[username]/route.ts
+++ b/src/app/api/github/[username]/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { validateParams } from "@/lib/validation";
+import { usernameParamSchema } from "@/lib/validation/schemas";
 
 /**
  * @param {{ params: any }} context
@@ -7,7 +9,12 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ username: string }> }
 ) {
-  const { username } = await params;
+  const paramValidation = validateParams(usernameParamSchema, await params);
+  if (!paramValidation.success) {
+    return paramValidation.response;
+  }
+
+  const { username } = paramValidation.data;
   return NextResponse.redirect(
     new URL(`/api/dev/${encodeURIComponent(username)}`, _request.url)
   );

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,47 @@
+import { getEnvNumber } from "@/lib/env";
+
+describe("getEnvNumber", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.TEST_ENV_NUM;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns valid numeric value", () => {
+    process.env.TEST_ENV_NUM = "42";
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(42);
+  });
+
+  it("returns fallback when env var is missing", () => {
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(10);
+  });
+
+  it("returns fallback for invalid numeric input", () => {
+    process.env.TEST_ENV_NUM = "abc";
+    expect(getEnvNumber("TEST_ENV_NUM", 10)).toBe(10);
+  });
+
+  it("returns fallback when below min (fallback mode)", () => {
+    process.env.TEST_ENV_NUM = "0";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1 })).toBe(10);
+  });
+
+  it("returns fallback when above max (fallback mode)", () => {
+    process.env.TEST_ENV_NUM = "100";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { max: 50 })).toBe(10);
+  });
+
+  it("clamps to min/max in clamp mode", () => {
+    process.env.TEST_ENV_NUM = "0";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1, max: 50, outOfRange: "clamp" })).toBe(1);
+
+    process.env.TEST_ENV_NUM = "100";
+    expect(getEnvNumber("TEST_ENV_NUM", 10, { min: 1, max: 50, outOfRange: "clamp" })).toBe(50);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,48 @@
+type EnvNumberOptions = {
+  min?: number;
+  max?: number;
+  outOfRange?: "fallback" | "clamp";
+};
+
+export function getEnvString(name: string, fallback = ""): string {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+  return raw;
+}
+
+export function getEnvBoolean(name: string, fallback = false): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+
+  return fallback;
+}
+
+export function getEnvNumber(
+  name: string,
+  fallback: number,
+  options: EnvNumberOptions = {}
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw.trim() === "") return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+
+  const { min, max, outOfRange = "fallback" } = options;
+
+  if (outOfRange === "clamp") {
+    let value = parsed;
+    if (typeof min === "number") value = Math.max(min, value);
+    if (typeof max === "number") value = Math.min(max, value);
+    return value;
+  }
+
+  if (typeof min === "number" && parsed < min) return fallback;
+  if (typeof max === "number" && parsed > max) return fallback;
+
+  return parsed;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -7,7 +7,7 @@ type EnvNumberOptions = {
 export function getEnvString(name: string, fallback = ""): string {
   const raw = process.env[name];
   if (raw === undefined || raw === null || raw.trim() === "") return fallback;
-  return raw;
+  return raw.trim();
 }
 
 export function getEnvBoolean(name: string, fallback = false): boolean {

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { z, type ZodType } from "zod";
+
+type ValidationSuccess<T> = { success: true; data: T };
+type ValidationFailure = { success: false; response: NextResponse };
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+type ValidationSource = "params" | "query" | "body";
+
+function formatValidationError(error: z.ZodError, source: ValidationSource) {
+  return {
+    error: "Validation failed",
+    details: error.issues.map((issue) => ({
+      field: [source, ...issue.path].filter(Boolean).join("."),
+      message: issue.message,
+      code: issue.code,
+    })),
+  };
+}
+
+export function validationErrorResponse(error: z.ZodError, source: ValidationSource) {
+  return NextResponse.json(formatValidationError(error, source), { status: 400 });
+}
+
+function parse<T>(schema: ZodType<T>, input: unknown, source: ValidationSource): ValidationResult<T> {
+  const parsed = schema.safeParse(input);
+  if (parsed.success) {
+    return { success: true, data: parsed.data };
+  }
+  return { success: false, response: validationErrorResponse(parsed.error, source) };
+}
+
+export function validateParams<T>(schema: ZodType<T>, params: unknown): ValidationResult<T> {
+  return parse(schema, params, "params");
+}
+
+export function validateQuery<T>(
+  schema: ZodType<T>,
+  searchParams: URLSearchParams,
+): ValidationResult<T> {
+  const query = Object.fromEntries(searchParams.entries());
+  return parse(schema, query, "query");
+}
+
+export async function validateJsonBody<T>(
+  request: Request,
+  schema: ZodType<T>,
+): Promise<ValidationResult<T>> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      success: false,
+      response: NextResponse.json(
+        {
+          error: "Validation failed",
+          details: [
+            {
+              field: "body",
+              message: "Request body must be valid JSON.",
+              code: "invalid_json",
+            },
+          ],
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return parse(schema, body, "body");
+}

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const queryNumber = (defaultValue: number, min: number, max: number) =>
+  z.preprocess(
+    (value) => (value === "" || value === undefined || value === null ? undefined : value),
+    z.coerce.number().int().min(min).max(max).default(defaultValue),
+  );
+
+const queryBoolean = () =>
+  z.preprocess(
+    (value) => {
+      if (value === undefined || value === null || value === "") return undefined;
+      if (typeof value === "boolean") return value;
+      if (typeof value === "string") {
+        if (value === "true" || value === "1") return true;
+        if (value === "false" || value === "0") return false;
+      }
+      return value;
+    },
+    z.boolean(),
+  );
+
+export const usernameSchema = z
+  .string()
+  .trim()
+  .min(1, "Username is required.")
+  .max(39, "Username must be at most 39 characters.")
+  .regex(
+    /^[A-Za-z0-9](?:[A-Za-z0-9_-]{0,37}[A-Za-z0-9])?$/,
+    "Username may only contain letters, numbers, underscores, and hyphens.",
+  );
+
+export const usernameParamSchema = z.object({
+  username: usernameSchema,
+});
+
+export const developerIdParamSchema = z.object({
+  developerId: z.coerce.number().int().min(1),
+});
+
+export const paginationQuerySchema = z.object({
+  page: queryNumber(1, 1, 100000),
+  limit: queryNumber(20, 1, 50),
+  sort: z.enum(["asc", "desc"]).optional(),
+});
+
+export const arcadeRoomsQuerySchema = paginationQuerySchema.extend({
+  q: z.string().trim().min(1).max(100).optional(),
+  category: z.string().trim().min(1).max(50).optional(),
+  featured: queryBoolean().optional(),
+});
+
+export const devQuerySchema = z.object({
+  refresh: queryBoolean().default(false),
+});


### PR DESCRIPTION
## What does this PR do?
Introduce a centralized, typed environment variable parsing utility and migrate API routes to use it instead of inline parseInt(process.env...) logic.This should ensure all operational config values (rate limits, TTLs, timeouts, pagination caps, etc.) are parsed safely, validated, and consistently defaulted.

## Related issue
Link to issue: Fixes #1093 

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
