### PR TITLE
feat : added Zod validation to preferences/theme PATCH route (#1201)

### DIFF
--- a/src/app/api/preferences/theme/route.ts
+++ b/src/app/api/preferences/theme/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
 import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { z } from "zod";
 
-const MAX_THEME = 3;
+const themeSchema = z.object({
+  city_theme: z.number().int().min(0, "Invalid theme index").max(3, "Invalid theme index"),
+});
+
 
 /**
  * GET /api/preferences/theme
@@ -43,13 +47,19 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: auth.error ?? "Not authenticated" }, { status: auth.status });
   }
 
-  const body = await request.json();
-  const theme = body.city_theme;
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-  if (typeof theme !== "number" || theme < 0 || theme > MAX_THEME || !Number.isInteger(theme)) {
+  const parsed = themeSchema.safeParse(rawBody);
+  if (!parsed.success) {
     return NextResponse.json({ error: "Invalid theme index" }, { status: 400 });
   }
 
+  const theme = parsed.data.city_theme;
   const sb = getSupabaseAdmin();
   const { error } = await sb
     .from("developers")


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the manual `typeof` and `Number.isInteger` validation in `src/app/api/preferences/theme/route.ts` PATCH handler with a Zod schema (`themeSchema`).

## Changes Made

- Added `import { z } from "zod"` to the route file
- Defined `themeSchema` as a Zod object schema validating `city_theme` as an integer between 0 and 3
- Replaced manual validation with `themeSchema.safeParse()`
- Added JSON parse error handling with 400 response
- Removed the now-redundant `MAX_THEME` constant

## Impact it Made

- Consistent Zod-based validation across all API routes
- Typed input with clear, structured error messages
- Reduced boilerplate validation code
- Follows the established pattern in the codebase

Closes #1201
## Note: Please assign this PR to the `tmdeveloper007` account.
