### PR TITLE
feat : added Zod validation to notification-preferences PATCH route (#1200)

### DIFF
--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -1,19 +1,21 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
+import { z } from "zod";
 
-const UPDATABLE_FIELDS = [
-  "email_enabled",
-  "push_enabled",
-  "social",
-  "digest",
-  "marketing",
-  "streak_reminders",
-  "digest_frequency",
-  "quiet_hours_start",
-  "quiet_hours_end",
-  "channel_overrides",
-] as const;
+const notificationPrefsSchema = z.object({
+  email_enabled: z.boolean().optional(),
+  push_enabled: z.boolean().optional(),
+  social: z.boolean().optional(),
+  digest: z.boolean().optional(),
+  marketing: z.boolean().optional(),
+  streak_reminders: z.boolean().optional(),
+  digest_frequency: z.enum(["realtime", "hourly", "daily", "weekly"]).optional(),
+  quiet_hours_start: z.number().int().min(0).max(23).nullable().optional(),
+  quiet_hours_end: z.number().int().min(0).max(23).nullable().optional(),
+  channel_overrides: z.record(z.unknown()).optional(),
+});
+
 
 /**
  * GET /api/notification-preferences
@@ -78,48 +80,34 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: auth.error ?? "Not authenticated" }, { status: auth.status });
   }
 
-  const body = await request.json();
-  const sb = getSupabaseAdmin();
-  const dev = auth.developer;
-
-  if (!dev) {
-    return NextResponse.json({ error: "Developer not found" }, { status: 404 });
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  // Filter to only allowed fields
-  const update: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      update[field] = body[field];
-    }
+  const parsed = notificationPrefsSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    return NextResponse.json({ error: firstIssue.message }, { status: 400 });
   }
 
+  const update = parsed.data as Record<string, unknown>;
   // Prevent disabling transactional
   if ("transactional" in update) {
     delete update.transactional;
   }
 
-  // Validate digest_frequency
-  if (update.digest_frequency && !["realtime", "hourly", "daily", "weekly"].includes(update.digest_frequency as string)) {
-    return NextResponse.json({ error: "Invalid digest_frequency" }, { status: 400 });
-  }
-
-  // Validate quiet hours
-  if (update.quiet_hours_start !== undefined) {
-    const h = update.quiet_hours_start as number | null;
-    if (h !== null && (h < 0 || h > 23)) {
-      return NextResponse.json({ error: "quiet_hours_start must be 0-23" }, { status: 400 });
-    }
-  }
-  if (update.quiet_hours_end !== undefined) {
-    const h = update.quiet_hours_end as number | null;
-    if (h !== null && (h < 0 || h > 23)) {
-      return NextResponse.json({ error: "quiet_hours_end must be 0-23" }, { status: 400 });
-    }
-  }
-
   if (Object.keys(update).length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  const sb = getSupabaseAdmin();
+  const dev = auth.developer;
+
+  if (!dev) {
+    return NextResponse.json({ error: "Developer not found" }, { status: 404 });
   }
 
   update.updated_at = new Date().toISOString();


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the manual body validation in `src/app/api/notification-preferences/route.ts` PATCH handler with a Zod schema (`notificationPrefsSchema`). The schema validates all updatable notification preference fields with their correct types and ranges.

## Changes Made

- Added `import { z } from "zod"` to the route file
- Defined `notificationPrefsSchema` as a Zod object schema validating: boolean flags, digest_frequency enum ("realtime"|"hourly"|"daily"|"weekly"), quiet_hours_start/end (0-23 or null), channel_overrides (object)
- Replaced the manual field filtering loop and individual type checks with `notificationPrefsSchema.safeParse()`
- Added JSON parse error handling with 400 response
- Removed the now-redundant `UPDATABLE_FIELDS` constant
- Kept the `transactional` field guard (cannot be disabled by user) as a post-validation step
- Kept the "no valid fields" check

## Impact it Made

- Consistent Zod-based validation across all API routes
- Typed input with clear, structured error messages from Zod
- Reduced boilerplate validation code
- Follows the established pattern in the codebase

Closes #1200
## Note: Please assign this PR to the `tmdeveloper007` account.
