### PR TITLE
fix : added time-based cleanup interval to in-memory rate limiter

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -38,6 +38,16 @@ export function _setMaxStoreSizeForTesting(size: number): void {
   MAX_STORE_SIZE = size;
 }
 
+// Periodic cleanup interval to prevent memory growth from expired entries
+// on cold-start serverless instances or processes with sparse traffic.
+let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
+
+function ensureCleanupInterval(): void {
+  if (cleanupIntervalId === null) {
+    cleanupIntervalId = setInterval(() => cleanup(true), CLEANUP_INTERVAL);
+  }
+}
+
 function cleanup(force = false) {
   const now = Date.now();
   if (!force && now - lastCleanup < CLEANUP_INTERVAL) return;
@@ -52,6 +62,7 @@ function rateLimitLocal(
   limit: number,
   windowMs: number,
 ): RateLimitResult {
+  ensureCleanupInterval();
   cleanup();
 
   const now = Date.now();


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `setInterval`-based periodic cleanup to the in-memory rate limiter fallback in `src/lib/rate-limit.ts`. The previous implementation only cleaned up expired entries when a new request arrived, meaning on serverless cold starts or processes with sparse traffic, expired entries would accumulate indefinitely.

## Changes Made

- `src/lib/rate-limit.ts`: Added `ensureCleanupInterval()` function that starts a `setInterval` timer calling `cleanup(true)` every `CLEANUP_INTERVAL` ms (default 60s). The interval is started lazily on first `rateLimitLocal` call.

## Impact it Made

- Prevents unbounded memory growth from expired rate limit entries in CI/serverless environments
- Ensures consistent cleanup regardless of request traffic patterns
- No impact on Redis-based deployments (Upstash Redis already manages its own state)

Closes #1432

Note: Please assign this PR to the `tmdeveloper007` account.
