### PR TITLE
docs : added JSDoc to re-engagement cron route GET handler (#1202)

### DIFF
--- a/src/app/api/cron/re-engagement/route.ts
+++ b/src/app/api/cron/re-engagement/route.ts
@@ -56,9 +56,10 @@ const TIERS: ReEngagementTier[] = [
 /**
  * Cron: Daily 14:00 UTC - Re-engagement emails for inactive developers.
  * Category: marketing (opt-in only, defaults to false).
- */
-/**
- * @param {import('next/server').NextRequest} request
+ * Sends tiered re-engagement emails (7d, 14d, 30d inactive) to opted-in developers.
+ *
+ * @param request - Incoming NextRequest with Authorization header
+ * @returns JSON with ok, sent, skipped, and errors counts
  */
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");


### PR DESCRIPTION
## Summary of What Has Been Done

Consolidated and improved the JSDoc block for the exported GET handler in `src/app/api/cron/re-engagement/route.ts`. Replaced the two-block JSDoc format with a single unified block and added `@returns` documentation.

## Changes Made

- Merged the two separate JSDoc comment blocks into one
- Added descriptive line: "Sends tiered re-engagement emails (7d, 14d, 30d inactive) to opted-in developers"
- Updated `@param` to use shorthand format: `@param request - Incoming NextRequest with Authorization header`
- Added `@returns JSON with ok, sent, skipped, and errors counts`
- Removed the old `@param {import('next/server').NextRequest} request` style

## Impact it Made

- Consistent documentation style with other cron routes in the codebase
- Improved API documentation for maintainers
- Better developer experience when reading the codebase
- Follows the JSDoc style used in other well-documented routes

Closes #1202
## Note: Please assign this PR to the `tmdeveloper007` account.
