### PR TITLE
fix : removed emoji from VS Code extension updater notification strings

### DIFF
--- a/packages/vscode-extension/src/updater.test.ts
+++ b/packages/vscode-extension/src/updater.test.ts
@@ -265,7 +265,7 @@ describe("updater.ts", () => {
         expect.stringContaining("[LeetCode City Updater] Extension update failed")
       );
       expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining("🏙️ LeetCode City: Pulse update failed:")
+        expect.stringContaining("LeetCode City: Pulse update failed:")
       );
       expect(globalStateStore["leetcodecity.lastUpdateCheck"]).toBeUndefined();
     });

--- a/packages/vscode-extension/src/updater.ts
+++ b/packages/vscode-extension/src/updater.ts
@@ -160,7 +160,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext): Promise
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: `🏙️ Updating LeetCode City: Pulse to v${remoteVersion}...`,
+        title: `Updating LeetCode City: Pulse to v${remoteVersion}...`,
         cancellable: false,
       },
       async (progress) => {
@@ -181,7 +181,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext): Promise
 
     // Prompt to reload so the new version activates
     const action = await vscode.window.showInformationMessage(
-      `🏙️ LeetCode City: Pulse has been updated to v${remoteVersion}! Please reload to activate.`,
+      `LeetCode City: Pulse has been updated to v${remoteVersion}! Please reload to activate.`,
       "Reload Now",
       "Later"
     );
@@ -193,7 +193,7 @@ export async function checkForUpdates(context: vscode.ExtensionContext): Promise
     const errMsg = err?.message || String(err);
     console.warn(`[LeetCode City Updater] Extension update failed: ${errMsg}`);
     vscode.window.showWarningMessage(
-      `🏙️ LeetCode City: Pulse update failed: ${errMsg}`
+      `LeetCode City: Pulse update failed: ${errMsg}`
     );
   } finally {
     try {


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the city emoji (`🏙`) from the VS Code extension update progress notification strings in the extension updater module. Replaced with plain text.

## Changes Made

- `packages/vscode-extension/src/updater.ts`: removed `🏙` prefix from three notification strings (progress title, success message, error message)
- `packages/vscode-extension/src/updater.test.ts`: updated test expectation to match the new emoji-free string

## Impact it Made

- VS Code extension notification strings comply with the project-wide no-emoji policy
- Extension status messages remain clear and informative
- No functional changes to the update flow

## Note

Please assign this PR to the `tmdeveloper007` account.