### PR TITLE
feat: make in-process rate limiter fallback configurable via environment variables

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -29,8 +29,10 @@ interface Entry {
 
 const store = new Map<string, Entry>();
 let lastCleanup = Date.now();
-const CLEANUP_INTERVAL = 60_000;
-export let MAX_STORE_SIZE = 10_000;
+const CLEANUP_INTERVAL =
+  Number(process.env.RATE_LIMIT_CLEANUP_INTERVAL_MS) || 60_000;
+export let MAX_STORE_SIZE =
+  Number(process.env.RATE_LIMIT_MAX_STORE_SIZE) || 10_000;
 
 export function _setMaxStoreSizeForTesting(size: number): void {
   MAX_STORE_SIZE = size;


### PR DESCRIPTION
## Summary of What Has Been Done

Made the in-process rate limiter fallback in `src/lib/rate-limit.ts` configurable via environment variables, replacing hardcoded constants.

## Changes Made

- `CLEANUP_INTERVAL`: now reads from `RATE_LIMIT_CLEANUP_INTERVAL_MS` env var, falls back to `60000` ms (1 minute) when unset
- `MAX_STORE_SIZE`: now reads from `RATE_LIMIT_MAX_STORE_SIZE` env var, falls back to `10000` entries when unset

## Impact it Made

Allows operators to tune the in-process fallback rate limiter's memory footprint and cleanup frequency via environment configuration without code changes. This is especially useful in local development and CI environments where the Upstash Redis backend is unavailable.

Note: Please assign this PR to the `tmdeveloper007` account.
