### PR TITLE
feat : make in-process rate limiter fallback configurable via environment variables

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -29,8 +29,10 @@ interface Entry {
 
 const store = new Map<string, Entry>();
 let lastCleanup = Date.now();
-const CLEANUP_INTERVAL = 60_000;
-export let MAX_STORE_SIZE = 10_000;
+const CLEANUP_INTERVAL =
+  Number(process.env.RATE_LIMIT_CLEANUP_INTERVAL_MS) || 60_000;
+export let MAX_STORE_SIZE =
+  Number(process.env.RATE_LIMIT_MAX_STORE_SIZE) || 10_000;
 
 export function _setMaxStoreSizeForTesting(size: number): void {
   MAX_STORE_SIZE = size;


### PR DESCRIPTION
Closes #1133

## Summary of What Has Been Done

Made the in-process fallback rate limiter in `src/lib/rate-limit.ts` configurable via environment variables instead of hardcoded constants.

## Changes Made

- `RATE_LIMIT_CLEANUP_INTERVAL_MS` env var controls the cleanup interval (default: 60000ms)
- `RATE_LIMIT_MAX_STORE_SIZE` env var controls the max store size (default: 10000)
- Existing `Number()` conversion handles invalid/missing values gracefully
- Test helper `_setMaxStoreSizeForTesting` continues to work correctly

## Impact it Made

- Operators can tune memory usage of the in-process fallback without code changes
- No changes to production behavior (Upstash Redis path unchanged)
- Existing tests continue to pass

## Note

Please assign this PR to the `tmdeveloper007` account.