### PR TITLE
docs : added JSDoc to geo.ts exported functions

### DIFF
--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -7,6 +7,7 @@
  *   3. Browser language (`navigator.language`) — least reliable for devs with English OS
  */
 
+/** Set of IANA timezone identifiers covering Brazilian territory. */
 const BR_TIMEZONES = new Set([
   "America/Sao_Paulo",
   "America/Fortaleza",
@@ -26,7 +27,20 @@ const BR_TIMEZONES = new Set([
   "America/Santarem",
 ]);
 
-/** Client-side check. Use `serverCountry` from headers when available. */
+/**
+ * Detects whether the current user is likely in Brazil.
+ *
+ * Checks three signals in order of reliability:
+ *   1. `serverCountry` — the Vercel `x-vercel-ip-country` header (most reliable)
+ *   2. Browser `Intl.DateTimeFormat().resolvedOptions().timeZone` against BR timezones
+ *   3. Browser `navigator.language` starting with "pt" (least reliable)
+ *
+ * Returns `true` as soon as any signal matches. Safe to call on both
+ * server and client (guards against `navigator` being undefined on the server).
+ *
+ * @param serverCountry - The country code detected server-side, or null/undefined.
+ * @returns `true` if Brazil is detected, `false` otherwise.
+ */
 export function isBrazilClient(serverCountry?: string | null): boolean {
   if (serverCountry && serverCountry.toUpperCase() === "BR") return true;
   if (typeof navigator === "undefined") return false;


### PR DESCRIPTION
Closes #1300

## Summary of What Has Been Done
Enhanced JSDoc documentation in `src/lib/geo.ts`.

- Added JSDoc to `BR_TIMEZONES` constant explaining what it contains
- Enhanced `isBrazilClient()` JSDoc with complete description of the three detection signals, their reliability order, `@param` and `@returns` tags

## Changes Made
- `src/lib/geo.ts`: Added 15 lines of JSDoc documentation

## Impact it Made
Improves developer experience by documenting the Brazil detection logic and its three-signal hierarchy, making future maintenance and extension easier.

## Note
Please assign this PR to the `tmdeveloper007` account.