### PR TITLE
fix : added tab parameter validation in leaderboard-position API route

### DIFF
--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
+const VALID_TABS = new Set(["solved", "lc_rank", "streak", "contest", "xp", "achievers"]);
+
 /**
  * @param {import('next/server').NextRequest} request
  */
@@ -11,6 +13,13 @@ export async function GET(request: Request) {
 
   if (!login) {
     return NextResponse.json({ error: "Missing login" }, { status: 400 });
+  }
+
+  if (!VALID_TABS.has(tab)) {
+    return NextResponse.json(
+      { error: `Invalid tab '${tab}'. Accepted values: ${[...VALID_TABS].join(", ")}` },
+      { status: 400 }
+    );
   }
 
   const sb = getSupabaseAdmin();


### PR DESCRIPTION
## Summary of What Has Been Done

Added validation for the `tab` query parameter in `GET /api/leaderboard-position`. If an unknown tab value is provided, the route now returns a `400 Bad Request` with a descriptive error message listing the accepted values.

## Changes Made

- Added `VALID_TABS` constant containing the allowed tab values: `solved`, `lc_rank`, `streak`, `contest`, `xp`, `achievers`
- Added a guard that returns `400` with a clear error message when `tab` is not in `VALID_TABS`
- The default fallback (when tab is null) continues to use `solved`

## Impact it Made

Prevents silent failures and provides immediate, descriptive feedback to API consumers when an invalid tab value is passed. Improves API robustness and developer experience.

Closes #1188

## Note: Please assign this PR to the `tmdeveloper007` account.
