### PR TITLE
fix : added null guard to stats API activeToday query

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -21,6 +21,7 @@ export async function GET() {
   const { count: activeToday } = await sb
     .from("developers")
     .select("id", { count: "exact", head: true })
+    .not("last_active_at", "is", null)
     .gte("last_active_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
 
   return NextResponse.json(


### PR DESCRIPTION
## What does this PR do?

Adds an explicit null guard to the activeToday query in the stats API.

## Summary of What Has Been Done

Added an explicit `.not("last_active_at", "is", null)` filter to the `activeToday` query in `src/app/api/stats/route.ts`. This makes the query intent explicit and provides an additional safety guard.

## Changes Made

- `src/app/api/stats/route.ts`:
  - Added `.not("last_active_at", "is", null)` before the `.gte("last_active_at", ...)` call in the `activeToday` query

## Impact it Made

- Active developer count query is more explicit and self-documenting
- Provides an additional safety guard against null value edge cases
- No functional changes to the returned stats data

Closes #1389

Note: Please assign this PR to the `tmdeveloper007` account.
