### PR TITLE
fix: return error for invalid tab in leaderboard-position route

### DIFF
--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -75,6 +75,11 @@ export async function GET(request: Request) {
     });
     position = (devsAbove ?? 0) + 1;
     metricValue = String(achCount);
+  } else {
+    return NextResponse.json(
+      { error: "Invalid tab. Must be one of: solved, lc_rank, streak, contest, xp, achievers." },
+      { status: 400 }
+    );
   }
 
   return NextResponse.json(


### PR DESCRIPTION
## Summary of What Has Been Done
Added an `else` branch at the end of the tab validation chain in `GET /api/leaderboard-position` that returns a `400 Bad Request` with a descriptive error message when an unrecognized `tab` value is provided.

Previously, invalid tab values silently fell through all branches, leaving `position` as `null` and returning a seemingly-valid but misleading response to callers.

## Changes Made
- `src/app/api/leaderboard-position/route.ts`: Added `else` branch returning `{ "error": "Invalid tab. Must be one of: solved, lc_rank, streak, contest, xp, achievers." }` with status 400

## Impact it Made
- Clear and actionable error feedback for API consumers using invalid tab values
- Prevents silent failures where callers treat a null position as valid
- Improved API robustness and developer experience

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1329