### PR TITLE
perf: add cache headers to city API

### DIFF
--- a/src/app/api/city/route.ts
+++ b/src/app/api/city/route.ts
@@ -32,6 +32,9 @@ export async function GET(request: Request) {
 
   return NextResponse.json(result.body, {
     status: result.status,
-    headers: result.headers,
+    headers: {
+      ...result.headers,
+      "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+    },
   });
 }


### PR DESCRIPTION
## What does this PR do?

Adds a Cache-Control header to the public GET /api/city success response so repeat city-data requests can be cached briefly while still allowing stale-while-revalidate freshness.

Changes:
- preserves existing headers returned by CityService
- adds Cache-Control: public, max-age=60, stale-while-revalidate=300 on successful responses
- leaves pagination validation and error responses unchanged

## Related issue

Fixes #1115

## Screenshots

Not applicable: backend API response header change only.

## Checklist

- [ ] npm run lint passes
- [x] Tested locally
- [x] No secrets or env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository

Validation run locally:
- git diff --check
- npx.cmd eslint src/app/api/city/route.ts
- npx.cmd tsc --noEmit --pretty false

Note: npm.cmd run build did not return before the local 5-minute timeout. Local npm install also reported that this repo expects Node 24.x while this environment is Node 22.18.0.