### PR TITLE
feat: include avatar_url and name in search API results

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -9,6 +9,13 @@ const querySchema = z.object({
   q: z.string().optional(),
 });
 
+/**
+ * GET /api/search
+ * Searches developers by GitHub login (case-insensitive, partial match).
+ * Returns up to 8 results including avatar_url and name for richer UI display.
+ * @param req.query.q - Search term (min 2 chars, case-insensitive partial match)
+ * @returns Array of developer records matching the query
+ */
 export async function GET(req: NextRequest) {
   const queryVal = validateQuery(req.nextUrl.searchParams, querySchema);
   if (!queryVal.success) {
@@ -23,7 +30,7 @@ export async function GET(req: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("developers")
-    .select("github_login, easy_solved, medium_solved, hard_solved, lc_global_rank")
+    .select("github_login, name, avatar_url, easy_solved, medium_solved, hard_solved, lc_global_rank")
     .ilike("github_login", `%${q}%`)
     .limit(8);
 


### PR DESCRIPTION
## Summary of What Has Been Done
Updated the `GET /api/search` route to include `avatar_url` and `name` fields in the Supabase select query, matching the data shape returned by other developer-related endpoints like `/api/leaderboard-position`. Also added JSDoc to the GET handler.

## Changes Made
- `src/app/api/search/route.ts`:
  - Added JSDoc `@description`, `@param`, and `@returns` to the GET handler
  - Extended `.select()` to include `name` and `avatar_url` alongside existing fields

## Impact it Made
- Clients can display user avatars and names directly from search results without additional API calls
- Consistent data shape with other developer-related API endpoints
- Better UX in search dropdown/autocomplete UI

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1330