### PR TITLE
fix : added graceful missing .env.local handling in add-leetcode-items script

### DIFF
--- a/scripts/add-leetcode-items.ts
+++ b/scripts/add-leetcode-items.ts
@@ -1,7 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 import { resolve } from "path";
+import { existsSync } from "fs";
 import dotenv from "dotenv";
-dotenv.config({ path: resolve(__dirname, "../.env.local") });
+
+const envPath = resolve(__dirname, "../.env.local");
+if (existsSync(envPath)) {
+    dotenv.config({ path: envPath });
+} else {
+    console.warn("Warning: .env.local not found. Ensure environment variables are set before running this script.");
+}
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;


### PR DESCRIPTION
## Summary of What Has Been Done

Added a file existence check before calling `dotenv.config()` in `scripts/add-leetcode-items.ts`. If `.env.local` is missing, the script now emits a clear warning instead of failing with a confusing downstream error.

## Changes Made

- `scripts/add-leetcode-items.ts`: Wrapped `dotenv.config()` with `fs.existsSync()` check; emits a warning if the env file is not found.

## Impact it Made

- Clearer developer experience during setup
- Prevents confusing downstream errors from missing env vars
- No impact on normal operation

Closes #1433

Note: Please assign this PR to the `tmdeveloper007` account.
