### PR TITLE
fix : prevent duplicate takeoff sound on raid intro phase transition

### DIFF
--- a/src/lib/raidAudio.ts
+++ b/src/lib/raidAudio.ts
@@ -38,6 +38,10 @@ export function stopRaidSound(name: string) {
   raidSounds?.[name]?.stop();
 }
 
+export function isRaidSoundPlaying(name: string): boolean {
+  return raidSounds?.[name]?.playing() ?? false;
+}
+
 export function fadeOutRaidSound(name: string, duration = 1000) {
   const s = raidSounds?.[name];
   if (s && s.playing()) {

--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { CityBuilding } from "@/lib/github";
 import type { RaidPreviewResponse, RaidExecuteResponse } from "@/lib/raid";
-import { preloadRaidAudio, playRaidSound, stopRaidSound, fadeOutRaidSound, stopAllRaidSounds } from "@/lib/raidAudio";
+import { preloadRaidAudio, playRaidSound, stopRaidSound, fadeOutRaidSound, stopAllRaidSounds, isRaidSoundPlaying } from "@/lib/raidAudio";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -108,7 +108,9 @@ export function useRaidSequence(): [RaidState, RaidActions] {
     switch (phase) {
       case "intro":
         preloadRaidAudio();
-        playRaidSound("takeoff");
+        if (!isRaidSoundPlaying("takeoff")) {
+          playRaidSound("takeoff");
+        }
         break;
       case "flight":
         playRaidSound("flight");


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `playing()` guard before calling `playRaidSound("takeoff")` in `src/lib/useRaidSequence.ts`. If the "takeoff" sound is already playing (e.g., from a previous phase transition), it will not be restarted. Also added an `isRaidSoundPlaying()` helper to `src/lib/raidAudio.ts` to expose the Howl `playing()` state.

## Changes Made

- `src/lib/raidAudio.ts`: Added `isRaidSoundPlaying(name: string): boolean` helper that returns true if the named sound is currently playing.
- `src/lib/useRaidSequence.ts`: Changed the "intro" phase audio trigger to guard with `!isRaidSoundPlaying("takeoff")` before calling `playRaidSound("takeoff")`.

## Impact it Made

- Eliminates duplicate takeoff sound on raid execution
- No negative side effects on other sounds or phases

Closes #1434

Note: Please assign this PR to the `tmdeveloper007` account.
