### PR TITLE
docs : added JSDoc to roadmap-data.ts exports

### DIFF
--- a/src/lib/roadmap-data.ts
+++ b/src/lib/roadmap-data.ts
@@ -1,21 +1,48 @@
+/**
+ * Roadmap data module.
+ * Defines the static roadmap structure displayed on the public roadmap page,
+ * including phases, items, and vote eligibility sets.
+ */
+
+/** Lifecycle status of a roadmap item or phase. */
 export type ItemStatus = "done" | "building" | "planned";
 
+/**
+ * A single item on the roadmap.
+ */
 export interface RoadmapItem {
+  /** Unique identifier for the item. */
   id: string;
+  /** Display name of the roadmap item. */
   name: string;
+  /** Optional human-readable description. */
   description?: string;
+  /** Current lifecycle status. */
   status: ItemStatus;
-  mystery?: boolean; // hides vote button, shows "???" vibe
+  /**
+   * If true, the item is a mystery placeholder.
+   * Hides the vote button and displays "???" instead of the name.
+   */
+  mystery?: boolean;
 }
 
+/**
+ * A roadmap phase containing a group of related items.
+ */
 export interface RoadmapPhase {
+  /** Unique identifier for the phase. */
   id: string;
+  /** Display title for the phase. */
   title: string;
+  /** Quarter or time range label (e.g. "Q1 2026"). */
   quarter: string;
+  /** Aggregate status of the phase. */
   status: ItemStatus;
+  /** Items belonging to this phase. */
   items: RoadmapItem[];
 }
 
+/** All roadmap phases and their items. */
 export const ROADMAP_PHASES: RoadmapPhase[] = [
   {
     id: "foundation",
@@ -218,12 +245,18 @@ export const ROADMAP_PHASES: RoadmapPhase[] = [
   },
 ];
 
-// All valid item IDs (for server-side vote validation)
+/**
+ * Set of all valid roadmap item IDs.
+ * Used for server-side validation when accepting votes or other item references.
+ */
 export const VALID_ITEM_IDS = new Set(
   ROADMAP_PHASES.flatMap((phase) => phase.items.map((item) => item.id))
 );
 
-// Items that can be voted on (not done, not mystery)
+/**
+ * Set of roadmap item IDs that are eligible for community votes.
+ * Excludes items that are `done` (already shipped) or `mystery` (hidden).
+ */
 export const VOTABLE_ITEM_IDS = new Set(
   ROADMAP_PHASES.flatMap((phase) =>
     phase.items


### PR DESCRIPTION
## Summary of What Has Been Done
Added JSDoc comments to all exported types, interfaces, constants, and the `ROADMAP_PHASES` array in `src/lib/roadmap-data.ts`.

## Changes Made
- Added module-level JSDoc describing the roadmap module
- Added JSDoc to the `ItemStatus` type alias
- Added JSDoc to the `RoadmapItem` interface with field descriptions
- Added JSDoc to the `RoadmapPhase` interface with field descriptions
- Added JSDoc to the `VALID_ITEM_IDS` constant describing its validation use
- Added JSDoc to the `VOTABLE_ITEM_IDS` constant describing its vote-filtering use

## Impact it Made
- Improves IDE tooltips and inline documentation for the roadmap subsystem
- Makes the roadmap data structure easier to understand and extend for contributors
- Consistent with other lib files that have JSDoc coverage

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1177
