### PR TITLE
feat: add structured error types for LeetCode API fetch failures-#1136

### DIFF
--- a/src/app/api/checkin/route.ts
+++ b/src/app/api/checkin/route.ts
@@ -102,11 +102,6 @@ async function grantStreakReward(
   return null;
 }
 
-// Lightweight LeetCode fetch: only current week contributions
-async function fetchWeeklyContributions(login: string): Promise<number | null> {
-  return fetchLeetCodeWeeklySubmissions(login);
-}
-
 export async function POST() {
   const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
   const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
@@ -333,8 +328,8 @@ export async function POST() {
   }
 
   // Refresh weekly contributions from LeetCode
-  const weeklyContribs = await fetchWeeklyContributions(githubLogin);
-  if (weeklyContribs !== null) {
+  const { data: weeklyContribs, error: weeklyContribsError } = await fetchLeetCodeWeeklySubmissions(githubLogin);
+  if (weeklyContribsError === null && weeklyContribs !== null) {
     await sb.from("developers").update({ current_week_contributions: weeklyContribs }).eq("id", dev.id);
   }
 

--- a/src/app/api/verify-leetcode/route.ts
+++ b/src/app/api/verify-leetcode/route.ts
@@ -79,9 +79,9 @@ export async function POST(req: Request) {
         const expectedToken = "LCC-" + user.id.split("-")[0].toUpperCase();
 
         // Fetch the user's public LeetCode 'About Me' / Summary
-        const aboutMe = await fetchLeetCodeAboutMe(leetcode_username);
+        const { data: aboutMe, error: aboutMeError } = await fetchLeetCodeAboutMe(leetcode_username);
 
-        if (aboutMe === null) {
+        if (aboutMeError !== null || aboutMe === null) {
             return NextResponse.json({ error: "Could not find this LeetCode account" }, { status: 404 });
         }
 

--- a/src/lib/__tests__/leetcode-weekly.test.ts
+++ b/src/lib/__tests__/leetcode-weekly.test.ts
@@ -1,12 +1,12 @@
 /**
- * Tests for fetchLeetCodeWeeklySubmissions (Issue #533).
- *
- * The contract: return a number on success (including a genuine 0 when the
- * developer made no submissions this week), and null on any failure so callers
- * preserve the existing contribution count instead of resetting it to 0.
+ * Tests for fetchLeetCodeWeeklySubmissions and fetchLeetCodeAboutMe (Issue #1136 & #533).
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { fetchLeetCodeWeeklySubmissions } from "../leetcode";
+import {
+  fetchLeetCodeWeeklySubmissions,
+  fetchLeetCodeAboutMe,
+  LeetCodeFetchError,
+} from "../leetcode";
 
 const FIXED_NOW = "2025-06-04T12:00:00.000Z";
 
@@ -48,7 +48,7 @@ describe("fetchLeetCodeWeeklySubmissions", () => {
       ),
     );
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(result).toBe(5);
+    expect(result).toEqual({ data: 5, error: null });
   });
 
   it("returns a genuine 0 when the user has no recent submissions", async () => {
@@ -57,19 +57,19 @@ describe("fetchLeetCodeWeeklySubmissions", () => {
       vi.fn().mockResolvedValue(calendarResponse({ [tenDaysAgoTs]: 99 })),
     );
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(result).toBe(0);
+    expect(result).toEqual({ data: 0, error: null });
   });
 
-  it("returns null (not 0) when the API responds with a non-OK status", async () => {
+  it("returns HTTP_ERROR when the API responds with a non-OK status", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }),
     );
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(result).toBeNull();
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.HTTP_ERROR });
   });
 
-  it("returns null (not 0) when the calendar payload is missing", async () => {
+  it("returns data: null, error: null when the calendar payload is missing", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -78,32 +78,104 @@ describe("fetchLeetCodeWeeklySubmissions", () => {
       }),
     );
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(result).toBeNull();
+    expect(result).toEqual({ data: null, error: null });
   });
 
-  it("returns null (not 0) when fetch throws (network error)", async () => {
+  it("returns NETWORK_ERROR when fetch throws (network error)", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(result).toBeNull();
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.NETWORK_ERROR });
   });
 
-  it("returns null when a year-boundary window has one failed year request", async () => {
-    // Early January: the 7-day window straddles the year boundary, so two
-    // year requests are made. The first (current year) succeeds but the
-    // second (previous year) fails. The current-year calendar alone is an
-    // undercount of the window, so the function must return null rather than
-    // overwrite the stored count with a partial total.
+  it("returns PARSE_ERROR when JSON parsing throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error("Invalid JSON");
+        },
+      }),
+    );
+    const result = await fetchLeetCodeWeeklySubmissions("alice");
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.PARSE_ERROR });
+  });
+
+  it("returns PARSE_ERROR when inner submissionCalendar string parsing throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            matchedUser: {
+              userCalendar: { submissionCalendar: "invalid-json" },
+            },
+          },
+        }),
+      }),
+    );
+    const result = await fetchLeetCodeWeeklySubmissions("alice");
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.PARSE_ERROR });
+  });
+
+  it("returns error when a year-boundary window has one failed year request", async () => {
     vi.setSystemTime(new Date("2026-01-02T12:00:00.000Z"));
     const jan1Ts = Math.floor(new Date("2026-01-01T00:00:00.000Z").getTime() / 1000);
 
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(calendarResponse({ [jan1Ts]: 3 })) // current year ok
-      .mockResolvedValueOnce({ ok: false, json: async () => ({}) }); // prior year fails
+      .mockResolvedValueOnce(calendarResponse({ [jan1Ts]: 3 }))
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) });
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await fetchLeetCodeWeeklySubmissions("alice");
-    expect(fetchMock).toHaveBeenCalledTimes(2); // current year then prior year (which fails)
-    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.HTTP_ERROR });
+  });
+});
+
+describe("fetchLeetCodeAboutMe", () => {
+  it("returns aboutMe text on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: { matchedUser: { profile: { aboutMe: "LCC-12345" } } },
+        }),
+      }),
+    );
+    const result = await fetchLeetCodeAboutMe("alice");
+    expect(result).toEqual({ data: "LCC-12345", error: null });
+  });
+
+  it("returns HTTP_ERROR when HTTP status is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }),
+    );
+    const result = await fetchLeetCodeAboutMe("alice");
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.HTTP_ERROR });
+  });
+
+  it("returns NETWORK_ERROR when fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failure")));
+    const result = await fetchLeetCodeAboutMe("alice");
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.NETWORK_ERROR });
+  });
+
+  it("returns PARSE_ERROR when response JSON parsing fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error("Bad JSON");
+        },
+      }),
+    );
+    const result = await fetchLeetCodeAboutMe("alice");
+    expect(result).toEqual({ data: null, error: LeetCodeFetchError.PARSE_ERROR });
   });
 });

--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -1,14 +1,24 @@
-export async function fetchLeetCodeAboutMe(username: string): Promise<string | null> {
+export enum LeetCodeFetchError {
+    NETWORK_ERROR = "NETWORK_ERROR",
+    HTTP_ERROR = "HTTP_ERROR",
+    PARSE_ERROR = "PARSE_ERROR",
+}
+
+export async function fetchLeetCodeAboutMe(
+    username: string
+): Promise<{ data: string | null; error: LeetCodeFetchError | null }> {
     try {
-        const res = await fetch("https://leetcode.com/graphql", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "User-Agent": "Mozilla/5.0",
-                "Referer": "https://leetcode.com/"
-            },
-            body: JSON.stringify({
-                query: `
+        let res: Response;
+        try {
+            res = await fetch("https://leetcode.com/graphql", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "User-Agent": "Mozilla/5.0",
+                    "Referer": "https://leetcode.com/"
+                },
+                body: JSON.stringify({
+                    query: `
           query getUserProfile($username: String!) {
             matchedUser(username: $username) {
               profile {
@@ -17,16 +27,33 @@ export async function fetchLeetCodeAboutMe(username: string): Promise<string | n
             }
           }
         `,
-                variables: { username }
-            })
-        });
+                    variables: { username }
+                })
+            });
+        } catch (err) {
+            console.error("[leetcode.ts] failed to fetch LeetCode aboutMe (network):", err);
+            return { data: null, error: LeetCodeFetchError.NETWORK_ERROR };
+        }
 
-        if (!res.ok) return null;
-        const data = await res.json();
-        return data?.data?.matchedUser?.profile?.aboutMe ?? null;
+        if (!res.ok) {
+            return { data: null, error: LeetCodeFetchError.HTTP_ERROR };
+        }
+
+        let data: unknown;
+        try {
+            data = await res.json();
+        } catch (err) {
+            console.error("[leetcode.ts] failed to parse LeetCode aboutMe JSON:", err);
+            return { data: null, error: LeetCodeFetchError.PARSE_ERROR };
+        }
+
+        const aboutMe =
+            (data as { data?: { matchedUser?: { profile?: { aboutMe?: string } } } })
+                ?.data?.matchedUser?.profile?.aboutMe ?? null;
+        return { data: aboutMe, error: null };
     } catch (err) {
         console.error("[leetcode.ts] failed to fetch LeetCode aboutMe:", err);
-        return null;
+        return { data: null, error: LeetCodeFetchError.NETWORK_ERROR };
     }
 }
 
@@ -76,7 +103,9 @@ export function parseMaxStreak(
     return maxStreak;
 }
 
-export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<number | null> {
+export async function fetchLeetCodeWeeklySubmissions(
+    username: string
+): Promise<{ data: number | null; error: LeetCodeFetchError | null }> {
     try {
         const now = new Date();
         const currentYear = now.getFullYear();
@@ -92,15 +121,17 @@ export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<
         let totalWeeklyCount = 0;
 
         for (const year of yearsToFetch) {
-            const res = await fetch("https://leetcode.com/graphql", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "User-Agent": "Mozilla/5.0",
-                    "Referer": "https://leetcode.com/"
-                },
-                body: JSON.stringify({
-                    query: `
+            let res: Response;
+            try {
+                res = await fetch("https://leetcode.com/graphql", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "User-Agent": "Mozilla/5.0",
+                        "Referer": "https://leetcode.com/"
+                    },
+                    body: JSON.stringify({
+                        query: `
               query getUserCalendar($username: String!, $year: Int) {
                 matchedUser(username: $username) {
                   userCalendar(year: $year) {
@@ -109,20 +140,39 @@ export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<
                 }
               }
             `,
-                    variables: { username, year }
-                })
-            });
+                        variables: { username, year }
+                    })
+                });
+            } catch (err) {
+                console.error("[leetcode.ts] failed to fetch weekly submissions (network):", err);
+                return { data: null, error: LeetCodeFetchError.NETWORK_ERROR };
+            }
 
-            // A failed request (or missing calendar) means we cannot compute a
-            // trustworthy weekly total. Return null so callers preserve the
-            // existing contribution count instead of overwriting it with a
-            // partial/zero value during a transient LeetCode outage.
-            if (!res.ok) return null;
-            const data = await res.json();
-            const calendarStr = data?.data?.matchedUser?.userCalendar?.submissionCalendar;
-            if (!calendarStr) return null;
+            if (!res.ok) {
+                return { data: null, error: LeetCodeFetchError.HTTP_ERROR };
+            }
 
-            const calendar = JSON.parse(calendarStr);
+            let data: unknown;
+            try {
+                data = await res.json();
+            } catch (err) {
+                console.error("[leetcode.ts] failed to parse weekly submissions JSON:", err);
+                return { data: null, error: LeetCodeFetchError.PARSE_ERROR };
+            }
+
+            const calendarStr =
+                (data as { data?: { matchedUser?: { userCalendar?: { submissionCalendar?: string } } } })
+                    ?.data?.matchedUser?.userCalendar?.submissionCalendar;
+            if (!calendarStr) return { data: null, error: null };
+
+            let calendar: Record<string, number>;
+            try {
+                calendar = JSON.parse(calendarStr);
+            } catch (err) {
+                console.error("[leetcode.ts] failed to parse submissionCalendar string:", err);
+                return { data: null, error: LeetCodeFetchError.PARSE_ERROR };
+            }
+
             const sevenDaysAgoTs = nowTs - 7 * 24 * 60 * 60;
 
             for (const [timestampStr, count] of Object.entries(calendar)) {
@@ -133,10 +183,9 @@ export async function fetchLeetCodeWeeklySubmissions(username: string): Promise<
             }
         }
 
-        return totalWeeklyCount;
+        return { data: totalWeeklyCount, error: null };
     } catch (err) {
         console.error("[leetcode.ts] failed to fetch weekly submissions:", err);
-        // Signal failure (not a real zero) so the caller keeps the prior count.
-        return null;
+        return { data: null, error: LeetCodeFetchError.NETWORK_ERROR };
     }
 }


### PR DESCRIPTION
## What does this PR do?

Added structured error types and result objects for LeetCode API fetch failures in `src/lib/leetcode.ts`:
- Defined and exported `LeetCodeFetchError` enum with `NETWORK_ERROR`, `HTTP_ERROR`, and `PARSE_ERROR` variants.
- Updated `fetchLeetCodeAboutMe` and `fetchLeetCodeWeeklySubmissions` to return `{ data, error }` objects instead of raw nullable primitives.
- Updated caller API routes (`src/app/api/verify-leetcode/route.ts` and `src/app/api/checkin/route.ts`) to handle structured responses.
- Expanded unit tests in `src/lib/__tests__/leetcode-weekly.test.ts` to cover all `LeetCodeFetchError` error cases.

## Related issue

Fixes #1136

## Screenshots

N/A (Backend / Utility refactoring)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
