### PR TITLE
fix: reduce LeetCode calendar year range

### DIFF
--- a/scripts/lc-hourly-fetcher.ts
+++ b/scripts/lc-hourly-fetcher.ts
@@ -55,8 +55,8 @@ function sleep(ms: number) {
 
 function calendarAliases(): string {
     const year = new Date().getFullYear();
-    // Return aliases from 2015 to current year
-    return Array.from({ length: year - 2014 }, (_, i) => 2015 + i)
+    // Return aliases from 2020 to current year to avoid oversized LC calendar payloads.
+    return Array.from({ length: year - 2019 }, (_, i) => 2020 + i)
         .map((y) => `\n        y${y}: userCalendar(year: ${y}) { submissionCalendar }`)
         .join("");
 }


### PR DESCRIPTION
## What does this PR do?

Reduces the LeetCode GraphQL calendar year range in `scripts/lc-hourly-fetcher.ts` from `2015..currentYear` to `2020..currentYear`.

This keeps current and recent-year contribution calculations intact while avoiding older calendar payloads that increase response size and request cost.

## Related issue

Fixes #1431

## Screenshots

Not applicable. This is a backend fetcher/performance change with no UI impact.

## Checklist

- [x] `git diff --check` passes
- [x] `npm run build` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [ ] I have starred this repository

## Changes made

- Updated `calendarAliases()` to generate aliases from 2020 through the current year.
- Updated the inline comment to document the smaller payload intent.
- Kept the fetcher behavior scoped to the approved issue.

## Testing notes

- `git diff --check` passed.
- `npm run build` passed.
- `npx eslint scripts/lc-hourly-fetcher.ts` reports this script is ignored by the repo's ESLint config.
- `npx eslint --no-ignore scripts/lc-hourly-fetcher.ts` surfaces existing lint issues in this script (`any` usage and an unused variable) that are unrelated to this range change, so I did not expand the PR into a broader lint cleanup.