### PR TITLE
🐛 fix(radio): validate saved radio settings

### DIFF
--- a/src/lib/radio.ts
+++ b/src/lib/radio.ts
@@ -21,13 +21,30 @@ const STORAGE_KEY = "gc_radio";
 
 const DEFAULT_STATE: RadioState = { volume: 0.15, trackIndex: 0, shuffle: false };
 
+function validateRadioState(state: unknown): RadioState {
+  const saved = state !== null && typeof state === "object" ? state as Record<string, unknown> : {};
+
+  return {
+    volume: typeof saved.volume === "number" && saved.volume >= 0 && saved.volume <= 1
+      ? saved.volume
+      : DEFAULT_STATE.volume,
+    trackIndex: typeof saved.trackIndex === "number"
+      && Number.isInteger(saved.trackIndex)
+      && saved.trackIndex >= 0
+      && saved.trackIndex < TRACKS.length
+      ? saved.trackIndex
+      : DEFAULT_STATE.trackIndex,
+    shuffle: typeof saved.shuffle === "boolean" ? saved.shuffle : DEFAULT_STATE.shuffle,
+  };
+}
+
 export function loadRadioState(): RadioState {
   if (typeof window === "undefined") return DEFAULT_STATE;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_STATE;
     const parsed = JSON.parse(raw);
-    return { ...DEFAULT_STATE, ...parsed };
+    return validateRadioState(parsed);
   } catch (err) {
     console.warn("[radio.ts] failed to load saved radio state:", err);
     return DEFAULT_STATE;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where radio settings loaded from `localStorage` were used without validation, which could cause the lofi radio to fail when invalid or corrupted values were stored.

### Changes Made
- Added validation for `volume` (must be a number between `0` and `1`).
- Added validation for `trackIndex` (must be a valid integer within the available tracks).
- Added validation for `shuffle` (must be a boolean).
- Invalid or corrupted values now safely fall back to the default radio settings.
- Malformed JSON is handled gracefully without breaking the application.

## Related issue

Fixes #1142

## Checklist

- [x] My code follows the project's coding style.
- [x] I have tested my changes locally.
- [x] I have not introduced unrelated changes.
- [x] I have updated only the necessary file(s).
- [x] This PR fixes the reported issue.