### PR TITLE
fix(instance): persist shared instance join and admin flows

### DIFF
--- a/src/app/api/instance/join/route.ts
+++ b/src/app/api/instance/join/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSupabaseAdmin } from "@/lib/supabase";
+import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
+
+const joinSchema = z.object({
+  inviteToken: z.string().trim().min(8).max(128),
+  displayName: z.string().trim().min(1).max(64).optional(),
+});
+
+function displayNameFromUser(user: {
+  user_metadata?: Record<string, unknown>;
+  email?: string | null;
+}): string {
+  const meta = user.user_metadata ?? {};
+  const login =
+    (typeof meta.user_name === "string" && meta.user_name) ||
+    (typeof meta.preferred_username === "string" && meta.preferred_username) ||
+    (typeof meta.full_name === "string" && meta.full_name) ||
+    user.email?.split("@")[0] ||
+    "member";
+  return login.slice(0, 64);
+}
+
+export async function POST(request: Request) {
+  const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+  if (!auth.ok || !auth.user) {
+    return NextResponse.json(
+      { error: auth.error ?? "Not authenticated" },
+      { status: auth.status },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const parsed = joinSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invite token is required" },
+      { status: 400 },
+    );
+  }
+
+  const sb = getSupabaseAdmin();
+  const userId = auth.user.id;
+  const token = parsed.data.inviteToken.replace(/^.*[/=]/, "").trim();
+
+  const { data: existing } = await sb
+    .from("shared_instance_memberships")
+    .select("id, status")
+    .eq("user_id", userId)
+    .in("status", ["pending", "approved"])
+    .limit(1)
+    .maybeSingle();
+
+  if (existing) {
+    return NextResponse.json(
+      { error: "You already have an active or pending membership" },
+      { status: 409 },
+    );
+  }
+
+  const { data: instance, error: instanceError } = await sb
+    .from("shared_instances")
+    .select("id, name, owner_user_id")
+    .eq("invite_token", token)
+    .maybeSingle();
+
+  if (instanceError) {
+    console.error("[api/instance/join] lookup:", instanceError);
+    return NextResponse.json({ error: "Failed to join instance" }, { status: 500 });
+  }
+
+  if (!instance) {
+    return NextResponse.json({ error: "Invalid invite token" }, { status: 404 });
+  }
+
+  if (instance.owner_user_id === userId) {
+    return NextResponse.json({ error: "You already own this instance" }, { status: 409 });
+  }
+
+  const displayName = parsed.data.displayName?.trim() || displayNameFromUser(auth.user);
+
+  const { data: membership, error: insertError } = await sb
+    .from("shared_instance_memberships")
+    .insert({
+      instance_id: instance.id,
+      user_id: userId,
+      display_name: displayName,
+      role: "member",
+      status: "pending",
+    })
+    .select("id, status")
+    .single();
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      return NextResponse.json(
+        { error: "Join request already exists for this instance" },
+        { status: 409 },
+      );
+    }
+    console.error("[api/instance/join] insert:", insertError);
+    return NextResponse.json({ error: "Failed to submit join request" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    state: "joined-member",
+    instance: { id: instance.id, name: instance.name },
+    membership,
+  });
+}
+
+export async function DELETE() {
+  const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+  if (!auth.ok || !auth.user) {
+    return NextResponse.json(
+      { error: auth.error ?? "Not authenticated" },
+      { status: auth.status },
+    );
+  }
+
+  const sb = getSupabaseAdmin();
+  const { error } = await sb
+    .from("shared_instance_memberships")
+    .delete()
+    .eq("user_id", auth.user.id)
+    .eq("status", "pending");
+
+  if (error) {
+    console.error("[api/instance/join] cancel:", error);
+    return NextResponse.json({ error: "Failed to cancel request" }, { status: 500 });
+  }
+
+  return NextResponse.json({ state: "no-instance" });
+}

--- a/src/app/api/instance/requests/route.ts
+++ b/src/app/api/instance/requests/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSupabaseAdmin } from "@/lib/supabase";
+import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
+
+const actionSchema = z.object({
+  membershipId: z.string().uuid(),
+  action: z.enum(["approve", "reject"]),
+});
+
+export async function POST(request: Request) {
+  const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+  if (!auth.ok || !auth.user) {
+    return NextResponse.json(
+      { error: auth.error ?? "Not authenticated" },
+      { status: auth.status },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const parsed = actionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const sb = getSupabaseAdmin();
+  const userId = auth.user.id;
+
+  const { data: membership, error: membershipError } = await sb
+    .from("shared_instance_memberships")
+    .select("id, instance_id, status, role")
+    .eq("id", parsed.data.membershipId)
+    .maybeSingle();
+
+  if (membershipError || !membership) {
+    return NextResponse.json({ error: "Request not found" }, { status: 404 });
+  }
+
+  if (membership.status !== "pending" || membership.role !== "member") {
+    return NextResponse.json({ error: "Request is not pending" }, { status: 409 });
+  }
+
+  const { data: instance, error: instanceError } = await sb
+    .from("shared_instances")
+    .select("id, owner_user_id")
+    .eq("id", membership.instance_id)
+    .maybeSingle();
+
+  if (instanceError || !instance) {
+    return NextResponse.json({ error: "Instance not found" }, { status: 404 });
+  }
+
+  if (instance.owner_user_id !== userId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const nextStatus = parsed.data.action === "approve" ? "approved" : "rejected";
+  const { error: updateError } = await sb
+    .from("shared_instance_memberships")
+    .update({ status: nextStatus })
+    .eq("id", membership.id)
+    .eq("status", "pending");
+
+  if (updateError) {
+    console.error("[api/instance/requests] update:", updateError);
+    return NextResponse.json({ error: "Failed to update request" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, status: nextStatus });
+}

--- a/src/app/api/instance/route.ts
+++ b/src/app/api/instance/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { z } from "zod";
+import { getSupabaseAdmin } from "@/lib/supabase";
+import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
+
+const createSchema = z.object({
+  name: z.string().trim().min(2).max(80),
+});
+
+function displayNameFromUser(user: {
+  user_metadata?: Record<string, unknown>;
+  email?: string | null;
+}): string {
+  const meta = user.user_metadata ?? {};
+  const login =
+    (typeof meta.user_name === "string" && meta.user_name) ||
+    (typeof meta.preferred_username === "string" && meta.preferred_username) ||
+    (typeof meta.full_name === "string" && meta.full_name) ||
+    user.email?.split("@")[0] ||
+    "member";
+  return login.slice(0, 64);
+}
+
+export async function GET() {
+  const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+  if (!auth.ok || !auth.user) {
+    return NextResponse.json(
+      { error: auth.error ?? "Not authenticated", state: "unauthorized" },
+      { status: auth.status },
+    );
+  }
+
+  const sb = getSupabaseAdmin();
+  const userId = auth.user.id;
+
+  const { data: membership, error: membershipError } = await sb
+    .from("shared_instance_memberships")
+    .select("id, instance_id, display_name, role, status, created_at")
+    .eq("user_id", userId)
+    .in("status", ["pending", "approved"])
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (membershipError) {
+    console.error("[api/instance] membership lookup:", membershipError);
+    return NextResponse.json({ error: "Failed to load instance" }, { status: 500 });
+  }
+
+  if (!membership) {
+    return NextResponse.json({ state: "no-instance" });
+  }
+
+  const { data: instance, error: instanceError } = await sb
+    .from("shared_instances")
+    .select("id, name, invite_token, owner_user_id, created_at")
+    .eq("id", membership.instance_id)
+    .maybeSingle();
+
+  if (instanceError || !instance) {
+    console.error("[api/instance] instance lookup:", instanceError);
+    return NextResponse.json({ error: "Failed to load instance" }, { status: 500 });
+  }
+
+  if (membership.status === "pending") {
+    return NextResponse.json({
+      state: "joined-member",
+      instance: { id: instance.id, name: instance.name },
+      membership,
+    });
+  }
+
+  if (membership.role === "owner" || instance.owner_user_id === userId) {
+    const { data: members, error: membersError } = await sb
+      .from("shared_instance_memberships")
+      .select("id, display_name, role, status, user_id, created_at")
+      .eq("instance_id", instance.id)
+      .order("created_at", { ascending: true });
+
+    if (membersError) {
+      console.error("[api/instance] members lookup:", membersError);
+      return NextResponse.json({ error: "Failed to load members" }, { status: 500 });
+    }
+
+    const pending = (members ?? []).filter((m) => m.status === "pending");
+    const active = (members ?? []).filter((m) => m.status === "approved");
+
+    return NextResponse.json({
+      state: "admin-dashboard",
+      instance: {
+        id: instance.id,
+        name: instance.name,
+        invite_token: instance.invite_token,
+      },
+      membership,
+      pendingRequests: pending.map((m) => ({
+        id: m.id,
+        name: m.display_name,
+        email: m.user_id,
+      })),
+      activeUsers: active.map((m) => ({
+        id: m.id,
+        name: m.role === "owner" ? `${m.display_name} (You)` : m.display_name,
+        role: m.role === "owner" ? "Owner" : "Member",
+      })),
+    });
+  }
+
+  return NextResponse.json({
+    state: "joined-member",
+    instance: { id: instance.id, name: instance.name },
+    membership: { ...membership, status: "approved" },
+  });
+}
+
+export async function POST(request: Request) {
+  const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
+  if (!auth.ok || !auth.user) {
+    return NextResponse.json(
+      { error: auth.error ?? "Not authenticated" },
+      { status: auth.status },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Instance name must be 2–80 characters" },
+      { status: 400 },
+    );
+  }
+
+  const sb = getSupabaseAdmin();
+  const userId = auth.user.id;
+
+  const { data: existing } = await sb
+    .from("shared_instance_memberships")
+    .select("id, status")
+    .eq("user_id", userId)
+    .in("status", ["pending", "approved"])
+    .limit(1)
+    .maybeSingle();
+
+  if (existing) {
+    return NextResponse.json(
+      { error: "You already belong to an instance" },
+      { status: 409 },
+    );
+  }
+
+  const inviteToken = randomBytes(16).toString("hex");
+  const displayName = displayNameFromUser(auth.user);
+
+  const { data: instance, error: createError } = await sb
+    .from("shared_instances")
+    .insert({
+      name: parsed.data.name,
+      invite_token: inviteToken,
+      owner_user_id: userId,
+    })
+    .select("id, name, invite_token")
+    .single();
+
+  if (createError || !instance) {
+    console.error("[api/instance] create:", createError);
+    return NextResponse.json({ error: "Failed to create instance" }, { status: 500 });
+  }
+
+  const { error: memberError } = await sb.from("shared_instance_memberships").insert({
+    instance_id: instance.id,
+    user_id: userId,
+    display_name: displayName,
+    role: "owner",
+    status: "approved",
+  });
+
+  if (memberError) {
+    console.error("[api/instance] owner membership:", memberError);
+    await sb.from("shared_instances").delete().eq("id", instance.id);
+    return NextResponse.json({ error: "Failed to create instance" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    state: "admin-dashboard",
+    instance,
+  });
+}

--- a/src/app/instance/page.tsx
+++ b/src/app/instance/page.tsx
@@ -1,42 +1,171 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from "react";
 
-// The page handles loading, empty, and unauthorized states as requested
-type ViewState = 'loading' | 'unauthorized' | 'no-instance' | 'joined-member' | 'admin-dashboard';
+type ViewState =
+  | "loading"
+  | "unauthorized"
+  | "no-instance"
+  | "joined-member"
+  | "member-active"
+  | "admin-dashboard";
+
+type PendingRequest = { id: string; name: string; email: string };
+type ActiveUser = { id: string; name: string; role: string };
 
 export default function InstancePage() {
-  const [viewState, setViewState] = useState<ViewState>('no-instance');
-  const [authMode, setAuthMode] = useState<'join' | 'create'>('join');
+  const [viewState, setViewState] = useState<ViewState>("loading");
+  const [authMode, setAuthMode] = useState<"join" | "create">("join");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
-  // Local Form States
-  const [inviteToken, setInviteToken] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [instanceName, setInstanceName] = useState('');
+  const [inviteToken, setInviteToken] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [instanceName, setInstanceName] = useState("");
+  const [instanceLabel, setInstanceLabel] = useState<string | null>(null);
+  const [inviteTokenDisplay, setInviteTokenDisplay] = useState<string | null>(null);
 
-  // Admin Mock Data State for Pending Requests and Active Users
-  const [pendingRequests, setPendingRequests] = useState([
-    { id: '1', name: 'developer_alpha', email: 'alpha@team.com' },
-    { id: '2', name: 'coder_beta', email: 'beta@team.com' },
-  ]);
-  const [activeUsers, setActiveUsers] = useState([
-    { id: 'admin', name: 'Admin (You)', role: 'Owner' },
-  ]);
+  const [pendingRequests, setPendingRequests] = useState<PendingRequest[]>([]);
+  const [activeUsers, setActiveUsers] = useState<ActiveUser[]>([]);
 
-  const handleApprove = (id: string, name: string) => {
-    setPendingRequests(prev => prev.filter(req => req.id !== id));
-    setActiveUsers(prev => [...prev, { id, name, role: 'Member' }]);
+  const applyPayload = useCallback((data: Record<string, unknown>) => {
+    const state = data.state as ViewState | undefined;
+    if (!state) return;
+
+    if (state === "joined-member") {
+      const membership = data.membership as { status?: string } | undefined;
+      if (membership?.status === "approved") {
+        setViewState("member-active");
+      } else {
+        setViewState("joined-member");
+      }
+    } else {
+      setViewState(state);
+    }
+
+    const instance = data.instance as
+      | { name?: string; invite_token?: string }
+      | undefined;
+    setInstanceLabel(instance?.name ?? null);
+    setInviteTokenDisplay(instance?.invite_token ?? null);
+    setPendingRequests((data.pendingRequests as PendingRequest[]) ?? []);
+    setActiveUsers((data.activeUsers as ActiveUser[]) ?? []);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch("/api/instance");
+      const data = (await res.json()) as Record<string, unknown>;
+      if (res.status === 401) {
+        setViewState("unauthorized");
+        return;
+      }
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Failed to load");
+        setViewState("no-instance");
+        return;
+      }
+      applyPayload(data);
+    } catch {
+      setError("Failed to load instance status");
+      setViewState("no-instance");
+    }
+  }, [applyPayload]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/instance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: instanceName }),
+      });
+      const data = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Create failed");
+        return;
+      }
+      await refresh();
+    } catch {
+      setError("Create failed");
+    } finally {
+      setBusy(false);
+    }
   };
 
-  const handleReject = (id: string) => {
-    setPendingRequests(prev => prev.filter(req => req.id !== id));
+  const handleJoin = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/instance/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inviteToken,
+          displayName: displayName || undefined,
+        }),
+      });
+      const data = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Join failed");
+        return;
+      }
+      await refresh();
+    } catch {
+      setError("Join failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCancelRequest = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/instance/join", { method: "DELETE" });
+      const data = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Cancel failed");
+        return;
+      }
+      await refresh();
+    } catch {
+      setError("Cancel failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRequestAction = async (id: string, action: "approve" | "reject") => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/instance/requests", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ membershipId: id, action }),
+      });
+      const data = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Action failed");
+        return;
+      }
+      await refresh();
+    } catch {
+      setError("Action failed");
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
     <div className="p-6 max-w-5xl mx-auto min-h-screen transition-colors duration-200 bg-white text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100">
-      
-      {/* HEADER SECTION */}
       <header className="border-b pb-4 mb-6 border-zinc-200 dark:border-zinc-800">
         <h1 className="text-3xl font-bold tracking-tight">Shared Instance Management</h1>
         <p className="text-sm mt-1 text-zinc-500 dark:text-zinc-400">
@@ -44,87 +173,82 @@ export default function InstancePage() {
         </p>
       </header>
 
-      {/* MANDATORY LOCAL-FIRST PRIVACY WARNING */}
       <div className="mb-6 p-4 rounded-lg border bg-amber-50 text-amber-900 border-amber-200 dark:bg-amber-950/30 dark:text-amber-200 dark:border-amber-900/50">
         <h4 className="font-semibold flex items-center gap-2 text-sm">
-          ⚠️ Local-First & Privacy Notice
+          Local-First & Privacy Notice
         </h4>
         <p className="text-xs mt-1 leading-relaxed opacity-90">
-          Sharing is completely opt-in. Single-user standalone installations are never forced through 
-          instance routing and remain completely private locally. If setting up a shared instance, 
+          Sharing is completely opt-in. Single-user standalone installations are never forced through
+          instance routing and remain completely private locally. If setting up a shared instance,
           the administrator is responsible for exposing the instance server safely.
         </p>
       </div>
 
-      {/* STATE 1: LOADING STATE VIEW */}
-      {viewState === 'loading' && (
+      {error && (
+        <div className="mb-4 p-3 rounded-lg border border-red-200 bg-red-50 text-red-800 text-sm dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-200">
+          {error}
+        </div>
+      )}
+
+      {viewState === "loading" && (
         <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
           <span className="ml-3 text-sm text-zinc-500">Checking instance status...</span>
         </div>
       )}
 
-      {/* STATE 2: UNAUTHORIZED STATE VIEW */}
-      {viewState === 'unauthorized' && (
+      {viewState === "unauthorized" && (
         <div className="p-6 border rounded-xl border-red-200 bg-red-50 text-red-900 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-200">
-          <h3 className="font-bold">Access Denied</h3>
-          <p className="text-sm mt-1">You do not have administrative permissions to configure this instance.</p>
-          <button onClick={() => setViewState('no-instance')} className="mt-4 px-3 py-1.5 bg-red-600 text-white text-sm rounded hover:bg-red-700">Back</button>
+          <h3 className="font-bold">Sign in required</h3>
+          <p className="text-sm mt-1">
+            Sign in to create or join a shared instance. Membership is tied to your account.
+          </p>
         </div>
       )}
 
-      {/* STATE 3: EMPTY STATE / JOIN OR CREATE FLOW */}
-      {viewState === 'no-instance' && (
+      {viewState === "no-instance" && (
         <div>
-          {/* Sub-tab Selection */}
           <div className="flex gap-4 border-b border-zinc-200 dark:border-zinc-800 mb-6">
-            <button 
-              onClick={() => setAuthMode('join')}
-              className={`pb-2 font-medium text-sm transition-all ${authMode === 'join' ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400' : 'text-zinc-400'}`}
+            <button
+              onClick={() => setAuthMode("join")}
+              className={`pb-2 font-medium text-sm transition-all ${authMode === "join" ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-400" : "text-zinc-400"}`}
             >
               Join Existing Instance
             </button>
-            <button 
-              onClick={() => setAuthMode('create')}
-              className={`pb-2 font-medium text-sm transition-all ${authMode === 'create' ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400' : 'text-zinc-400'}`}
+            <button
+              onClick={() => setAuthMode("create")}
+              className={`pb-2 font-medium text-sm transition-all ${authMode === "create" ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-400" : "text-zinc-400"}`}
             >
               Create Admin Setup Flow
             </button>
           </div>
 
-          {/* Form Routing Panels */}
-          {authMode === 'join' ? (
+          {authMode === "join" ? (
             <div className="space-y-4 max-w-md p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-800/30">
               <div>
                 <h3 className="text-lg font-medium">Join an Instance</h3>
-                <p className="text-xs text-zinc-500">Enter your invitation details below.</p>
+                <p className="text-xs text-zinc-500">
+                  Enter the invite token. Your signed-in account is used for the join request.
+                </p>
               </div>
-              <input 
-                type="text" 
-                placeholder="Invite Token or Link" 
+              <input
+                type="text"
+                placeholder="Invite Token"
                 value={inviteToken}
                 onChange={(e) => setInviteToken(e.target.value)}
-                className="w-full p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700" 
+                className="w-full p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700"
               />
-              <div className="flex gap-2">
-                <input 
-                  type="text" 
-                  placeholder="Username" 
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  className="w-1/2 p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700" 
-                />
-                <input 
-                  type="password" 
-                  placeholder="Password" 
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-1/2 p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700" 
-                />
-              </div>
-              <button 
-                onClick={() => setViewState('joined-member')}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-medium text-sm w-full transition-colors"
+              <input
+                type="text"
+                placeholder="Display name (optional)"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                className="w-full p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700"
+              />
+              <button
+                onClick={() => void handleJoin()}
+                disabled={busy || !inviteToken.trim()}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded font-medium text-sm w-full transition-colors"
               >
                 Submit Join Request
               </button>
@@ -133,18 +257,21 @@ export default function InstancePage() {
             <div className="space-y-4 max-w-md p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-800/30">
               <div>
                 <h3 className="text-lg font-medium">Initialize Shared Instance</h3>
-                <p className="text-xs text-zinc-500">Setup explicit admin authentication parameters.</p>
+                <p className="text-xs text-zinc-500">
+                  Creates a persisted instance and makes you the owner.
+                </p>
               </div>
-              <input 
-                type="text" 
-                placeholder="Instance Name (e.g., Core Engineering)" 
+              <input
+                type="text"
+                placeholder="Instance Name (e.g., Core Engineering)"
                 value={instanceName}
                 onChange={(e) => setInstanceName(e.target.value)}
-                className="w-full p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700" 
+                className="w-full p-2 text-sm border rounded bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700"
               />
-              <button 
-                onClick={() => setViewState('admin-dashboard')}
-                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded font-medium text-sm w-full transition-colors"
+              <button
+                onClick={() => void handleCreate()}
+                disabled={busy || instanceName.trim().length < 2}
+                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white rounded font-medium text-sm w-full transition-colors"
               >
                 Confirm Setup Flow
               </button>
@@ -153,80 +280,115 @@ export default function InstancePage() {
         </div>
       )}
 
-      {/* STATE 4: JOINED MEMBER VIEW */}
-      {viewState === 'joined-member' && (
+      {viewState === "joined-member" && (
         <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 text-center max-w-md mx-auto">
-          <div className="text-4xl mb-2">⏳</div>
           <h3 className="text-xl font-bold">Request Pending</h3>
           <p className="text-sm mt-1 text-zinc-500 dark:text-zinc-400">
-            Your request to join has been submitted successfully using your token. Please wait for the instance admin to approve your account.
+            {instanceLabel
+              ? `Your request to join “${instanceLabel}” is waiting for admin approval.`
+              : "Your request to join has been submitted. Wait for the instance admin to approve your account."}
           </p>
-          <button onClick={() => setViewState('no-instance')} className="mt-4 text-xs text-blue-500 underline">Cancel Request</button>
+          <button
+            onClick={() => void handleCancelRequest()}
+            disabled={busy}
+            className="mt-4 text-xs text-blue-500 underline disabled:opacity-50"
+          >
+            Cancel Request
+          </button>
         </div>
       )}
 
-      {/* STATE 5: ADMIN MANAGEMENT DASHBOARD */}
-      {viewState === 'admin-dashboard' && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          
-          {/* PENDING REQUESTS PANEL */}
-          <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/30 dark:bg-zinc-800/10">
-            <h3 className="text-lg font-semibold mb-4 flex items-center justify-between">
-              <span>Pending Join Requests</span>
-              <span className="px-2 py-0.5 text-xs bg-zinc-200 dark:bg-zinc-700 rounded-full">{pendingRequests.length}</span>
-            </h3>
-            
-            {pendingRequests.length === 0 ? (
-              <p className="text-sm text-zinc-400 dark:text-zinc-500 py-4 text-center">No pending requests found.</p>
-            ) : (
+      {viewState === "member-active" && (
+        <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 text-center max-w-md mx-auto">
+          <h3 className="text-xl font-bold">Member</h3>
+          <p className="text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+            You are an approved member
+            {instanceLabel ? ` of “${instanceLabel}”` : ""}.
+          </p>
+        </div>
+      )}
+
+      {viewState === "admin-dashboard" && (
+        <div className="space-y-4">
+          {inviteTokenDisplay && (
+            <div className="p-4 border rounded-xl border-zinc-200 dark:border-zinc-800 text-sm">
+              <span className="font-medium">Invite token: </span>
+              <code className="text-xs break-all">{inviteTokenDisplay}</code>
+              {instanceLabel && (
+                <span className="ml-2 text-zinc-500">({instanceLabel})</span>
+              )}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/30 dark:bg-zinc-800/10">
+              <h3 className="text-lg font-semibold mb-4 flex items-center justify-between">
+                <span>Pending Join Requests</span>
+                <span className="px-2 py-0.5 text-xs bg-zinc-200 dark:bg-zinc-700 rounded-full">
+                  {pendingRequests.length}
+                </span>
+              </h3>
+
+              {pendingRequests.length === 0 ? (
+                <p className="text-sm text-zinc-400 dark:text-zinc-500 py-4 text-center">
+                  No pending requests found.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {pendingRequests.map((req) => (
+                    <div
+                      key={req.id}
+                      className="p-3 border rounded-lg bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 flex items-center justify-between"
+                    >
+                      <div>
+                        <p className="text-sm font-medium">{req.name}</p>
+                        <p className="text-xs text-zinc-400 font-mono truncate max-w-[180px]">
+                          {req.email}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => void handleRequestAction(req.id, "approve")}
+                          disabled={busy}
+                          className="px-2 py-1 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-xs font-medium rounded transition-colors"
+                        >
+                          Approve
+                        </button>
+                        <button
+                          onClick={() => void handleRequestAction(req.id, "reject")}
+                          disabled={busy}
+                          className="px-2 py-1 bg-zinc-200 hover:bg-zinc-300 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-600 disabled:opacity-50 text-xs font-medium rounded transition-colors"
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/30 dark:bg-zinc-800/10">
+              <h3 className="text-lg font-semibold mb-4">Active User Directory</h3>
               <div className="space-y-3">
-                {pendingRequests.map(req => (
-                  <div key={req.id} className="p-3 border rounded-lg bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium">{req.name}</p>
-                      <p className="text-xs text-zinc-400">{req.email}</p>
-                    </div>
-                    <div className="flex gap-2">
-                      <button 
-                        onClick={() => handleApprove(req.id, req.name)}
-                        className="px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded transition-colors"
-                      >
-                        Approve
-                      </button>
-                      <button 
-                        onClick={() => handleReject(req.id)}
-                        className="px-2 py-1 bg-zinc-200 hover:bg-zinc-300 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-600 text-xs font-medium rounded transition-colors"
-                      >
-                        Reject
-                      </button>
-                    </div>
+                {activeUsers.map((user) => (
+                  <div
+                    key={user.id}
+                    className="p-3 border rounded-lg bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 flex items-center justify-between"
+                  >
+                    <span className="text-sm font-medium">{user.name}</span>
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full font-medium ${user.role === "Owner" ? "bg-purple-100 text-purple-800 dark:bg-purple-950/50 dark:text-purple-300" : "bg-zinc-100 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300"}`}
+                    >
+                      {user.role}
+                    </span>
                   </div>
                 ))}
               </div>
-            )}
-          </div>
-
-          {/* ACTIVE TEAM MEMBERS PANEL */}
-          <div className="p-6 border rounded-xl border-zinc-200 dark:border-zinc-800 bg-zinc-50/30 dark:bg-zinc-800/10">
-            <h3 className="text-lg font-semibold mb-4">Active User Directory</h3>
-            <div className="space-y-3">
-              {activeUsers.map(user => (
-                <div key={user.id} className="p-3 border rounded-lg bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 flex items-center justify-between">
-                  <span className="text-sm font-medium">{user.name}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${user.role === 'Owner' ? 'bg-purple-100 text-purple-800 dark:bg-purple-950/50 dark:text-purple-300' : 'bg-zinc-100 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300'}`}>
-                    {user.role}
-                  </span>
-                </div>
-              ))}
             </div>
-            <button onClick={() => setViewState('no-instance')} className="mt-6 w-full text-xs text-zinc-400 hover:underline">
-              ← Leave Admin Dashboard View
-            </button>
           </div>
-
         </div>
       )}
-
     </div>
   );
 }

--- a/supabase/migrations/075_shared_instances.sql
+++ b/supabase/migrations/075_shared_instances.sql
@@ -1,0 +1,78 @@
+-- Shared Instance Management (opt-in team collaboration)
+-- Used by /instance and /api/instance/*
+
+CREATE TABLE IF NOT EXISTS public.shared_instances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  invite_token text NOT NULL UNIQUE,
+  owner_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT shared_instances_name_len CHECK (char_length(trim(name)) BETWEEN 2 AND 80)
+);
+
+CREATE TABLE IF NOT EXISTS public.shared_instance_memberships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  instance_id uuid NOT NULL REFERENCES public.shared_instances(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name text NOT NULL,
+  role text NOT NULL CHECK (role IN ('owner', 'member')),
+  status text NOT NULL CHECK (status IN ('pending', 'approved', 'rejected')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (instance_id, user_id),
+  CONSTRAINT shared_instance_memberships_display_name_len CHECK (char_length(trim(display_name)) BETWEEN 1 AND 64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_shared_instances_owner ON public.shared_instances (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_shared_instances_invite_token ON public.shared_instances (invite_token);
+CREATE INDEX IF NOT EXISTS idx_shared_instance_memberships_user ON public.shared_instance_memberships (user_id);
+CREATE INDEX IF NOT EXISTS idx_shared_instance_memberships_instance_status
+  ON public.shared_instance_memberships (instance_id, status);
+
+ALTER TABLE public.shared_instances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shared_instance_memberships ENABLE ROW LEVEL SECURITY;
+
+-- Members can read their instance; owners manage via service role in API routes.
+CREATE POLICY "Members read shared_instances"
+  ON public.shared_instances FOR SELECT TO authenticated
+  USING (
+    owner_user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.shared_instance_memberships m
+      WHERE m.instance_id = shared_instances.id
+        AND m.user_id = auth.uid()
+        AND m.status IN ('pending', 'approved')
+    )
+  );
+
+CREATE POLICY "Owners insert shared_instances"
+  ON public.shared_instances FOR INSERT TO authenticated
+  WITH CHECK (owner_user_id = auth.uid());
+
+CREATE POLICY "Members read own memberships"
+  ON public.shared_instance_memberships FOR SELECT TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.shared_instances i
+      WHERE i.id = shared_instance_memberships.instance_id
+        AND i.owner_user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users insert own memberships"
+  ON public.shared_instance_memberships FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Owners update memberships"
+  ON public.shared_instance_memberships FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.shared_instances i
+      WHERE i.id = shared_instance_memberships.instance_id
+        AND i.owner_user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users delete own pending memberships"
+  ON public.shared_instance_memberships FOR DELETE TO authenticated
+  USING (user_id = auth.uid() AND status = 'pending');


### PR DESCRIPTION
## What does this PR do?

`/instance` was pure local state — empty joins “succeeded”, setup opened a seeded admin view, and nothing survived a reload.

Adds `shared_instances` / `shared_instance_memberships`, API routes for create/join/approve/reject, and wires the page to authenticated server state with input validation.

## Related issue

Fixes #1297

## Screenshots

N/A

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)

Made with [Cursor](https://cursor.com)