### PR TITLE
fix(sky-ads): exclude lifetime baselines from short analytics periods

### DIFF
--- a/src/app/api/sky-ads/analytics/route.ts
+++ b/src/app/api/sky-ads/analytics/route.ts
@@ -70,13 +70,16 @@ export async function GET(request: Request) {
     cur.cta_clicks += Number(row.cta_clicks);
     aggregated.set(row.ad_id, cur);
   }
-  // Merge historical baselines
-  for (const [adId, baseline] of Object.entries(HISTORICAL_BASELINES)) {
-    const cur = aggregated.get(adId) ?? { impressions: 0, clicks: 0, cta_clicks: 0 };
-    cur.impressions += baseline.impressions;
-    cur.clicks += baseline.clicks;
-    cur.cta_clicks += baseline.cta_clicks;
-    aggregated.set(adId, cur);
+  // Merge historical baselines only for all-time reports. Short windows must
+  // reflect activity inside the selected period, not lifetime migrated totals.
+  if (!dayFilter) {
+    for (const [adId, baseline] of Object.entries(HISTORICAL_BASELINES)) {
+      const cur = aggregated.get(adId) ?? { impressions: 0, clicks: 0, cta_clicks: 0 };
+      cur.impressions += baseline.impressions;
+      cur.clicks += baseline.clicks;
+      cur.cta_clicks += baseline.cta_clicks;
+      aggregated.set(adId, cur);
+    }
   }
 
   function buildAdEntry(id: string, s: { impressions: number; clicks: number; cta_clicks: number }) {


### PR DESCRIPTION
## What does this PR do?

`/api/sky-ads/analytics` was applying Himetrica lifetime baselines on every request, including `period=7d` and `period=30d`. That inflated impressions/clicks/CTR outside the selected window.

Baselines now only merge when there is no day filter (all-time / `period=all`).

## Related issue

Fixes #1296

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)