### PR TITLE
fix : prevent duplicate takeoff audio on raid sequence execution

### DIFF
--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -107,7 +107,6 @@ export function useRaidSequence(): [RaidState, RaidActions] {
     // Audio triggers
     switch (phase) {
       case "intro":
-        preloadRaidAudio();
         playRaidSound("takeoff");
         break;
       case "flight":
@@ -254,7 +253,8 @@ export function useRaidSequence(): [RaidState, RaidActions] {
           };
         });
 
-        // Set phase using setPhase so all audio preloading and fallback timers are set up!
+        // Preload audio before starting the intro phase to avoid duplicate playback
+        preloadRaidAudio();
         setPhase("intro");
 
         


### PR DESCRIPTION
Closes #1135

## Summary of What Has Been Done

Fixed the duplicate takeoff audio issue in `src/lib/useRaidSequence.ts` by moving the `preloadRaidAudio()` call out of `setPhase("intro")` and into `executeRaid`, where it is called exactly once before the intro phase starts.

## Changes Made

- Removed `preloadRaidAudio()` from `setPhase("intro")` case
- Added `preloadRaidAudio()` call in `executeRaid` before `setPhase("intro")`
- `playRaidSound("takeoff")` continues to be called inside `setPhase("intro")`

## Impact it Made

- Eliminates the duplicate takeoff sound on raid sequence execution
- Audio preloading still happens exactly once per raid execution
- No changes to any other phase audio behavior

## Note

Please assign this PR to the `tmdeveloper007` account.