### PR TITLE
fix: guard achievement notifications

### DIFF
--- a/src/lib/notification-senders/achievement.ts
+++ b/src/lib/notification-senders/achievement.ts
@@ -51,30 +51,30 @@ export function sendAchievementNotification(
 
   try {
     sendNotificationAsync({
-    type: "achievement_unlocked",
-    category: "social",
-    developerId: devId,
-    dedupKey,
-    title,
-    body,
-    html: `
-      <p style="color: #ffa116; font-size: 16px;">
-        ${isSingle ? "Achievement Unlocked!" : `${notable.length} Achievements Unlocked!`}
-      </p>
-      <ul style="padding-left: 20px; margin: 16px 0; list-style: none;">
-        ${achievementListHtml}
-      </ul>
-      ${buildButton("View Achievements", `${BASE_URL}/?user=${login}`)}
-    `,
-    actionUrl: `${BASE_URL}/?user=${login}`,
-    priority: "low",
-    channels: ["email"],
-    // Batch eligible in case user unlocks multiple across separate calls
-    batchKey: `achievements:${devId}`,
-    batchWindowMinutes: 30,
-    batchEventData: {
-      achievements: notable.map((a) => ({ id: a.id, name: a.name, tier: a.tier })),
-    },
+      type: "achievement_unlocked",
+      category: "social",
+      developerId: devId,
+      dedupKey,
+      title,
+      body,
+      html: `
+        <p style="color: #ffa116; font-size: 16px;">
+          ${isSingle ? "Achievement Unlocked!" : `${notable.length} Achievements Unlocked!`}
+        </p>
+        <ul style="padding-left: 20px; margin: 16px 0; list-style: none;">
+          ${achievementListHtml}
+        </ul>
+        ${buildButton("View Achievements", `${BASE_URL}/?user=${login}`)}
+      `,
+      actionUrl: `${BASE_URL}/?user=${login}`,
+      priority: "low",
+      channels: ["email"],
+      // Batch eligible in case user unlocks multiple across separate calls
+      batchKey: `achievements:${devId}`,
+      batchWindowMinutes: 30,
+      batchEventData: {
+        achievements: notable.map((a) => ({ id: a.id, name: a.name, tier: a.tier })),
+      },
     });
   } catch (err: unknown) {
     console.error("[achievement] notification failed", err);

--- a/src/lib/notification-senders/achievement.ts
+++ b/src/lib/notification-senders/achievement.ts
@@ -49,7 +49,8 @@ export function sendAchievementNotification(
     })
     .join("");
 
-  sendNotificationAsync({
+  try {
+    sendNotificationAsync({
     type: "achievement_unlocked",
     category: "social",
     developerId: devId,
@@ -74,5 +75,8 @@ export function sendAchievementNotification(
     batchEventData: {
       achievements: notable.map((a) => ({ id: a.id, name: a.name, tier: a.tier })),
     },
-  });
+    });
+  } catch (err: unknown) {
+    console.error("[achievement] notification failed", err);
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a focused try/catch around the achievement notification dispatch path so synchronous notification setup errors are logged with achievement-specific context instead of bubbling out of sendAchievementNotification.

Changes:
- wraps the existing achievement notification send call in try/catch
- logs failures as [achievement] notification failed
- keeps notable-achievement filtering, payload shape, batching, and channels unchanged

## Related issue

Fixes #1113

## Screenshots

Not applicable: backend notification-sender guard only.

## Checklist

- [ ] npm run lint passes
- [ ] Tested locally
- [x] No secrets or env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository

Validation note:
- Local Git/npm validation could not run because the workspace drive is currently full (0 bytes free), so this branch was prepared through the GitHub API and should be validated by the repository CI.
- The change is limited to src/lib/notification-senders/achievement.ts and preserves the existing payload behavior.