### PR TITLE
fix : added parseMaxStreak year range reduced to last 3 years

### DIFF
--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -40,7 +40,9 @@ export function parseMaxStreak(
 ): number {
     if (!matchedUser) return 0;
     const allTimestamps: number[] = [];
-    for (let y = 2015; y <= currentYear; y++) {
+    // Only iterate over the last 3 years to avoid processing overhead from early LeetCode years.
+    const startYear = Math.max(currentYear - 2, 2015);
+    for (let y = startYear; y <= currentYear; y++) {
         const cal = (matchedUser[`y${y}`] as YearCalendar | undefined)?.submissionCalendar;
         if (cal) {
             try {


### PR DESCRIPTION
## Summary of What Has Been Done

## Summary of What Needs to be Done

The `parseMaxStreak` function in `src/lib/leetcode.ts` iterates from year 2015 through the current year when extracting timestamps from submission calendars. This causes unnecessary processing overhead since most users have no submissions in the early years.

## Changes that Need to be Made

In `src/lib/leetcode.ts`, modify the `parseMaxStreak` function to limit year iteration to the last 3 years instead of starting from 2015. This significantly reduces processing time for users with large submission histories.

## Impact that it would Provide

- Faster streak calculation for the profile page
- Reduced CPU usage on server-side API calls
- No functional change — streak calculation for the last 3 years covers any meaningful streak

## Note

Please assign this issue to the `tmdeveloper007` account.

---

## Changes Made

- Implemented the fix described in issue #1132

## Impact it Made

Reduces processing overhead for LeetCode submission calendar parsing, improving performance for users with large submission histories.

---

Closes #1132

Note: Please assign this PR to the `tmdeveloper007` account.