### PR TITLE
docs: add JSDoc comments to vscode-key API route

### DIFF
--- a/src/app/api/vscode-key/route.ts
+++ b/src/app/api/vscode-key/route.ts
@@ -4,10 +4,20 @@ import crypto from "crypto";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * SHA-256 hash a VS Code API key for storage.
+ * @param key - The raw API key string to hash.
+ * @returns A 64-character hexadecimal SHA-256 digest.
+ */
 function hashKey(key: string): string {
   return crypto.createHash("sha256").update(key).digest("hex");
 }
 
+/**
+ * Resolves the authenticated developer ID from the current session.
+ * First tries matching by `claimed_by`, then falls back to GitHub login.
+ * @returns The developer `id` on success, or an `{ error, status }` object on failure.
+ */
 async function getAuthenticatedDevId(): Promise<{ devId: number } | { error: string; status: number }> {
   const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
   const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
@@ -45,6 +55,11 @@ async function getAuthenticatedDevId(): Promise<{ devId: number } | { error: str
   return { error: "Developer not found. Claim your building first.", status: 404 };
 }
 
+/**
+ * GET /api/vscode-key
+ * Returns whether the authenticated developer has a stored VS Code API key.
+ * @returns `{ hasKey: boolean }`
+ */
 export async function GET() {
   const auth = await getAuthenticatedDevId();
   if ("error" in auth) {
@@ -62,6 +77,11 @@ export async function GET() {
   return NextResponse.json({ hasKey: !!dev?.vscode_api_key_hash });
 }
 
+/**
+ * POST /api/vscode-key
+ * Generates and stores a new random VS Code API key for the authenticated developer.
+ * @returns `{ key: string }` containing the raw key (shown once, never stored).
+ */
 export async function POST() {
   const auth = await getAuthenticatedDevId();
   if ("error" in auth) {


### PR DESCRIPTION
## Summary of What Has Been Done
Added JSDoc comments to all exported and significant private functions in `src/app/api/vscode-key/route.ts`:
- `hashKey`: `@description`, `@param`, `@returns` describing SHA-256 hex digest
- `getAuthenticatedDevId`: `@description`, `@returns` describing session-based developer resolution
- `GET`: `@description`, `@returns` for the `hasKey` response
- `POST`: `@description`, `@returns` for the generated key response

## Changes Made
- `src/app/api/vscode-key/route.ts`: 20 lines of JSDoc added

## Impact it Made
- Improved IDE support and autocomplete for contributors
- Clearer API contract documentation inline with the code
- No functional change

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1328