### PR TITLE
fix(arcade): run battle submissions against real test cases

### DIFF
--- a/src/app/arcade/battle/page.tsx
+++ b/src/app/arcade/battle/page.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/lib/supabase";
+import {
+  runBattleTests,
+  type BattleTestCase,
+} from "@/lib/arcade/battleJudge";
 
 // Custom styles for CRT, retro borders, and scanlines
 const RETRO_CSS = `
@@ -84,9 +88,10 @@ interface Problem {
   difficulty: "Easy" | "Medium" | "Hard";
   stars: string;
   description: string;
+  fnName: string;
   defaultCode: string;
   solutionTemplate: string;
-  tests: { input: string; output: string }[];
+  tests: BattleTestCase[];
 }
 
 const PROBLEMS: Record<string, Problem> = {
@@ -95,14 +100,15 @@ const PROBLEMS: Record<string, Problem> = {
     difficulty: "Easy",
     stars: "★☆☆",
     description: "Given an array of integers nums and an integer target, return indices of the two numbers such that they add up to target.",
+    fnName: "twoSum",
     defaultCode: `def twoSum(nums, target):\n    # Write your code here\n    pass`,
     solutionTemplate: `def twoSum(nums, target):\n    seen = {}\n    for i, num in enumerate(nums):\n        diff = target - num\n        if diff in seen:\n            return [seen[diff], i]\n        seen[num] = i\n    return []`,
     tests: [
-      { input: "nums = [2,7,11,15], target = 9", output: "[0, 1]" },
-      { input: "nums = [3,2,4], target = 6", output: "[1, 2]" },
-      { input: "nums = [3,3], target = 6", output: "[0, 1]" },
-      { input: "nums = [1,5,8,3], target = 11", output: "[2, 3]" },
-      { input: "nums = [2,5,5,11], target = 10", output: "[1, 2]" },
+      { input: "nums = [2,7,11,15], target = 9", output: "[0, 1]", args: [[2, 7, 11, 15], 9], expected: [0, 1] },
+      { input: "nums = [3,2,4], target = 6", output: "[1, 2]", args: [[3, 2, 4], 6], expected: [1, 2] },
+      { input: "nums = [3,3], target = 6", output: "[0, 1]", args: [[3, 3], 6], expected: [0, 1] },
+      { input: "nums = [1,5,8,3], target = 11", output: "[2, 3]", args: [[1, 5, 8, 3], 11], expected: [2, 3] },
+      { input: "nums = [2,5,5,11], target = 10", output: "[1, 2]", args: [[2, 5, 5, 11], 10], expected: [1, 2] },
     ]
   },
   container: {
@@ -110,14 +116,15 @@ const PROBLEMS: Record<string, Problem> = {
     difficulty: "Medium",
     stars: "★★☆",
     description: "Find two lines that together with the x-axis form a container, such that the container contains the most water.",
+    fnName: "maxArea",
     defaultCode: `def maxArea(height):\n    # Write your code here\n    l, r = 0, len(height) - 1\n    res = 0\n    return res`,
     solutionTemplate: `def maxArea(height):\n    l, r = 0, len(height) - 1\n    res = 0\n    while l < r:\n        width = r - l\n        area = min(height[l], height[r]) * width\n        res = max(res, area)\n        if height[l] < height[r]:\n            l += 1\n        else:\n            r -= 1\n    return res`,
     tests: [
-      { input: "height = [1,8,6,2,5,4,8,3,7]", output: "49" },
-      { input: "height = [1,1]", output: "1" },
-      { input: "height = [4,3,2,1,4]", output: "16" },
-      { input: "height = [1,2,1]", output: "2" },
-      { input: "height = [2,3,4,5,18,17,6]", output: "17" },
+      { input: "height = [1,8,6,2,5,4,8,3,7]", output: "49", args: [[1, 8, 6, 2, 5, 4, 8, 3, 7]], expected: 49 },
+      { input: "height = [1,1]", output: "1", args: [[1, 1]], expected: 1 },
+      { input: "height = [4,3,2,1,4]", output: "16", args: [[4, 3, 2, 1, 4]], expected: 16 },
+      { input: "height = [1,2,1]", output: "2", args: [[1, 2, 1]], expected: 2 },
+      { input: "height = [2,3,4,5,18,17,6]", output: "17", args: [[2, 3, 4, 5, 18, 17, 6]], expected: 17 },
     ]
   }
 };
@@ -267,20 +274,16 @@ export default function BattlePage() {
   const runTests = () => {
     setSolveMode("testing");
     setConsoleLogs(["[compiler] Compiling main.py...", "[compiler] Running test cases..."]);
+    setTestsPassed(0);
+    setTestsEvaluated([]);
 
-    const timerIdx = [0, 1, 2, 3, 4];
+    const judged = runBattleTests(code, activeProblem.fnName, activeProblem.tests);
     const results: boolean[] = [];
-
-    // Evaluate code correctness based on if it matches solution length/keywords
-    const normalized = code.replace(/\s+/g, "");
-    const correctNormalized = activeProblem.solutionTemplate.replace(/\s+/g, "");
-    // Check key variables to mock correct vs incorrect solution
-    const isCorrect = normalized.includes("seen") || normalized.includes("width=r-l") || normalized === correctNormalized;
-
     let idx = 0;
+
     const interval = setInterval(() => {
       if (idx < activeProblem.tests.length) {
-        const passed = isCorrect || (idx < 3); // mock partially passing if incorrect
+        const passed = judged[idx]?.passed === true;
         results.push(passed);
         setTestsEvaluated([...results]);
         setConsoleLogs((prev) => [

--- a/src/lib/arcade/__tests__/battleJudge.test.ts
+++ b/src/lib/arcade/__tests__/battleJudge.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { runBattleTests, transpilePythonSubset } from "../battleJudge";
+
+const TWO_SUM = `def twoSum(nums, target):
+    seen = {}
+    for i, num in enumerate(nums):
+        diff = target - num
+        if diff in seen:
+            return [seen[diff], i]
+        seen[num] = i
+    return []`;
+
+const TWO_SUM_BRUTE = `def twoSum(nums, target):
+    for i, a in enumerate(nums):
+        for j, b in enumerate(nums):
+            if i != j and a + b == target:
+                return [i, j]
+    return []`;
+
+const MAX_AREA = `def maxArea(height):
+    l, r = 0, len(height) - 1
+    res = 0
+    while l < r:
+        width = r - l
+        area = min(height[l], height[r]) * width
+        res = max(res, area)
+        if height[l] < height[r]:
+            l += 1
+        else:
+            r -= 1
+    return res`;
+
+const TWO_SUM_TESTS = [
+  { input: "", output: "", args: [[2, 7, 11, 15], 9], expected: [0, 1] },
+  { input: "", output: "", args: [[3, 2, 4], 6], expected: [1, 2] },
+  { input: "", output: "", args: [[3, 3], 6], expected: [0, 1] },
+];
+
+const MAX_AREA_TESTS = [
+  { input: "", output: "", args: [[1, 8, 6, 2, 5, 4, 8, 3, 7]], expected: 49 },
+  { input: "", output: "", args: [[1, 1]], expected: 1 },
+  { input: "", output: "", args: [[4, 3, 2, 1, 4]], expected: 16 },
+];
+
+describe("battleJudge", () => {
+  it("rejects keyword-only fake solutions", () => {
+    const results = runBattleTests("# seen", "twoSum", TWO_SUM_TESTS);
+    expect(results.every((r) => r.passed)).toBe(false);
+  });
+
+  it("accepts the hash-map twoSum template", () => {
+    const results = runBattleTests(TWO_SUM, "twoSum", TWO_SUM_TESTS);
+    expect(results.every((r) => r.passed)).toBe(true);
+  });
+
+  it("accepts an equivalent brute-force twoSum", () => {
+    const results = runBattleTests(TWO_SUM_BRUTE, "twoSum", TWO_SUM_TESTS);
+    expect(results.every((r) => r.passed)).toBe(true);
+  });
+
+  it("accepts the maxArea template", () => {
+    const results = runBattleTests(MAX_AREA, "maxArea", MAX_AREA_TESTS);
+    expect(results.every((r) => r.passed)).toBe(true);
+  });
+
+  it("fails default stub code", () => {
+    const stub = `def twoSum(nums, target):\n    pass`;
+    const results = runBattleTests(stub, "twoSum", TWO_SUM_TESTS);
+    expect(results.every((r) => r.passed)).toBe(false);
+  });
+
+  it("transpiles enumerate loops", () => {
+    const js = transpilePythonSubset(TWO_SUM);
+    expect(js).toContain("function twoSum");
+    expect(js).toContain("for (let i = 0;");
+  });
+});

--- a/src/lib/arcade/battleJudge.ts
+++ b/src/lib/arcade/battleJudge.ts
@@ -1,0 +1,262 @@
+/** Local Arcade Battle judge: runs submitted Python-like code against structured tests. */
+
+export type BattleTestCase = {
+  /** Human-readable input shown in the console */
+  input: string;
+  /** Human-readable expected output shown in the console */
+  output: string;
+  /** Arguments passed to the solution function */
+  args: unknown[];
+  /** Expected return value (deep-compared) */
+  expected: unknown;
+};
+
+export type BattleTestResult = {
+  passed: boolean;
+  error?: string;
+};
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const keys = Object.keys(ao);
+    if (keys.length !== Object.keys(bo).length) return false;
+    return keys.every((k) => deepEqual(ao[k], bo[k]));
+  }
+  return false;
+}
+
+/**
+ * Transpile a small Python subset used by Arcade Battle templates into JS.
+ * Supports: def/if/elif/else/while/for-enumerate/for-in, len, min/max, dict `in`,
+ * tuple unpack assignment, True/False/None, pass, and # comments.
+ */
+export function transpilePythonSubset(source: string): string {
+  const rawLines = source.replace(/\r\n/g, "\n").split("\n");
+  const lines: string[] = [];
+
+  for (const raw of rawLines) {
+    const hash = raw.indexOf("#");
+    const withoutComment = hash >= 0 ? raw.slice(0, hash) : raw;
+    if (withoutComment.trim().length === 0) continue;
+    lines.push(withoutComment.replace(/\t/g, "    "));
+  }
+
+  const indentOf = (line: string) => {
+    const m = line.match(/^ */);
+    return m ? Math.floor(m[0].length / 4) : 0;
+  };
+
+  const rewriteExpr = (expr: string): string => {
+    let e = expr.trim();
+    e = e.replace(/\bTrue\b/g, "true");
+    e = e.replace(/\bFalse\b/g, "false");
+    e = e.replace(/\bNone\b/g, "null");
+    e = e.replace(/\band\b/g, "&&");
+    e = e.replace(/\bor\b/g, "||");
+    e = e.replace(/\bnot\b/g, "!");
+    e = e.replace(/\blen\s*\(/g, "__len__(");
+    e = e.replace(/\bmin\s*\(/g, "Math.min(");
+    e = e.replace(/\bmax\s*\(/g, "Math.max(");
+    // `x in mapping` → key check (Arcade Battle only uses dict membership)
+    e = e.replace(
+      /(\b[\w.]+)\s+in\s+(\b[\w.]+)/g,
+      "Object.prototype.hasOwnProperty.call($2, $1)",
+    );
+    return e;
+  };
+
+  const out: string[] = [];
+  const stack: number[] = [0];
+  const declared = new Set<string>();
+
+  const closeTo = (level: number) => {
+    while (stack.length > 1 && stack[stack.length - 1] > level) {
+      stack.pop();
+      out.push("}");
+    }
+  };
+
+  const declareOrAssign = (name: string, rhs: string) => {
+    if (declared.has(name)) {
+      out.push(`${name} = ${rhs};`);
+    } else {
+      declared.add(name);
+      out.push(`let ${name} = ${rhs};`);
+    }
+  };
+
+  for (const line of lines) {
+    const indent = indentOf(line);
+    const content = line.trim();
+
+    closeTo(indent);
+
+    if (content === "pass") {
+      out.push(";");
+      continue;
+    }
+
+    const defMatch = content.match(/^def\s+(\w+)\s*\((.*)\)\s*:$/);
+    if (defMatch) {
+      declared.clear();
+      for (const param of defMatch[2].split(",").map((p) => p.trim()).filter(Boolean)) {
+        declared.add(param);
+      }
+      out.push(`function ${defMatch[1]}(${defMatch[2]}) {`);
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const elifMatch = content.match(/^elif\s+(.+):$/);
+    if (elifMatch) {
+      // closeTo() already closed the previous if/elif body
+      out.push(`else if (${rewriteExpr(elifMatch[1])}) {`);
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const elseMatch = content.match(/^else\s*:$/);
+    if (elseMatch) {
+      out.push("else {");
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const ifMatch = content.match(/^if\s+(.+):$/);
+    if (ifMatch) {
+      out.push(`if (${rewriteExpr(ifMatch[1])}) {`);
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const whileMatch = content.match(/^while\s+(.+):$/);
+    if (whileMatch) {
+      out.push(`while (${rewriteExpr(whileMatch[1])}) {`);
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const enumMatch = content.match(
+      /^for\s+(\w+)\s*,\s*(\w+)\s+in\s+enumerate\s*\(\s*([\w.]+)\s*\)\s*:$/,
+    );
+    if (enumMatch) {
+      const [, i, val, arr] = enumMatch;
+      declared.add(i);
+      declared.add(val);
+      out.push(
+        `for (let ${i} = 0; ${i} < __len__(${arr}); ${i}++) { const ${val} = ${arr}[${i}];`,
+      );
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const forInMatch = content.match(/^for\s+(\w+)\s+in\s+(.+):$/);
+    if (forInMatch) {
+      declared.add(forInMatch[1]);
+      out.push(`for (const ${forInMatch[1]} of ${rewriteExpr(forInMatch[2])}) {`);
+      stack.push(indent + 1);
+      continue;
+    }
+
+    const compoundMatch = content.match(/^([\w.\[\]]+)\s*(\+\=|\-\=|\*\=|\/\=)\s*(.+)$/);
+    if (compoundMatch) {
+      out.push(
+        `${compoundMatch[1]} ${compoundMatch[2]} ${rewriteExpr(compoundMatch[3])};`,
+      );
+      continue;
+    }
+
+    const unpackMatch = content.match(/^([\w\s,]+)=(.+)$/);
+    if (unpackMatch && unpackMatch[1].includes(",")) {
+      const names = unpackMatch[1]
+        .split(",")
+        .map((n) => n.trim())
+        .filter(Boolean);
+      for (const n of names) declared.add(n);
+      const rhs = rewriteExpr(unpackMatch[2]);
+      out.push(`let [${names.join(", ")}] = [${rhs}];`);
+      continue;
+    }
+
+    if (content.startsWith("return ")) {
+      out.push(`return ${rewriteExpr(content.slice(7))};`);
+      continue;
+    }
+
+    const assignMatch = content.match(/^([\w.\[\]]+)\s*=\s*(.+)$/);
+    if (
+      assignMatch &&
+      !content.includes("==") &&
+      !content.includes("!=") &&
+      !content.includes("<=") &&
+      !content.includes(">=")
+    ) {
+      const lhs = assignMatch[1];
+      const rhs = rewriteExpr(assignMatch[2]);
+      if (/^[A-Za-z_]\w*$/.test(lhs)) {
+        declareOrAssign(lhs, rhs);
+      } else {
+        out.push(`${lhs} = ${rhs};`);
+      }
+      continue;
+    }
+
+    out.push(`${rewriteExpr(content)};`);
+  }
+
+  closeTo(0);
+  return out.join("\n");
+}
+
+export function runBattleTests(
+  source: string,
+  fnName: string,
+  tests: BattleTestCase[],
+): BattleTestResult[] {
+  let fn: ((...args: unknown[]) => unknown) | null = null;
+  let compileError: string | null = null;
+
+  try {
+    const js = transpilePythonSubset(source);
+    const factory = new Function(
+      `"use strict";
+      const __len__ = (x) => (x == null ? 0 : x.length);
+      ${js}
+      if (typeof ${fnName} !== "function") {
+        throw new Error("Missing function ${fnName}");
+      }
+      return ${fnName};`,
+    );
+    fn = factory() as (...args: unknown[]) => unknown;
+  } catch (e) {
+    compileError = e instanceof Error ? e.message : String(e);
+  }
+
+  if (!fn) {
+    return tests.map(() => ({
+      passed: false,
+      error: compileError ?? "Compile error",
+    }));
+  }
+
+  return tests.map((t) => {
+    try {
+      const result = fn!(...t.args);
+      return { passed: deepEqual(result, t.expected) };
+    } catch (e) {
+      return {
+        passed: false,
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Arcade Battle was treating submissions as correct if they contained keywords like `seen`, and always marking the first 3 tests as passed otherwise. `# seen` would clear the whole challenge.

Added a small Python-subset judge that executes the submitted function against structured test args. Invalid code fails; equivalent solutions (e.g. brute-force Two Sum) pass.

## Related issue

Fixes #1295

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

Made with [Cursor](https://cursor.com)