### PR TITLE
fix(vscode-extension): add robust error handling, retries, and logging to extension updater (#1158)

### DIFF
--- a/packages/vscode-extension/src/updater.test.ts
+++ b/packages/vscode-extension/src/updater.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  compareSemver,
+  fetchWithTimeout,
+  fetchWithRetry,
+  downloadFile,
+  checkForUpdates,
+} from "./updater";
+
+// Mock vscode module
+vi.mock("vscode", () => {
+  return {
+    extensions: {
+      getExtension: vi.fn(),
+    },
+    window: {
+      withProgress: vi.fn(),
+      showInformationMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
+    },
+    commands: {
+      executeCommand: vi.fn(),
+    },
+    ProgressLocation: {
+      Notification: 15,
+    },
+    Uri: {
+      file: (p: string) => ({ fsPath: p }),
+    },
+  };
+});
+
+import * as vscode from "vscode";
+
+describe("updater.ts", () => {
+  const originalFetch = (globalThis as any).fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("compareSemver", () => {
+    it("correctly compares version numbers", () => {
+      expect(compareSemver("0.2.4", "0.2.3")).toBe(1);
+      expect(compareSemver("0.2.3", "0.2.3")).toBe(0);
+      expect(compareSemver("0.2.2", "0.2.3")).toBe(-1);
+      expect(compareSemver("1.0.0", "0.9.9")).toBe(1);
+      expect(compareSemver("0.2.3", "1.0.0")).toBe(-1);
+    });
+  });
+
+  describe("fetchWithTimeout", () => {
+    it("resolves when fetch succeeds within timeout", async () => {
+      const mockRes = { ok: true, status: 200 };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(mockRes);
+
+      const res = await fetchWithTimeout("https://example.com/test", {}, 1000);
+      expect(res).toBe(mockRes);
+      expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("fetchWithRetry", () => {
+    it("succeeds on first attempt", async () => {
+      const mockRes = { ok: true, status: 200 };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(mockRes);
+
+      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 10);
+      expect(res).toBe(mockRes);
+      expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on failure and succeeds eventually", async () => {
+      const failRes = { ok: false, status: 500, statusText: "Internal Error" };
+      const successRes = { ok: true, status: 200 };
+      (globalThis as any).fetch = vi
+        .fn()
+        .mockResolvedValueOnce(failRes)
+        .mockResolvedValueOnce(successRes);
+
+      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 10);
+      expect(res).toBe(successRes);
+      expect((globalThis as any).fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws error after exhausting retries", async () => {
+      const failRes = { ok: false, status: 404, statusText: "Not Found" };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(failRes);
+
+      await expect(
+        fetchWithRetry("https://example.com/test", {}, 1000, 2, 10)
+      ).rejects.toThrow("HTTP 404 Not Found");
+      expect((globalThis as any).fetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("downloadFile", () => {
+    it("throws error if downloaded file buffer is empty", async () => {
+      const emptyRes = {
+        ok: true,
+        status: 200,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+      };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(emptyRes);
+
+      const tmpFile = path.join(os.tmpdir(), "test_empty.vsix");
+      await expect(downloadFile("https://example.com/empty.vsix", tmpFile)).rejects.toThrow(
+        "Downloaded file is empty"
+      );
+    });
+
+    it("downloads and writes file successfully", async () => {
+      const bufferContent = new TextEncoder().encode("vsix-mock-content").buffer;
+      const successRes = {
+        ok: true,
+        status: 200,
+        arrayBuffer: vi.fn().mockResolvedValue(bufferContent),
+      };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(successRes);
+
+      const tmpFile = path.join(os.tmpdir(), "test_success.vsix");
+      await downloadFile("https://example.com/valid.vsix", tmpFile);
+
+      expect(fs.existsSync(tmpFile)).toBe(true);
+      const readData = fs.readFileSync(tmpFile, "utf-8");
+      expect(readData).toBe("vsix-mock-content");
+
+      // Cleanup
+      fs.unlinkSync(tmpFile);
+    });
+  });
+
+  describe("checkForUpdates", () => {
+    let mockContext: any;
+    let globalStateStore: Record<string, any>;
+
+    beforeEach(() => {
+      globalStateStore = {};
+      mockContext = {
+        globalState: {
+          get: vi.fn((key: string, defaultValue: any) => globalStateStore[key] ?? defaultValue),
+          update: vi.fn((key: string, value: any) => {
+            globalStateStore[key] = value;
+            return Promise.resolve();
+          }),
+        },
+      };
+    });
+
+    it("skips check if debounced (within 6 hours)", async () => {
+      const recentTime = Date.now() - 1000;
+      globalStateStore["leetcodecity.lastUpdateCheck"] = recentTime;
+
+      (globalThis as any).fetch = vi.fn();
+
+      await checkForUpdates(mockContext);
+      expect((globalThis as any).fetch).not.toHaveBeenCalled();
+    });
+
+    it("logs warning and aborts cleanly when fetch throws an error", async () => {
+      (globalThis as any).fetch = vi.fn().mockRejectedValue(new Error("Network disconnect"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await checkForUpdates(mockContext);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[LeetCode City Updater] Check for updates failed: Network disconnect")
+      );
+      expect(mockContext.globalState.update).not.toHaveBeenCalled();
+    });
+
+    it("updates lastCheck timestamp when local version is up-to-date", async () => {
+      const mockPackageJsonRes = {
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(JSON.stringify({ version: "0.2.3" })),
+      };
+      (globalThis as any).fetch = vi.fn().mockResolvedValue(mockPackageJsonRes);
+
+      vi.mocked(vscode.extensions.getExtension).mockReturnValue({
+        packageJSON: { version: "0.2.3" },
+      } as any);
+
+      await checkForUpdates(mockContext);
+
+      expect(mockContext.globalState.update).toHaveBeenCalledWith(
+        "leetcodecity.lastUpdateCheck",
+        expect.any(Number)
+      );
+    });
+
+    it("shows warning message when update download/install fails", async () => {
+      const mockPackageJsonRes = {
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(JSON.stringify({ version: "0.3.0" })),
+      };
+      // package.json fetch succeeds, vsix download fails (e.g., 404)
+      const failVsixRes = {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      };
+
+      (globalThis as any).fetch = vi
+        .fn()
+        .mockResolvedValueOnce(mockPackageJsonRes) // package.json check attempt 1
+        .mockResolvedValue(failVsixRes); // vsix download attempts
+
+      vi.mocked(vscode.extensions.getExtension).mockReturnValue({
+        packageJSON: { version: "0.2.3" },
+      } as any);
+
+      vi.mocked(vscode.window.withProgress).mockImplementation(async (_options, task) => {
+        return task({ report: vi.fn() } as any);
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await checkForUpdates(mockContext);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[LeetCode City Updater] Extension update failed")
+      );
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining("🏙️ LeetCode City: Pulse update failed:")
+      );
+      // Ensure globalState timestamp was NOT updated on failure
+      expect(globalStateStore["leetcodecity.lastUpdateCheck"]).toBeUndefined();
+    });
+
+    it("installs vsix and updates timestamp on success", async () => {
+      const mockPackageJsonRes = {
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(JSON.stringify({ version: "0.3.0" })),
+      };
+      const bufferContent = new TextEncoder().encode("fake-vsix").buffer;
+      const mockVsixRes = {
+        ok: true,
+        status: 200,
+        arrayBuffer: vi.fn().mockResolvedValue(bufferContent),
+      };
+
+      (globalThis as any).fetch = vi
+        .fn()
+        .mockResolvedValueOnce(mockPackageJsonRes)
+        .mockResolvedValueOnce(mockVsixRes);
+
+      vi.mocked(vscode.extensions.getExtension).mockReturnValue({
+        packageJSON: { version: "0.2.3" },
+      } as any);
+
+      vi.mocked(vscode.window.withProgress).mockImplementation(async (_options, task) => {
+        return task({ report: vi.fn() } as any);
+      });
+
+      vi.mocked(vscode.window.showInformationMessage).mockResolvedValue("Reload Now" as any);
+
+      await checkForUpdates(mockContext);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        "workbench.extensions.installExtension",
+        expect.anything()
+      );
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        "workbench.action.reloadWindow"
+      );
+      expect(globalStateStore["leetcodecity.lastUpdateCheck"]).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/vscode-extension/src/updater.test.ts
+++ b/packages/vscode-extension/src/updater.test.ts
@@ -66,6 +66,27 @@ describe("updater.ts", () => {
       expect(res).toBe(mockRes);
       expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
     });
+
+    it("propagates caller signal abort to controller signal", async () => {
+      const callerController = new AbortController();
+      (globalThis as any).fetch = vi.fn().mockImplementation((_url: string, init: any) => {
+        return new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            reject(new Error("Aborted by signal"));
+          });
+        });
+      });
+
+      const fetchPromise = fetchWithTimeout(
+        "https://example.com/test",
+        { signal: callerController.signal },
+        5000
+      );
+
+      callerController.abort();
+
+      await expect(fetchPromise).rejects.toThrow("Aborted by signal");
+    });
   });
 
   describe("fetchWithRetry", () => {
@@ -73,7 +94,7 @@ describe("updater.ts", () => {
       const mockRes = { ok: true, status: 200 };
       (globalThis as any).fetch = vi.fn().mockResolvedValue(mockRes);
 
-      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 10);
+      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 0);
       expect(res).toBe(mockRes);
       expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
     });
@@ -86,7 +107,7 @@ describe("updater.ts", () => {
         .mockResolvedValueOnce(failRes)
         .mockResolvedValueOnce(successRes);
 
-      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 10);
+      const res = await fetchWithRetry("https://example.com/test", {}, 1000, 2, 0);
       expect(res).toBe(successRes);
       expect((globalThis as any).fetch).toHaveBeenCalledTimes(2);
     });
@@ -96,7 +117,7 @@ describe("updater.ts", () => {
       (globalThis as any).fetch = vi.fn().mockResolvedValue(failRes);
 
       await expect(
-        fetchWithRetry("https://example.com/test", {}, 1000, 2, 10)
+        fetchWithRetry("https://example.com/test", {}, 1000, 2, 0)
       ).rejects.toThrow("HTTP 404 Not Found");
       expect((globalThis as any).fetch).toHaveBeenCalledTimes(3);
     });
@@ -112,7 +133,7 @@ describe("updater.ts", () => {
       (globalThis as any).fetch = vi.fn().mockResolvedValue(emptyRes);
 
       const tmpFile = path.join(os.tmpdir(), "test_empty.vsix");
-      await expect(downloadFile("https://example.com/empty.vsix", tmpFile)).rejects.toThrow(
+      await expect(downloadFile("https://example.com/empty.vsix", tmpFile, 0)).rejects.toThrow(
         "Downloaded file is empty"
       );
     });
@@ -127,7 +148,7 @@ describe("updater.ts", () => {
       (globalThis as any).fetch = vi.fn().mockResolvedValue(successRes);
 
       const tmpFile = path.join(os.tmpdir(), "test_success.vsix");
-      await downloadFile("https://example.com/valid.vsix", tmpFile);
+      await downloadFile("https://example.com/valid.vsix", tmpFile, 0);
 
       expect(fs.existsSync(tmpFile)).toBe(true);
       const readData = fs.readFileSync(tmpFile, "utf-8");
@@ -166,10 +187,17 @@ describe("updater.ts", () => {
     });
 
     it("logs warning and aborts cleanly when fetch throws an error", async () => {
+      vi.useFakeTimers();
       (globalThis as any).fetch = vi.fn().mockRejectedValue(new Error("Network disconnect"));
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await checkForUpdates(mockContext);
+      try {
+        const updatePromise = checkForUpdates(mockContext);
+        await vi.runAllTimersAsync();
+        await updatePromise;
+      } finally {
+        vi.useRealTimers();
+      }
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("[LeetCode City Updater] Check for updates failed: Network disconnect")
@@ -198,12 +226,12 @@ describe("updater.ts", () => {
     });
 
     it("shows warning message when update download/install fails", async () => {
+      vi.useFakeTimers();
       const mockPackageJsonRes = {
         ok: true,
         status: 200,
         text: vi.fn().mockResolvedValue(JSON.stringify({ version: "0.3.0" })),
       };
-      // package.json fetch succeeds, vsix download fails (e.g., 404)
       const failVsixRes = {
         ok: false,
         status: 404,
@@ -212,8 +240,8 @@ describe("updater.ts", () => {
 
       (globalThis as any).fetch = vi
         .fn()
-        .mockResolvedValueOnce(mockPackageJsonRes) // package.json check attempt 1
-        .mockResolvedValue(failVsixRes); // vsix download attempts
+        .mockResolvedValueOnce(mockPackageJsonRes)
+        .mockResolvedValue(failVsixRes);
 
       vi.mocked(vscode.extensions.getExtension).mockReturnValue({
         packageJSON: { version: "0.2.3" },
@@ -225,7 +253,13 @@ describe("updater.ts", () => {
 
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await checkForUpdates(mockContext);
+      try {
+        const updatePromise = checkForUpdates(mockContext);
+        await vi.runAllTimersAsync();
+        await updatePromise;
+      } finally {
+        vi.useRealTimers();
+      }
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("[LeetCode City Updater] Extension update failed")
@@ -233,7 +267,6 @@ describe("updater.ts", () => {
       expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining("🏙️ LeetCode City: Pulse update failed:")
       );
-      // Ensure globalState timestamp was NOT updated on failure
       expect(globalStateStore["leetcodecity.lastUpdateCheck"]).toBeUndefined();
     });
 

--- a/packages/vscode-extension/src/updater.ts
+++ b/packages/vscode-extension/src/updater.ts
@@ -25,6 +25,7 @@ export function compareSemver(a: string, b: string): number {
 
 /**
  * Perform a fetch call with timeout control via AbortController.
+ * Respects any caller-provided RequestInit.signal by propagating abort events.
  */
 export async function fetchWithTimeout(
   url: string,
@@ -33,6 +34,17 @@ export async function fetchWithTimeout(
 ): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let abortListener: (() => void) | undefined;
+  if (options.signal) {
+    if (options.signal.aborted) {
+      controller.abort();
+    } else {
+      abortListener = () => controller.abort();
+      options.signal.addEventListener("abort", abortListener);
+    }
+  }
+
   try {
     const res = await (globalThis as any).fetch(url, {
       ...options,
@@ -41,6 +53,9 @@ export async function fetchWithTimeout(
     return res;
   } finally {
     clearTimeout(timeoutId);
+    if (options.signal && abortListener) {
+      options.signal.removeEventListener("abort", abortListener);
+    }
   }
 }
 
@@ -75,8 +90,12 @@ export async function fetchWithRetry(
 /**
  * Download a file from a URL to a local path with retries and validation.
  */
-export async function downloadFile(url: string, destPath: string): Promise<void> {
-  const res = await fetchWithRetry(url, {}, 30000, 2, 1000);
+export async function downloadFile(
+  url: string,
+  destPath: string,
+  backoffMs = 1000
+): Promise<void> {
+  const res = await fetchWithRetry(url, {}, 30000, 2, backoffMs);
   const buffer = await res.arrayBuffer();
   if (!buffer || buffer.byteLength === 0) {
     throw new Error("Downloaded file is empty");
@@ -178,9 +197,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext): Promise
     );
   } finally {
     try {
-      if (fs.existsSync(vsixPath)) {
-        await fs.promises.unlink(vsixPath);
-      }
+      await fs.promises.unlink(vsixPath);
     } catch {
       /* best effort cleanup */
     }

--- a/packages/vscode-extension/src/updater.ts
+++ b/packages/vscode-extension/src/updater.ts
@@ -3,15 +3,15 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 
-const GITHUB_RAW_BASE =
+export const GITHUB_RAW_BASE =
   "https://raw.githubusercontent.com/Ixotic27/The-Leetcode-City/main/packages/vscode-extension";
 
-const PACKAGE_JSON_URL = `${GITHUB_RAW_BASE}/package.json`;
+export const PACKAGE_JSON_URL = `${GITHUB_RAW_BASE}/package.json`;
 
 /**
- * Compare two semver strings.  Returns 1 if a > b, -1 if a < b, 0 if equal.
+ * Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal.
  */
-function compareSemver(a: string, b: string): number {
+export function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map(Number);
   const pb = b.split(".").map(Number);
   for (let i = 0; i < 3; i++) {
@@ -24,71 +24,120 @@ function compareSemver(a: string, b: string): number {
 }
 
 /**
- * Download a file from a URL to a local path.
+ * Perform a fetch call with timeout control via AbortController.
  */
-async function downloadFile(url: string, destPath: string): Promise<void> {
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 5000
+): Promise<Response> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s timeout for download
-
-  const res = await (globalThis as any).fetch(url, { signal: controller.signal });
-  clearTimeout(timeoutId);
-
-  if (!res.ok) {
-    throw new Error(`Download failed: HTTP ${res.status}`);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await (globalThis as any).fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    return res;
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
 
+/**
+ * Perform fetch with retries on network failures, timeouts, or non-200 HTTP statuses.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 5000,
+  retries = 2,
+  backoffMs = 1000
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetchWithTimeout(url, options, timeoutMs);
+      if (res.ok) {
+        return res;
+      }
+      throw new Error(`HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}`);
+    } catch (err: any) {
+      lastError = err;
+      if (attempt < retries && backoffMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, backoffMs * (attempt + 1)));
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Download a file from a URL to a local path with retries and validation.
+ */
+export async function downloadFile(url: string, destPath: string): Promise<void> {
+  const res = await fetchWithRetry(url, {}, 30000, 2, 1000);
   const buffer = await res.arrayBuffer();
+  if (!buffer || buffer.byteLength === 0) {
+    throw new Error("Downloaded file is empty");
+  }
   await fs.promises.writeFile(destPath, Buffer.from(buffer));
 }
 
 /**
- * Runs once on activation – silently checks if a newer version exists on the
- * main branch. If so, downloads the .vsix and installs it automatically,
- * just like a marketplace extension update.
+ * Runs once on activation – checks if a newer version exists on the main branch.
+ * If so, downloads the .vsix and installs it automatically, with retries, logging,
+ * and robust error handling.
  *
  * Debounced: runs at most once every 6 hours via globalState timestamp.
  */
-export async function checkForUpdates(context: vscode.ExtensionContext) {
+export async function checkForUpdates(context: vscode.ExtensionContext): Promise<void> {
   const DEBOUNCE_MS = 6 * 60 * 60 * 1000; // 6 hours
   const lastCheck = context.globalState.get<number>("leetcodecity.lastUpdateCheck", 0);
   if (Date.now() - lastCheck < DEBOUNCE_MS) return;
 
+  let remotePackage: any;
   try {
-    // 1. Fetch remote package.json to get latest version
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const res = await fetchWithRetry(
+      PACKAGE_JSON_URL,
+      { headers: { "Cache-Control": "no-cache" } },
+      5000,
+      2,
+      1000
+    );
+    const rawText = await res.text();
+    remotePackage = JSON.parse(rawText);
+  } catch (err: any) {
+    console.warn(`[LeetCode City Updater] Check for updates failed: ${err?.message || err}`);
+    return;
+  }
 
-    const res = await (globalThis as any).fetch(PACKAGE_JSON_URL, {
-      signal: controller.signal,
-      headers: { "Cache-Control": "no-cache" },
-    });
-    clearTimeout(timeoutId);
+  const remoteVersion = remotePackage?.version;
+  if (typeof remoteVersion !== "string") {
+    console.warn("[LeetCode City Updater] Invalid remote package.json version format");
+    return;
+  }
 
-    if (!res.ok) return;
+  const ext = vscode.extensions.getExtension("leetcode-city.leetcode-city-pulse");
+  if (!ext) {
+    console.warn("[LeetCode City Updater] Extension 'leetcode-city.leetcode-city-pulse' not found");
+    return;
+  }
 
-    const remote = await res.json();
-    const remoteVersion = remote?.version;
+  const localVersion: string = ext.packageJSON.version;
 
-    // Validate that the remote version exists and is a string
-    if (typeof remoteVersion !== "string") return;
+  if (compareSemver(remoteVersion, localVersion) <= 0) {
+    // Update last-check timestamp if we are already on the latest version
+    await context.globalState.update("leetcodecity.lastUpdateCheck", Date.now());
+    return;
+  }
 
-    const ext = vscode.extensions.getExtension("leetcode-city.leetcode-city-pulse");
-    if (!ext) return;
+  // Newer version available — download the .vsix
+  const vsixUrl = `${GITHUB_RAW_BASE}/leetcode-city-pulse-${remoteVersion}.vsix`;
+  const tmpDir = os.tmpdir();
+  const vsixPath = path.join(tmpDir, `leetcode-city-pulse-${remoteVersion}.vsix`);
 
-    const localVersion: string = ext.packageJSON.version;
-
-    if (compareSemver(remoteVersion, localVersion) <= 0) {
-      // Update the last-check timestamp if we are already on the latest version
-      context.globalState.update("leetcodecity.lastUpdateCheck", Date.now());
-      return;
-    }
-
-    // 2. Newer version available — download the .vsix
-    const vsixUrl = `${GITHUB_RAW_BASE}/leetcode-city-pulse-${remoteVersion}.vsix`;
-    const tmpDir = os.tmpdir();
-    const vsixPath = path.join(tmpDir, `leetcode-city-pulse-${remoteVersion}.vsix`);
-
-    // Show a progress notification while downloading
+  try {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
@@ -99,22 +148,19 @@ export async function checkForUpdates(context: vscode.ExtensionContext) {
         progress.report({ message: "Downloading..." });
         await downloadFile(vsixUrl, vsixPath);
 
-        // 3. Install the .vsix using VS Code's built-in command
+        // Install the .vsix using VS Code's built-in command
         progress.report({ message: "Installing..." });
         await vscode.commands.executeCommand(
           "workbench.extensions.installExtension",
           vscode.Uri.file(vsixPath)
         );
-
-        // 4. Clean up the temp file
-        try { await fs.promises.unlink(vsixPath); } catch { /* best effort */ }
       }
     );
 
-    // Update the last-check timestamp ONLY after successful update
-    context.globalState.update("leetcodecity.lastUpdateCheck", Date.now());
+    // Update the last-check timestamp ONLY after successful download & installation
+    await context.globalState.update("leetcodecity.lastUpdateCheck", Date.now());
 
-    // 5. Prompt to reload so the new version activates
+    // Prompt to reload so the new version activates
     const action = await vscode.window.showInformationMessage(
       `🏙️ LeetCode City: Pulse has been updated to v${remoteVersion}! Please reload to activate.`,
       "Reload Now",
@@ -124,7 +170,19 @@ export async function checkForUpdates(context: vscode.ExtensionContext) {
     if (action === "Reload Now") {
       vscode.commands.executeCommand("workbench.action.reloadWindow");
     }
-  } catch {
-    // Network error, download failure, or timeout – fail silently.
+  } catch (err: any) {
+    const errMsg = err?.message || String(err);
+    console.warn(`[LeetCode City Updater] Extension update failed: ${errMsg}`);
+    vscode.window.showWarningMessage(
+      `🏙️ LeetCode City: Pulse update failed: ${errMsg}`
+    );
+  } finally {
+    try {
+      if (fs.existsSync(vsixPath)) {
+        await fs.promises.unlink(vsixPath);
+      }
+    } catch {
+      /* best effort cleanup */
+    }
   }
 }

--- a/src/components/AtmosphereCycleManager.tsx
+++ b/src/components/AtmosphereCycleManager.tsx
@@ -4,7 +4,7 @@
 import * as THREE from "three";
 import { useRef, useMemo, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
-// useGLTF removed — FlyingAirplane dead code, not rendered
+import { useGLTF } from "@react-three/drei";
 import { useWeather } from "@/context/WeatherContext";
 
 // Helper to interpolate two hex colors using THREE.Color

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "scripts", "packages", "scratch", "party"]
+  "exclude": ["node_modules", "scripts", "packages", "packages/**/*", "scratch", "party"]
 }


### PR DESCRIPTION
## What does this PR do?

Improves error handling, network resiliency, and logging in the VSCode extension updater (`packages/vscode-extension/src/updater.ts`):
- Added `fetchWithTimeout` using `AbortController` and `try...finally` to ensure timeout timers are always cleared cleanly.
- Added `fetchWithRetry` to handle transient network rejections, timeouts, and non-200 HTTP statuses with configurable retries and backoff.
- Refactored `downloadFile` to validate downloaded buffer length (> 0 bytes) and handle disk writing errors gracefully.
- Enhanced `checkForUpdates` to log detailed diagnostic messages (`console.warn("[LeetCode City Updater] ...")`) and display warning messages (`vscode.window.showWarningMessage`) when update downloads/installations fail during an active update attempt.
- Ensured temporary `.vsix` download files are cleaned up in a `finally` block and the debounce timestamp (`leetcodecity.lastUpdateCheck`) is updated ONLY upon a successful check or installation.
- Added comprehensive unit tests in `packages/vscode-extension/src/updater.test.ts`.

## Related issue

Fixes #1158

## Screenshots

N/A (Background updater logic and extension error handling)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**
