### PR TITLE
fix : align Dockerfile Node version with package.json engines (node:22-alpine to node:24-alpine)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
## What does this PR do?

Aligns the Dockerfile base image from `node:22-alpine` to `node:24-alpine` to match the Node.js version specified in `package.json` engines field.

## Related issue

Fixes #1157

## Screenshots

N/A (infrastructure change)

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [ ] No secrets or .env values committed
- [ ] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository!
