### PR TITLE
fix : added reduced calendar year range (2020 instead of 2015)

### DIFF
--- a/scripts/lc-hourly-fetcher.ts
+++ b/scripts/lc-hourly-fetcher.ts
@@ -55,8 +55,8 @@ function sleep(ms: number) {
 
 function calendarAliases(): string {
     const year = new Date().getFullYear();
-    // Return aliases from 2015 to current year
-    return Array.from({ length: year - 2014 }, (_, i) => 2015 + i)
+    // Return aliases from 2020 to current year (2015-2019 data is sparse on LC)
+    return Array.from({ length: year - 2019 }, (_, i) => 2020 + i)
         .map((y) => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`)
         .join("");
 }


### PR DESCRIPTION
## Summary of What Has Been Done

Changed the `calendarAliases()` function in `scripts/lc-hourly-fetcher.ts` to generate GraphQL aliases starting from 2020 instead of 2015. LeetCode user calendars have minimal meaningful data before 2020.

## Changes Made

- `scripts/lc-hourly-fetcher.ts`: Changed start year from 2015 to 2020 in the `calendarAliases()` function
  - Before: `Array.from({ length: year - 2014 }, (_, i) => 2015 + i)`
  - After: `Array.from({ length: year - 2019 }, (_, i) => 2020 + i)`

## Impact it Made

- Reduces unnecessary GraphQL payload by fetching only years with meaningful data
- Faster API response times during profile refresh
- Consistent with `parseMaxStreak` which already uses 2020 as the year floor

Closes #1431

Note: Please assign this PR to the `tmdeveloper007` account.
