### PR TITLE
feat : added avatar_url and name to search API results

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
   const escapedQ = q.replace(/[%_\\]/g, (c) => (c === "\\" ? "\\\\" : `\\${c}`));
   const { data, error } = await supabase
     .from("developers")
-    .select("github_login, easy_solved, medium_solved, hard_solved, lc_global_rank")
+    .select("github_login, avatar_url, name, easy_solved, medium_solved, hard_solved, lc_global_rank")
     .ilike("github_login", `%${escapedQ}%`)
     .limit(8);
 


### PR DESCRIPTION
## Summary of What Has Been Done

Extended the search API `GET /api/search` to return `avatar_url` and `name` fields alongside the existing fields, matching the shape returned by other endpoints like `leaderboard-position`.

## Changes Made

- `src/app/api/search/route.ts`: added `avatar_url` and `name` to the Supabase `.select()` call

## Impact it Made

- Search results now include avatar URL and display name, eliminating the need for clients to make additional API calls to fetch this information
- Search result shape is now consistent with other developer-profile endpoints
- No changes to API contract for existing fields

## Note

Please assign this PR to the `tmdeveloper007` account.