### PR TITLE
🐛 fix(streak): await sendNotificationAsync so errors are actually caught

### DIFF
--- a/src/lib/notification-senders/streak.ts
+++ b/src/lib/notification-senders/streak.ts
@@ -18,37 +18,45 @@ export function sendStreakMilestoneNotification(
   rewardItemName?: string,
 ) {
   const milestoneInfo = MILESTONE_MESSAGES[streak];
-  if (!milestoneInfo) return; // Only send at defined milestones
+  if (!milestoneInfo) return;
 
   const rewardHtml = rewardItemName
     ? `<p style="color: #ffa116; font-size: 14px;">Reward unlocked: <strong>${rewardItemName}</strong></p>`
     : "";
 
-  try {
-    sendNotificationAsync({
-      type: "streak_milestone",
-      category: "social",
-      developerId: devId,
-      dedupKey: `streak_milestone:${devId}:${streak}`,
-      title: `${streak}-day streak! ${milestoneInfo.tagline}`,
-      body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
-      html: `
-        <div style="text-align: center;">
-          <p style="font-family: monospace; font-size: 28px; font-weight: bold; color: #ffa116; margin: 0; letter-spacing: 2px;">${milestoneInfo.badge}</p>
-          <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">${streak}-day streak!</p>
-          <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">${milestoneInfo.tagline}</p>
-        </div>
-        ${rewardHtml}
-        <p style="color: #666; font-size: 13px; text-align: center;">
-          Longest streak: ${longestStreak} days
-        </p>
-        ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
-      `,
-      actionUrl: `${BASE_URL}/?user=${login}`,
-      priority: "high", // Streak milestones are celebratory, send immediately
-      channels: ["email"],
-    });
-  } catch (err: unknown) {
-    console.error("[streak] notification failed", err);
-  }
+  void (async () => {
+    try {
+      await sendNotificationAsync({
+        type: "streak_milestone",
+        category: "social",
+        developerId: devId,
+        dedupKey: `streak_milestone:${devId}:${streak}`,
+        title: `${streak}-day streak! ${milestoneInfo.tagline}`,
+        body: `${streak}-day streak! ${milestoneInfo.tagline}${rewardItemName ? ` Reward: ${rewardItemName}` : ""}`,
+        html: `
+          <div style="text-align: center;">
+            <p style="font-family: monospace; font-size: 28px; font-weight: bold; color: #ffa116; margin: 0; letter-spacing: 2px;">
+              ${milestoneInfo.badge}
+            </p>
+            <p style="color: #ffa116; font-size: 24px; font-weight: bold; margin: 8px 0;">
+              ${streak}-day streak!
+            </p>
+            <p style="color: #f0f0f0; font-size: 16px; margin-top: 0;">
+              ${milestoneInfo.tagline}
+            </p>
+          </div>
+          ${rewardHtml}
+          <p style="color: #666; font-size: 13px; text-align: center;">
+            Longest streak: ${longestStreak} days
+          </p>
+          ${buildButton("Keep It Going", `${BASE_URL}/?user=${login}`)}
+        `,
+        actionUrl: `${BASE_URL}/?user=${login}`,
+        priority: "high",
+        channels: ["email"],
+      });
+    } catch (err: unknown) {
+      console.error("[streak] notification failed", err);
+    }
+  })();
 }


### PR DESCRIPTION
What does this PR do?

Fixes the missing/ineffective error handling around the sendNotificationAsync call in src/lib/notification-senders/streak.ts.

The issue asked to match the pattern in achievements.ts/achievement.ts, but on inspection, that reference pattern itself doesn't actually catch async errors — it wraps the call in try/catch without awaiting the promise, so a rejection from sendNotificationAsync occurs after the try block has already exited and is never caught.

This PR fixes streak.ts properly:

Wraps the call in an async IIFE (void (async () => { ... })())
Awaits sendNotificationAsync so its rejection is actually caught by the try/catch
Logs failures via console.error("[streak] notification failed", err)

Note for maintainers: sendAchievementNotification in notification-senders/achievement.ts, and its caller in achievements.ts, have the same missing-await issue. I kept this PR scoped to streak.ts only, but happy to open a follow-up issue/PR for those two if useful.

Related issue

Fixes #1074

Screenshots

Not applicable — this is a backend/logic-only fix with no UI or rendering changes.

Checklist
 npm run lint passes
 Tested locally
 No secrets or .env values committed
 I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
 ⭐ I have starred this repository!
