### PR TITLE
fix : added missing null guards for submitStats and userCalendar in upsertFullProfile

### DIFF
--- a/scripts/lc-hourly-fetcher.ts
+++ b/scripts/lc-hourly-fetcher.ts
@@ -112,6 +112,16 @@ async function upsertFullProfile(username: string, data: any): Promise<boolean> 
     const user = data?.matchedUser;
     if (!user) return false;
 
+    if (!user.submitStats) {
+        console.warn(`  [lc-refresh] Missing submitStats for ${username}, skipping.`);
+        return false;
+    }
+
+    if (!user.userCalendar) {
+        console.warn(`  [lc-refresh] Missing userCalendar for ${username}, skipping.`);
+        return false;
+    }
+
     const acNums = user.submitStats?.acSubmissionNum ?? [];
     const totNums = user.submitStats?.totalSubmissionNum ?? [];
     const getAC = (d: string) => acNums.find((x: any) => x.difficulty === d)?.count ?? 0;


### PR DESCRIPTION
## Summary of What Has Been Done

Added explicit null guards for `user.submitStats` and `user.userCalendar` in `scripts/lc-hourly-fetcher.ts`. The function now emits a warning and returns early if either property is missing, making failures more visible instead of silently propagating bad data.

## Changes Made

- `scripts/lc-hourly-fetcher.ts`: Added two early-return guards in `upsertFullProfile`:
  - `if (!user.submitStats)` - warns and returns false
  - `if (!user.userCalendar)` - warns and returns false

## Impact it Made

- Prevents crashes on malformed LeetCode API responses
- Makes failures more visible via explicit warnings
- Improves robustness of the hourly fetcher cron job

Closes #1435

Note: Please assign this PR to the `tmdeveloper007` account.
