### PR TITLE
docs : added JSDoc comments to vscode-key API route

### DIFF
--- a/src/app/api/vscode-key/route.ts
+++ b/src/app/api/vscode-key/route.ts
@@ -4,10 +4,19 @@ import crypto from "crypto";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * SHA-256 hash of a VS Code extension API key.
+ * @param key - The raw API key string to hash.
+ * @returns A 64-character hexadecimal SHA-256 digest.
+ */
 function hashKey(key: string): string {
   return crypto.createHash("sha256").update(key).digest("hex");
 }
 
+/**
+ * Resolves the authenticated developer ID from the current session.
+ * @returns The developer's database ID on success, or an error object on failure.
+ */
 async function getAuthenticatedDevId(): Promise<{ devId: number } | { error: string; status: number }> {
   const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
   const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
@@ -45,6 +54,11 @@ async function getAuthenticatedDevId(): Promise<{ devId: number } | { error: str
   return { error: "Developer not found. Claim your building first.", status: 404 };
 }
 
+/**
+ * GET /api/vscode-key
+ * Returns whether the authenticated developer has a VS Code API key set.
+ * @returns JSON with `hasKey: boolean`.
+ */
 export async function GET() {
   const auth = await getAuthenticatedDevId();
   if ("error" in auth) {
@@ -62,6 +76,12 @@ export async function GET() {
   return NextResponse.json({ hasKey: !!dev?.vscode_api_key_hash });
 }
 
+/**
+ * POST /api/vscode-key
+ * Generates and stores a new VS Code API key for the authenticated developer.
+ * The raw key is returned once; only its SHA-256 hash is persisted.
+ * @returns JSON with `key: string` (the raw key, shown only once).
+ */
 export async function POST() {
   const auth = await getAuthenticatedDevId();
   if ("error" in auth) {


### PR DESCRIPTION
## Summary of What Has Been Done

Added comprehensive JSDoc comments to all exported functions and internal helpers in `src/app/api/vscode-key/route.ts`, including parameter types, return shapes, and descriptions of behavior.

## Changes Made

- `src/app/api/vscode-key/route.ts`:
  - Added `@param` and `@returns` JSDoc to `hashKey()`
  - Added description JSDoc to `getAuthenticatedDevId()` documenting its return shape
  - Added `@returns` JSDoc to `GET` handler describing the `{ hasKey: boolean }` response
  - Added `@returns` JSDoc to `POST` handler describing the `{ key: string }` response

## Impact it Made

- Improved IDE autocomplete and type hints for contributors working with this API route
- Clear API contract documentation for both GET and POST handlers
- Consistent with the project's JSDoc documentation standards

## Note

Please assign this PR to the `tmdeveloper007` account.