### PR TITLE
fix(arcade): fail discovery POST when persistence throws

### DIFF
--- a/src/app/api/arcade/discoveries/route.ts
+++ b/src/app/api/arcade/discoveries/route.ts
@@ -53,15 +53,21 @@ export async function POST(request: Request) {
 
   try {
     // Get current discoveries
-    const { data: existing } = await sb
+    const { data: existing, error: readError } = await sb
       .from("arcade_discoveries")
       .select("commands")
       .eq("user_id", userId)
       .maybeSingle();
 
+    if (readError) {
+      console.error("Discoveries read error:", readError);
+      return NextResponse.json({ error: "Failed to save" }, { status: 500 });
+    }
+
     current = existing?.commands ?? [];
   } catch (e) {
-    console.warn("Could not query arcade_discoveries on POST:", e);
+    console.error("Could not query arcade_discoveries on POST:", e);
+    return NextResponse.json({ error: "Failed to save" }, { status: 500 });
   }
 
   // Already discovered
@@ -86,7 +92,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Failed to save" }, { status: 500 });
     }
   } catch (e) {
-    console.warn("Could not upsert discoveries, mocking success:", e);
+    console.error("Could not upsert discoveries:", e);
+    return NextResponse.json({ error: "Failed to save" }, { status: 500 });
   }
 
   return NextResponse.json({ commands: updated, new: true });

--- a/src/app/arcade/[slug]/page.tsx
+++ b/src/app/arcade/[slug]/page.tsx
@@ -1274,14 +1274,22 @@ export default function ArcadeRoomPage({
     });
     setTerminalLines((prev) => [...prev, ...lines]);
 
-    // Save new discovery to server
+    // Persist discovery only after a successful write
     if (discovery && !discoveriesRef.current.includes(discovery)) {
-      discoveriesRef.current.push(discovery);
       fetch("/api/arcade/discoveries", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ command: discovery }),
-      }).catch(() => {});
+      })
+        .then(async (r) => {
+          if (!r.ok) return;
+          const data = (await r.json()) as { commands?: string[] };
+          discoveriesRef.current = data.commands ?? [
+            ...discoveriesRef.current,
+            discovery,
+          ];
+        })
+        .catch(() => {});
     }
   };
 


### PR DESCRIPTION
## What does this PR do?

Discovery upserts that throw were catching the error, logging "mocking success", and still returning `{ new: true }`. Terminal then kept the command unlocked in memory until refresh wiped it.

POST now returns 500 on read/write failures. Client only updates `discoveriesRef` after a successful response.

## Related issue

Fixes #1294

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

Made with [Cursor](https://cursor.com)