### PR TITLE
🐛 fix(rate-limit): add time-based cleanup interval to in-memory rate limiter

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -33,6 +33,7 @@ const CLEANUP_INTERVAL =
   Number(process.env.RATE_LIMIT_CLEANUP_INTERVAL_MS) || 60_000;
 export let MAX_STORE_SIZE =
   Number(process.env.RATE_LIMIT_MAX_STORE_SIZE) || 10_000;
+let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 export function _setMaxStoreSizeForTesting(size: number): void {
   MAX_STORE_SIZE = size;
@@ -47,11 +48,18 @@ function cleanup(force = false) {
   }
 }
 
+function ensureCleanupInterval(): void {
+  if (!cleanupIntervalId) {
+    cleanupIntervalId = setInterval(() => cleanup(true), CLEANUP_INTERVAL);
+  }
+}
+
 function rateLimitLocal(
   key: string,
   limit: number,
   windowMs: number,
 ): RateLimitResult {
+  ensureCleanupInterval();
   cleanup();
 
   const now = Date.now();
@@ -154,4 +162,9 @@ export async function rateLimit(
 export function _resetLocalStoreForTesting(): void {
   store.clear();
   lastCleanup = Date.now();
+
+  if (cleanupIntervalId) {
+    clearInterval(cleanupIntervalId);
+    cleanupIntervalId = null;
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a periodic time-based `setInterval` cleanup trigger to `src/lib/rate-limit.ts` for the in-memory fallback store.

- Introduces a module-scoped `cleanupIntervalId` timer to periodically invoke `cleanup(true)`.
- Implements `ensureCleanupInterval()` to initialize the timer guarded against duplicate intervals.
- Clears the interval in `_resetLocalStoreForTesting()` to prevent lingering timers during test runs.
- Prevents memory leaks from expired rate-limit entries in low-traffic or long-running serverless processes.

## Related issue

Fixes #1432

## Checklist

- [x] `npm run lint` / formatting passes
- [x] Tested locally via Vitest
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**