### PR TITLE
📝 docs(radio): add JSDoc comments

### DIFF
--- a/src/lib/radio.ts
+++ b/src/lib/radio.ts
@@ -21,6 +21,14 @@ const STORAGE_KEY = "gc_radio";
 
 const DEFAULT_STATE: RadioState = { volume: 0.15, trackIndex: 0, shuffle: false };
 
+/**
+ * Loads the saved radio state from localStorage.
+ *
+ * If localStorage is unavailable or contains invalid data,
+ * the default radio state is returned.
+ *
+ * @returns The saved or default radio state.
+ */
 export function loadRadioState(): RadioState {
   if (typeof window === "undefined") return DEFAULT_STATE;
   try {
@@ -57,6 +65,14 @@ export function loadRadioState(): RadioState {
   }
 }
 
+/**
+ * Saves radio state properties to localStorage.
+ *
+ * Existing radio state is preserved, and only the provided
+ * properties are updated.
+ *
+ * @param state - The radio state properties to save.
+ */
 export function saveRadioState(state: Partial<RadioState>) {
   if (typeof window === "undefined") return;
   try {


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc documentation to the `loadRadioState()` and `saveRadioState()` functions in `src/lib/radio.ts`.

The changes are documentation-only and do not modify the existing functionality.

## Related issue

Fixes #1176

## Screenshots

Not applicable — this PR contains no visual/UI changes.

## Checklist

* [ ] `npm run lint` passes
* [ ] Tested locally
* [x] No secrets or .env values were committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
