### PR TITLE
🐛 fix(ci): resolve race condition between auto-labeler and gssoc validator

### DIFF
--- a/.github/workflows/gssoc-label-validator.yml
+++ b/.github/workflows/gssoc-label-validator.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     # Skip bot-triggered label events unless it's a review submission to avoid loops
     if: >
-      github.actor != 'github-actions[bot]' ||
-      github.event_name == 'pull_request_review'
+      github.event_name == 'pull_request_review' ||
+      github.event.action == 'labeled' ||
+      github.event.action == 'unlabeled' ||
+      github.actor != 'github-actions[bot]'
 
     steps:
       - name: Audit GSSoC Labels


### PR DESCRIPTION
## What does this PR do?

Updates the `jobs.validate-labels.if` guard in `.github/workflows/gssoc-label-validator.yml` to allow bot-driven `labeled` and `unlabeled` events to execute.

- Resolves the race condition where `gssoc-label-validator` evaluated pre-labeled snapshots on PR creation and failed permanently.
- Allows `github-actions[bot]` label events to re-audit the PR without causing workflow loops.

## Related issue

Fixes #1249

## Checklist

- [x] `npm run lint` / formatting passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**