### PR TITLE
fix: remove emoji from VS Code extension updater notification strings

### DIFF
--- a/packages/vscode-extension/src/updater.ts
+++ b/packages/vscode-extension/src/updater.ts
@@ -92,7 +92,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext) {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: `🏙️ Updating LeetCode City: Pulse to v${remoteVersion}...`,
+        title: `LeetCode City: Pulse update to v${remoteVersion}...`,
         cancellable: false,
       },
       async (progress) => {
@@ -116,7 +116,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext) {
 
     // 5. Prompt to reload so the new version activates
     const action = await vscode.window.showInformationMessage(
-      `🏙️ LeetCode City: Pulse has been updated to v${remoteVersion}! Please reload to activate.`,
+      `LeetCode City: Pulse has been updated to v${remoteVersion}! Please reload to activate.`,
       "Reload Now",
       "Later"
     );


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the city emoji from the VS Code extension progress notification title and information message in `packages/vscode-extension/src/updater.ts`:
- Progress notification `title`: `LeetCode City: Pulse update to v{version}...` (removed city emoji prefix)
- Information message: `LeetCode City: Pulse has been updated to v{version}! Please reload to activate.` (removed city emoji prefix)

## Changes Made
- `packages/vscode-extension/src/updater.ts`: 2 string changes

## Impact it Made
- Consistent with project no-emoji policy
- Cleaner display in VS Code notifications

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #1327