### PR TITLE
feat : added Zod validation to fly-scores POST route (#1198)

### DIFF
--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -4,6 +4,14 @@ import { rateLimit } from "@/lib/rate-limit";
 import { trackDailyMission } from "@/lib/dailies";
 import { buildFlyLeaderboard, type FlyScoreRow } from "@/lib/fly-leaderboard";
 import { getTodaySeed } from "@/lib/fly-seed";
+import { z } from "zod";
+
+const flyScoreSchema = z.object({
+  score: z.number().int().min(0, "Invalid score").max(430, "Invalid score"),
+  collected: z.number().int().min(0, "Invalid collected").max(40, "Invalid collected"),
+  max_combo: z.number().int().min(1, "Invalid combo").max(3, "Invalid combo"),
+  flight_ms: z.number().int().min(10000, "Invalid flight time"),
+});
 
 function maxScoreForCollected(collected: number): number {
   if (collected <= 0) return 0;
@@ -32,21 +40,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Too fast" }, { status: 429 });
   }
 
-  const body = await request.json();
-  const { score, collected, max_combo, flight_ms } = body;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-  if (typeof score !== "number" || score < 0 || score > 430) {
-    return NextResponse.json({ error: "Invalid score" }, { status: 400 });
+  const parsed = flyScoreSchema.safeParse(body);
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    return NextResponse.json({ error: firstIssue.message }, { status: 400 });
   }
-  if (typeof collected !== "number" || collected < 0 || collected > 40) {
-    return NextResponse.json({ error: "Invalid collected" }, { status: 400 });
-  }
-  if (typeof max_combo !== "number" || max_combo < 1 || max_combo > 3) {
-    return NextResponse.json({ error: "Invalid combo" }, { status: 400 });
-  }
-  if (typeof flight_ms !== "number" || flight_ms < 10_000) {
-    return NextResponse.json({ error: "Invalid flight time" }, { status: 400 });
-  }
+
+  const { score, collected, max_combo, flight_ms } = parsed.data;
 
   const ceiling = maxScoreForCollected(collected);
   if (score > ceiling) {


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the manual `typeof` checks in `src/app/api/fly-scores/route.ts` POST handler with a Zod schema (`flyScoreSchema`). The schema validates `score` (0-430), `collected` (0-40), `max_combo` (1-3), and `flight_ms` (min 10000) with descriptive error messages. Added proper try/catch for JSON parsing.

## Changes Made

- Added `import { z } from "zod"` to the route file
- Defined `flyScoreSchema` as a Zod object schema at the top of the file
- Replaced 4 manual `typeof` validation blocks with `flyScoreSchema.safeParse(body)`
- Added JSON parse error handling with 400 response
- Kept the business logic checks (ceiling validation, flight time per collected) intact
- Returns the first Zod error message for consistency with other routes

## Impact it Made

- Consistent Zod-based validation across all API routes
- Typed input with clear, structured error messages
- Follows the established pattern in the codebase
- Reduced boilerplate validation code

Closes #1198
## Note: Please assign this PR to the `tmdeveloper007` account.
