### PR TITLE
fix : added LIKE escape to developer search API

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -21,10 +21,12 @@ export async function GET(req: NextRequest) {
   }
 
   const supabase = getSupabaseAdmin();
+  // Escape LIKE special characters (% _ \) to prevent wildcard injection
+  const escapedQ = q.replace(/[%_\\]/g, (c) => (c === "\\" ? "\\\\" : `\\${c}`));
   const { data, error } = await supabase
     .from("developers")
     .select("github_login, easy_solved, medium_solved, hard_solved, lc_global_rank")
-    .ilike("github_login", `%${q}%`)
+    .ilike("github_login", `%${escapedQ}%`)
     .limit(8);
 
   if (error) {


### PR DESCRIPTION
## What does this PR do?

Adds LIKE special character escaping to the developer search API to prevent wildcard injection.

## Summary of What Has Been Done

Added escaping for LIKE special characters (`%`, `_`, `\`) in `src/app/api/search/route.ts` before passing the user query to Supabase's `.ilike()` method. The search string is now sanitized by prepending `\` to each special character, ensuring user input is treated as literal text in the LIKE pattern.

## Changes Made

- `src/app/api/search/route.ts`:
  - Added escaping: `q.replace(/[%_\\]/g, (c) => (c === "\\" ? "\\\\" : `\\${c}`))`
  - Applied escaped query to the `.ilike()` pattern instead of the raw query

## Impact it Made

- Search API returns accurate results for all query values including `%`, `_`, and `\`
- Prevents wildcard injection attacks via the developer search endpoint
- No functional changes to normal search behavior

Closes 1387

Note: Please assign this PR to the `tmdeveloper007` account.
