### PR TITLE
docs: add JSDoc for utc-date.ts exported functions (#1299)

### DIFF
--- a/src/lib/utc-date.ts
+++ b/src/lib/utc-date.ts
@@ -1,8 +1,17 @@
 /**
- * Returns the current UTC calendar date as a YYYY-MM-DD string.
- * Uses a single Date instantiation so `today` and `yesterday` are
- * guaranteed to be derived from the same moment — they can never
- * drift relative to each other if a request straddles midnight.
+ * Utility functions for generating UTC date strings.
+ * These helpers ensure consistent date calculations without timezone or DST issues.
+ */
+/**
+ * Returns the current UTC date and the previous UTC date.
+ *
+ * Uses a single Date instance to ensure both values are derived
+ * from the same moment, preventing inconsistencies around midnight
+ * and daylight saving time (DST) transitions.
+ *
+ * @returns An object containing:
+ * - `today`: The current UTC date in YYYY-MM-DD format.
+ * - `yesterday`: The previous UTC date in YYYY-MM-DD format.
  */
 export function getUtcDateStrings(): { today: string; yesterday: string } {
   const now = new Date();


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc documentation to the exported functions in src/lib/utc-date.ts .

## Related issue

Closes #1299

## Changes

- Added module-level JSDoc describing the purpose of utc-date.ts.
- Added JSDoc to getUtcDateStrings().
- Documented the return value and UTC/DST handling.
- No functionality was changed.

## Checklist

- [ ] `npm run lint` passes
- [ ] Tested locally
- [x ] No secrets or .env values committed
