### PR TITLE
🐛 fix: return 500 instead of fake success when arcade favorite toggle throws

### DIFF
--- a/src/app/api/arcade/favorites/route.test.ts
+++ b/src/app/api/arcade/favorites/route.test.ts
@@ -48,9 +48,13 @@ function createListAdmin({ data = [], error = null, throws }: SelectResult) {
 function createToggleAdmin({
   existing,
   deleteError = null,
+  throws,
+  deleteThrows,
 }: {
   existing: FavoriteRow | null;
   deleteError?: { message: string } | null;
+  throws?: Error;
+  deleteThrows?: Error;
 }) {
   const insert = vi.fn().mockResolvedValue({ error: null });
   const del = vi.fn();
@@ -64,8 +68,13 @@ function createToggleAdmin({
       delEq(...args);
       return deleteBuilder;
     },
-    then: (resolve: (value: { error: { message: string } | null }) => unknown) =>
-      Promise.resolve({ error: deleteError }).then(resolve),
+    then: (
+      resolve: (value: { error: { message: string } | null }) => unknown,
+      reject?: (reason: unknown) => unknown
+    ) =>
+      deleteThrows
+        ? Promise.reject(deleteThrows).then(resolve, reject)
+        : Promise.resolve({ error: deleteError }).then(resolve, reject),
   };
 
   mockFrom.mockImplementation((table: string) => {
@@ -76,7 +85,9 @@ function createToggleAdmin({
     const query = {
       select: () => query,
       eq: () => query,
-      single: vi.fn().mockResolvedValue({ data: existing, error: null }),
+      single: vi.fn().mockImplementation(() =>
+        throws ? Promise.reject(throws) : Promise.resolve({ data: existing, error: null })
+      ),
       delete: () => {
         del();
         return deleteBuilder;
@@ -183,6 +194,34 @@ describe("/api/arcade/favorites", () => {
       expect(response.status).toBe(500);
       expect(response.headers.get("Cache-Control")).toBe("no-store");
       await expect(response.json()).resolves.toEqual({ error: "delete failed" });
+    });
+
+    it("does not fabricate success when the favorites table is unreachable", async () => {
+      // GET degrades to an empty list on a throw, but a write cannot be faked:
+      // a 200 here would suppress the client's `if (!res.ok)` rollback and leave
+      // the star lit for a row that was never written.
+      createToggleAdmin({ existing: null, throws: new Error("connection reset") });
+
+      const response = await POST(postRequest({ room_id: "lobby" }));
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      await expect(response.json()).resolves.toEqual({ error: "Could not toggle favorite" });
+    });
+
+    it("never reports favorited: true for an un-favorite that throws", async () => {
+      // The hardcoded fallback returned the *opposite* of the requested action
+      // whenever a removal threw, so assert on the body and not just the status.
+      createToggleAdmin({
+        existing: { room_id: "lobby" },
+        deleteThrows: new Error("connection reset"),
+      });
+
+      const response = await POST(postRequest({ room_id: "lobby" }));
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      await expect(response.json()).resolves.not.toMatchObject({ favorited: true });
     });
 
     it("does not allow validation errors to be cached", async () => {

--- a/src/app/api/arcade/favorites/route.ts
+++ b/src/app/api/arcade/favorites/route.ts
@@ -103,8 +103,17 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ favorited: true }, { headers: NO_STORE });
   } catch (e) {
-    console.warn("Could not toggle favorite in DB, fallback to fake success:", e);
-    // Just toggle locally
-    return NextResponse.json({ favorited: true }, { headers: NO_STORE });
+    // A throw here means the toggle never reached the table, so there is no
+    // state to report. The previous hardcoded `favorited: true` was wrong twice
+    // over: it claimed a write that did not happen, and for an un-favorite it
+    // returned the opposite of the action the user took. Unlike GET — where an
+    // unreachable table can safely degrade to "no favorites" — a write cannot
+    // be faked, so this surfaces a 500 and lets the optimistic update in
+    // /arcade roll back via its `if (!res.ok)` check.
+    console.error("Could not toggle favorite in DB:", e);
+    return NextResponse.json(
+      { error: "Could not toggle favorite" },
+      { status: 500, headers: NO_STORE }
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?

Stops `POST /api/arcade/favorites` from reporting success when the database write never happened.

### Scope note — half of this issue is already fixed on `main`

The issue describes two paths. Before writing anything I checked both against current `main`, and **path 1 is already resolved**: #1247 (merged earlier today) added the `deleteError` check to the remove-favorite path, along with the `NO_STORE` headers. Re-fixing it would be a no-op.

So this PR addresses **only the second path — the catch block**, which is still live on `main`:

```ts
} catch (e) {
  console.warn("Could not toggle favorite in DB, fallback to fake success:", e);
  // Just toggle locally
  return NextResponse.json({ favorited: true }, { headers: NO_STORE });
}
```

### Why the hardcoded value is wrong twice over

1. It claims a write that did not happen. `src/app/arcade/page.tsx:133` rolls back its optimistic update only via `if (!res.ok) setFavorites(prev)`, so a 200 means the rollback never fires and the star stays lit against a row that was never written.
2. Because the value is **hardcoded**, an *un*-favorite that throws responds `{ favorited: true }` — the opposite of the action the user took.

### The fix

The catch now returns a 500 so the client's existing rollback fires:

```ts
console.error("Could not toggle favorite in DB:", e);
return NextResponse.json(
  { error: "Could not toggle favorite" },
  { status: 500, headers: NO_STORE }
);
```

I kept the `NO_STORE` header that #1247 established, and left the `GET` fallback alone on purpose — degrading a *read* to "no favorites" keeps the room browser alive, but a *write* cannot be faked. That asymmetry is now stated in the comment so the fallback doesn't get re-added later.

`console.warn` → `console.error`, since this is now a real error path rather than a swallowed one.

### Tests

Two cases added to the existing `route.test.ts`, one per failure mode above. The `createToggleAdmin` helper gained `throws` / `deleteThrows` options so the mock can reject the way an unreachable table actually does.

**I verified the new tests fail without the fix** rather than assuming they were meaningful — stashing only `route.ts` and re-running:

```
× does not fabricate success when the favorites table is unreachable
  AssertionError: expected 200 to be 500
× never reports favorited: true for an un-favorite that throws
  AssertionError: expected 200 to be 500
Tests  2 failed | 10 passed (12)
```

Both pass with the fix — 12/12.

The second test asserts on the response **body**, not just the status, because the status alone would not have caught the inverted-action half of the bug.

## Related issue

Fixes #1245

## Screenshots

Not applicable — API error-handling change with no visual surface.

## Verification

```
npx vitest run src/app/api/arcade/favorites/route.test.ts   # 12/12 passed
npx eslint src/app/api/arcade/favorites/                    # clean, 0 problems
npm run build                                               # ✓ Compiled successfully (exit 0)
```

`src/app/arcade/page.tsx:128` is the only caller of this endpoint, and it already handles `!res.ok`, so no client change is needed.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**
