### PR TITLE
fix : validate and clamp saved radio settings in loadRadioState

### DIFF
--- a/src/lib/radio.ts
+++ b/src/lib/radio.ts
@@ -27,7 +27,12 @@ export function loadRadioState(): RadioState {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_STATE;
     const parsed = JSON.parse(raw);
-    return { ...DEFAULT_STATE, ...parsed };
+    const state: RadioState = { ...DEFAULT_STATE, ...parsed };
+    // Clamp volume to [0, 1] to prevent invalid audio levels
+    state.volume = Math.max(0, Math.min(1, state.volume));
+    // Clamp trackIndex to valid range to prevent out-of-bounds track access
+    state.trackIndex = Math.max(0, Math.min(TRACKS.length - 1, state.trackIndex));
+    return state;
   } catch (err) {
     console.warn("[radio.ts] failed to load saved radio state:", err);
     return DEFAULT_STATE;


### PR DESCRIPTION
## What does this PR do?

Adds validation and clamping to `loadRadioState` in `src/lib/radio.ts` so that saved radio settings (volume and trackIndex) are validated to valid ranges before being returned.

## Related issue

Fixes #1142

## Screenshots

N/A (non-visual change)

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository!
