### PR TITLE
fix : reduce LeetCode calendar year range in parseMaxStreak from 2015 to 2020

### DIFF
--- a/src/lib/leetcode.ts
+++ b/src/lib/leetcode.ts
@@ -30,7 +30,7 @@ export async function fetchLeetCodeAboutMe(username: string): Promise<string | n
     }
 }
 
-// Calendars are keyed dynamically as `y<year>` (e.g. y2015, y2016, …),
+// Calendars are keyed dynamically as `y<year>` (e.g. y2020, y2021, …),
 // each holding a JSON-encoded submissionCalendar string.
 type YearCalendar = { submissionCalendar?: string };
 
@@ -40,7 +40,7 @@ export function parseMaxStreak(
 ): number {
     if (!matchedUser) return 0;
     const allTimestamps: number[] = [];
-    for (let y = 2015; y <= currentYear; y++) {
+    for (let y = 2020; y <= currentYear; y++) {
         const cal = (matchedUser[`y${y}`] as YearCalendar | undefined)?.submissionCalendar;
         if (cal) {
             try {


### PR DESCRIPTION
## What does this PR do?

Reduces the LeetCode calendar year range in `parseMaxStreak` from 2015 to 2020, significantly reducing unnecessary processing for most developers who have zero submissions in early years.

## Related issue

Fixes #831

## Screenshots

N/A (non-visual change)

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository!
