### PR TITLE
fix : added colored tier indicators to emblem earned notification emails

### DIFF
--- a/src/lib/notification-senders/emblem.ts
+++ b/src/lib/notification-senders/emblem.ts
@@ -1,6 +1,6 @@
 import { sendNotificationAsync } from "../notifications";
 import { buildButton } from "../email-template";
-import { TIER_EMOJI } from "../achievements";
+import { TIER_COLORS } from "../achievements";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://thegitcity.com";
 
@@ -39,8 +39,8 @@ export function sendEmblemNotification(
 
   const emblemListHtml = notable
     .map((e) => {
-      const emoji = TIER_EMOJI[e.tier] ?? "";
-      return `<li style="margin-bottom:8px; font-size:15px; color:#555555;">${emoji} <strong style="color:#111111;">${e.name}</strong> <span style="color:#999;">(${e.tier})</span></li>`;
+      const tierColor = TIER_COLORS[e.tier] ?? "#888888";
+      return `<li style="margin-bottom:8px; font-size:15px; color:#555555;"><span style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background-color: ${tierColor}; margin-right: 8px;"></span><strong style="color:#111111;">${e.name}</strong> <span style="color:#999;">(${e.tier})</span></li>`;
     })
     .join("");
 


### PR DESCRIPTION
## What does this PR do?

Removes emoji characters from emblem earned notification emails by replacing TIER_EMOJI with TIER_COLORS.

## Summary of What Has Been Done

Replaced `TIER_EMOJI` usage in `src/lib/notification-senders/emblem.ts` with `TIER_COLORS` from the same module. Tier indicators are now rendered as colored circles instead of emoji characters.

## Changes Made

- `src/lib/notification-senders/emblem.ts`:
  - Changed import from `TIER_EMOJI` to `TIER_COLORS` from `../achievements`
  - Replaced `const emoji = TIER_EMOJI[e.tier] ?? ""` with `const tierColor = TIER_COLORS[e.tier] ?? "#888888"`
  - Updated HTML list item to render a colored circle span instead of an emoji character

## Impact it Made

- Emblem earned emails no longer contain emoji characters
- Tier information remains visually communicated through color-coded indicators
- All notification code now complies with the project-wide no-emoji policy

Closes #1385

Note: Please assign this PR to the `tmdeveloper007` account.
