### PR TITLE
feat: add custom cursor selector and dropdown menu

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -514,3 +514,20 @@ html, body {
   animation: rise 3.5s infinite ease-in 1.5s;
 }
 
+
+/* ─── Custom Cursors ─── */
+body[data-cursor="pixel"] *, body[data-cursor="pixel"] {
+  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><polygon points="0,0 0,18 5,13 11,20 14,18 8,11 16,11" fill="%23ffa116" stroke="%23000000" stroke-width="2"/></svg>') 0 0, auto;
+}
+
+body[data-cursor="glow"] *, body[data-cursor="glow"] {
+  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="%23ffa116" opacity="0.8" stroke="%23ffffff" stroke-width="2"/></svg>') 12 12, auto;
+}
+
+body[data-cursor="trail"] *, body[data-cursor="trail"] {
+  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4" fill="%2338bdf8" stroke="%23ffffff" stroke-width="2"/><circle cx="12" cy="12" r="9" fill="none" stroke="%2338bdf8" stroke-width="1.5" stroke-dasharray="2 2"/></svg>') 12 12, auto;
+}
+
+body[data-cursor="crosshair"] *, body[data-cursor="crosshair"] {
+  cursor: crosshair;
+}

--- a/src/components/ActionToolbar.tsx
+++ b/src/components/ActionToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CursorSelector from './CursorSelector';
 
 interface ActionToolbarProps {
   cycleTheme: () => void;
@@ -33,7 +34,7 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
   cycleWeather = () => {},
 }) => {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 flex-wrap">
       {/* Theme Cycle Button */}
       <button
         onClick={cycleTheme}
@@ -102,6 +103,9 @@ const ActionToolbar: React.FC<ActionToolbarProps> = ({
         <span style={{ color: theme.accent }} aria-hidden="true">&#9654;</span>
         <span>WEATHER: {weatherMode.toUpperCase()}</span>
       </button>
+
+      {/* Cursor Selector Widget */}
+      <CursorSelector accentColor={theme.accent} />
 
       {/* Audio/Radio Slot if mounted */}
       {isMounted && <div id="gc-radio-slot" />}

--- a/src/components/CursorSelector.tsx
+++ b/src/components/CursorSelector.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export type CursorType = 'default' | 'pixel' | 'glow' | 'trail' | 'crosshair';
+
+interface CursorSelectorProps {
+  accentColor?: string;
+}
+
+const CURSOR_OPTIONS: { id: CursorType; label: string }[] = [
+  { id: 'default', label: 'DEFAULT' },
+  { id: 'pixel', label: 'PIXEL' },
+  { id: 'glow', label: 'GLOW' },
+  { id: 'trail', label: 'TRAIL' },
+  { id: 'crosshair', label: 'CROSSHAIR' },
+];
+
+export const CursorSelector: React.FC<CursorSelectorProps> = ({ accentColor = '#3b82f6' }) => {
+  const [activeCursor, setActiveCursor] = useState<CursorType>('default');
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('leetcodecity_cursor') as CursorType;
+      if (saved && CURSOR_OPTIONS.some(c => c.id === saved)) {
+        setActiveCursor(saved);
+        document.body.setAttribute('data-cursor', saved);
+      }
+    } catch (err) {
+      console.warn('[CursorSelector] Failed to load cursor preference:', err);
+    }
+
+    // Close dropdown on outside click
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const changeCursor = (cursor: CursorType) => {
+    setActiveCursor(cursor);
+    document.body.setAttribute('data-cursor', cursor);
+    setIsOpen(false);
+    try {
+      localStorage.setItem('leetcodecity_cursor', cursor);
+    } catch (err) {
+      console.warn('[CursorSelector] Failed to save cursor preference:', err);
+    }
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="btn-press flex items-center gap-1.5 border-[3px] border-border bg-bg/70 px-2.5 py-1 text-[10px] backdrop-blur-sm transition-colors hover:border-border-light text-cream"
+        aria-expanded={isOpen}
+        aria-label={`Cursor style: currently ${activeCursor}`}
+        title="Select cursor style"
+      >
+        <span style={{ color: accentColor }} aria-hidden="true">&#9654;</span>
+        <span>CURSOR: {activeCursor.toUpperCase()}</span>
+        <span className="text-dim text-[8px] ml-1">&#9660;</span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full mb-1 left-0 z-50 min-w-[130px] border-[3px] border-border bg-bg/95 p-1 backdrop-blur-md shadow-xl flex flex-col gap-1">
+          {CURSOR_OPTIONS.map((opt) => {
+            const isSelected = activeCursor === opt.id;
+            return (
+              <button
+                key={opt.id}
+                onClick={() => changeCursor(opt.id)}
+                className={`flex items-center justify-between px-2 py-1.5 text-[10px] text-left transition-colors ${
+                  isSelected
+                    ? 'bg-amber-500/20 text-amber-400 font-bold border border-amber-500/50'
+                    : 'text-cream hover:bg-border/40 hover:text-white'
+                }`}
+              >
+                <span>{opt.label}</span>
+                {isSelected && <span style={{ color: accentColor }}>&#10003;</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CursorSelector;

--- a/src/components/CursorSelector.tsx
+++ b/src/components/CursorSelector.tsx
@@ -15,22 +15,28 @@ const CURSOR_OPTIONS: { id: CursorType; label: string }[] = [
 ];
 
 export const CursorSelector: React.FC<CursorSelectorProps> = ({ accentColor = '#3b82f6' }) => {
-  const [activeCursor, setActiveCursor] = useState<CursorType>('default');
+  const [activeCursor, setActiveCursor] = useState<CursorType>(() => {
+    try {
+      const saved = localStorage.getItem('leetcodecity_cursor') as CursorType;
+      if (saved && CURSOR_OPTIONS.some(c => c.id === saved)) {
+        return saved;
+      }
+    } catch (err) {
+      console.warn('[CursorSelector] Failed to load cursor preference:', err);
+    }
+    return 'default';
+  });
+
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     try {
-      const saved = localStorage.getItem('leetcodecity_cursor') as CursorType;
-      if (saved && CURSOR_OPTIONS.some(c => c.id === saved)) {
-        setActiveCursor(saved);
-        document.body.setAttribute('data-cursor', saved);
-      }
+      document.body.setAttribute('data-cursor', activeCursor);
     } catch (err) {
-      console.warn('[CursorSelector] Failed to load cursor preference:', err);
+      console.warn('[CursorSelector] Failed to set body cursor attribute:', err);
     }
 
-    // Close dropdown on outside click
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
@@ -38,11 +44,10 @@ export const CursorSelector: React.FC<CursorSelectorProps> = ({ accentColor = '#
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [activeCursor]);
 
   const changeCursor = (cursor: CursorType) => {
     setActiveCursor(cursor);
-    document.body.setAttribute('data-cursor', cursor);
     setIsOpen(false);
     try {
       localStorage.setItem('leetcodecity_cursor', cursor);


### PR DESCRIPTION
## What does this PR do?

- Added a new `CursorSelector` component to the `ActionToolbar` to allow users to customize their mouse cursor style.
- Implemented a retro pixel-themed dropdown menu with options: **Default**, **Pixel**, **Glow**, **Trail**, and **Crosshair**.
- Added persistent storage support via `localStorage` so user cursor preferences are saved across sessions.
- Injected dynamic cursor CSS styling rules mapped to the `body[data-cursor]` attribute.

## Related issue

Closes: #1271

## Screenshots / Demo

I have attached the video showing full working :

<img width="1710" height="985" alt="image" src="https://github.com/user-attachments/assets/574cfa46-9d8e-418a-9068-eb8729a99d78" />

https://github.com/user-attachments/assets/463e6060-9efa-4e7d-bfb7-02341747ea85



## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)