### PR TITLE
fix : Arcade Battle no longer accepts invalid code as passing

### DIFF
--- a/src/app/arcade/battle/page.tsx
+++ b/src/app/arcade/battle/page.tsx
@@ -280,7 +280,7 @@ export default function BattlePage() {
     let idx = 0;
     const interval = setInterval(() => {
       if (idx < activeProblem.tests.length) {
-        const passed = isCorrect || (idx < 3); // mock partially passing if incorrect
+        const passed = isCorrect;
         results.push(passed);
         setTestsEvaluated([...results]);
         setConsoleLogs((prev) => [


### PR DESCRIPTION
## What does this PR do?
Fixes the Arcade Battle `runTests` function to correctly evaluate test case results. Previously the first 3 tests always passed regardless of code correctness due to `|| (idx < 3)` condition.

## Related issue
Addresses: #1295

## Screenshots
N/A (game logic fix)

## Checklist
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] I have starred this Repository!

## Note: Please assign this PR to the `tmdeveloper007` account.