### PR TITLE
refactor: modularize raid execution pipeline

### DIFF
--- a/src/app/api/raid/preview/route.ts
+++ b/src/app/api/raid/preview/route.ts
@@ -10,6 +10,11 @@ import {
 import type { RaidBoostItem } from "@/lib/raid";
 import { findRaidAttackerForUser } from "@/lib/raid-attacker";
 import { getIsoWeekStart } from "@/lib/week";
+import {
+  buildRaidOffensiveItems,
+  buildRaidVehicleOptions,
+  resolveRaidLoadoutSelection,
+} from "@/lib/raid-planner";
 
 type RaidDefender = {
   id: number;
@@ -214,40 +219,17 @@ export async function POST(request: Request) {
     };
   });
 
-  // Build available vehicles list (always includes default airplane)
-  const VEHICLE_META: Record<string, { name: string; emoji: string; type: string }> = {
-    airplane: { name: "Airplane", emoji: "✈️", type: "air" },
-    raid_helicopter: { name: "Helicopter", emoji: "🚁", type: "air" },
-    raid_drone: { name: "Stealth Drone", emoji: "🛸", type: "air" },
-    raid_rocket: { name: "Rocket", emoji: "🚀", type: "air" },
-    raid_b2_bomber: { name: "B-2 Bomber", emoji: "🛩️", type: "air" },
-    raid_ufo: { name: "UFO", emoji: "👽", type: "air" },
-    vehicle_tank: { name: "Heavy Tank", emoji: "🛡️", type: "ground" },
-  };
-
   const ownedVehicleIds = new Set((vehiclePurchases ?? []).map((p) => p.item_id));
-  const available_vehicles = [
-    { item_id: "airplane", name: "Airplane", emoji: "✈️" },
-    { item_id: "raid_helicopter", name: "Helicopter", emoji: "🚁" },
-    { item_id: "vehicle_tank", name: "Heavy Tank", emoji: "🛡️" },
-    { item_id: "raid_b2_bomber", name: "B-2 Bomber", emoji: "🛩️" },
-    ...Array.from(ownedVehicleIds)
-      .filter((id) => VEHICLE_META[id] && id !== "raid_helicopter" && id !== "vehicle_tank" && id !== "raid_b2_bomber")
-      .map((id) => ({ item_id: id, ...VEHICLE_META[id] })),
-  ];
+  const available_vehicles = buildRaidVehicleOptions(ownedVehicleIds);
 
   // Use saved selection, fallback to airplane
-  const savedLoadout = (raidLoadoutRow?.config as { vehicle?: string } | null) ?? {};
-  let vehicle = savedLoadout.vehicle ?? "airplane";
-  if (
-    vehicle !== "airplane" &&
-    vehicle !== "raid_helicopter" &&
-    vehicle !== "vehicle_tank" &&
-    vehicle !== "raid_b2_bomber" &&
-    !ownedVehicleIds.has(vehicle)
-  ) {
-    vehicle = "airplane";
-  }
+  const savedLoadout = (raidLoadoutRow?.config as { vehicle?: string; tag?: string } | null) ?? {};
+  const { vehicle } = resolveRaidLoadoutSelection({
+    savedVehicle: savedLoadout.vehicle ?? "airplane",
+    savedTag: savedLoadout.tag ?? "default",
+    ownedItemIds: ownedVehicleIds,
+    xpLevel: attacker.xp_level ?? 1,
+  });
 
   // Calculate scores
   const attack = calculateAttackScore({
@@ -265,21 +247,8 @@ export async function POST(request: Request) {
   );
 
   // Compute available offensive consumables (must have qty > 0 and < 3 weekly uses)
-  const currentWeekStr = getIsoWeekStart().toISOString().split('T')[0];
-  const availableOffensiveItems = (offensiveConsumables ?? []).filter(c => {
-    if (c.quantity <= 0) return false;
-    const lastReset = c.last_reset_week ? new Date(c.last_reset_week).toISOString().split('T')[0] : null;
-    const weeklyUses = lastReset === currentWeekStr ? c.weekly_uses : 0;
-    return weeklyUses < 3;
-  }).map(c => {
-    const lastReset = c.last_reset_week ? new Date(c.last_reset_week).toISOString().split('T')[0] : null;
-    const weeklyUses = lastReset === currentWeekStr ? c.weekly_uses : 0;
-    return {
-      item_id: c.item_id,
-      quantity: c.quantity,
-      uses_left_this_week: 3 - weeklyUses,
-    };
-  });
+  const currentWeekStr = getIsoWeekStart().toISOString().split("T")[0];
+  const availableOffensiveItems = buildRaidOffensiveItems(offensiveConsumables ?? [], currentWeekStr);
 
   return NextResponse.json({
     can_raid: true,

--- a/src/lib/__tests__/raid-planner.test.ts
+++ b/src/lib/__tests__/raid-planner.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRaidOffensiveItems,
+  buildRaidVehicleOptions,
+  resolveRaidConsumableSelection,
+  resolveRaidDefenses,
+  resolveRaidLoadoutSelection,
+} from "../raid-planner";
+
+describe("raid planner", () => {
+  it("preserves the current loadout selection rules", () => {
+    const selected = resolveRaidLoadoutSelection({
+      requestedVehicleId: "raid_ufo",
+      savedVehicle: "raid_rocket",
+      savedTag: "tag_fire",
+      ownedItemIds: new Set(["raid_ufo", "tag_fire"]),
+      xpLevel: 1,
+    });
+
+    expect(selected.vehicle).toBe("raid_ufo");
+    expect(selected.tagStyle).toBe("tag_fire");
+  });
+
+  it("falls back to airplane and default tag when unlocks are missing", () => {
+    const selected = resolveRaidLoadoutSelection({
+      savedVehicle: "raid_ufo",
+      savedTag: "tag_gold",
+      ownedItemIds: new Set<string>(),
+      xpLevel: 1,
+    });
+
+    expect(selected.vehicle).toBe("airplane");
+    expect(selected.tagStyle).toBe("default");
+  });
+
+  it("resolves offensive consumables exactly like the service did before the split", () => {
+    const result = resolveRaidConsumableSelection({
+      consumableItemId: "emp_device",
+      consumableRow: {
+        quantity: 1,
+        weekly_uses: 1,
+        last_reset_week: "2026-08-03",
+      },
+      raidWeekStart: "2026-08-03",
+      attackerXpLevel: 20,
+    });
+
+    expect(result.attackerConsumableItemId).toBe("emp_device");
+  });
+
+  it("nulls a defense when EMP is used", () => {
+    const result = resolveRaidDefenses({
+      defenderActiveDefenses: ["emp_shield"],
+      attackerConsumableItemId: "emp_device",
+      raidWeekStart: "2026-08-03",
+    });
+
+    expect(result.activeDefenses).toEqual(["emp_shield"]);
+    expect(result.defenderItemUsed).toBe(true);
+    expect(result.defenderEffectiveDefense).toBeNull();
+  });
+
+  it("builds vehicle options with owned extras after the base set", () => {
+    const options = buildRaidVehicleOptions(new Set(["raid_ufo", "raid_rocket"]));
+
+    expect(options.slice(0, 4).map((option) => option.item_id)).toEqual([
+      "airplane",
+      "raid_helicopter",
+      "vehicle_tank",
+      "raid_b2_bomber",
+    ]);
+    expect(options.map((option) => option.item_id)).toContain("raid_ufo");
+    expect(options.map((option) => option.item_id)).toContain("raid_rocket");
+  });
+
+  it("filters consumed offensive items based on weekly uses", () => {
+    const items = buildRaidOffensiveItems(
+      [
+        { item_id: "emp_device", quantity: 1, weekly_uses: 2, last_reset_week: "2026-08-03" },
+        { item_id: "sabotage_virus", quantity: 0, weekly_uses: 0, last_reset_week: "2026-08-03" },
+      ],
+      "2026-08-03",
+    );
+
+    expect(items).toEqual([
+      { item_id: "emp_device", quantity: 1, uses_left_this_week: 1 },
+    ]);
+  });
+});

--- a/src/lib/raid-planner.ts
+++ b/src/lib/raid-planner.ts
@@ -1,0 +1,246 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { ITEM_UNLOCK_LEVELS } from "@/lib/zones";
+import { getUtcDateString } from "@/lib/week";
+import type { RaidOffensiveItem, RaidVehicleOption } from "@/lib/raid";
+
+export type RaidExecutionPayload = {
+  target_login: string;
+  boost_purchase_id?: number;
+  consumable_item_id?: string;
+  offensive_item_id?: string;
+  vehicle_id?: string;
+};
+
+export type RaidDeveloper = {
+  id: number;
+  claimed?: boolean | null;
+  github_login: string;
+  avatar_url?: string | null;
+  contributions?: number | null;
+  public_repos?: number | null;
+  total_stars?: number | null;
+  kudos_count?: number | null;
+  app_streak?: number | null;
+  raid_xp?: number | null;
+  xp_level?: number | null;
+  current_week_contributions?: number | null;
+  current_week_kudos_given?: number | null;
+  current_week_kudos_received?: number | null;
+  last_raided_at?: string | null;
+  active_defenses?: unknown;
+  easy_solved?: number | null;
+  medium_solved?: number | null;
+  hard_solved?: number | null;
+  contest_rating?: number | null;
+  lc_streak?: number | null;
+  total_prs?: number | null;
+};
+
+type RaidConsumableRow = {
+  id?: string;
+  quantity: number;
+  weekly_uses: number;
+  last_reset_week: string | null;
+};
+
+type RaidPurchaseRow = {
+  id: number;
+  item_id: string;
+  items?: unknown;
+};
+
+type RaidDefenseRow = {
+  item_id: string;
+  quantity: number;
+  weekly_uses: number;
+  last_reset_week: string | null;
+};
+
+const BASE_RAID_VEHICLE_IDS = new Set(["airplane", "raid_helicopter", "vehicle_tank", "raid_b2_bomber"]);
+
+export const RAID_VEHICLE_META: Record<string, { name: string; emoji: string; type: string }> = {
+  airplane: { name: "Airplane", emoji: "✈️", type: "air" },
+  raid_helicopter: { name: "Helicopter", emoji: "🚁", type: "air" },
+  raid_drone: { name: "Stealth Drone", emoji: "🛸", type: "air" },
+  raid_rocket: { name: "Rocket", emoji: "🚀", type: "air" },
+  raid_b2_bomber: { name: "B-2 Bomber", emoji: "🛩️", type: "air" },
+  raid_ufo: { name: "UFO", emoji: "👽", type: "air" },
+  vehicle_tank: { name: "Heavy Tank", emoji: "🛡️", type: "ground" },
+};
+
+export function getRaidColumns(): string {
+  return "id, claimed, github_login, avatar_url, contributions, public_repos, total_stars, kudos_count, app_streak, raid_xp, xp_level, current_week_contributions, current_week_kudos_given, current_week_kudos_received, last_raided_at, active_defenses, easy_solved, medium_solved, hard_solved, contest_rating, lc_streak, total_prs";
+}
+
+export async function loadRaidDefender(admin: SupabaseClient, targetLogin: string): Promise<RaidDeveloper | null> {
+  const { data: defender } = await admin
+    .from("developers")
+    .select(getRaidColumns())
+    .ilike("github_login", targetLogin)
+    .limit(1)
+    .maybeSingle();
+
+  return defender as RaidDeveloper | null;
+}
+
+export function resolveRaidLoadoutSelection(inputs: {
+  requestedVehicleId?: string;
+  savedVehicle?: string | null;
+  savedTag?: string | null;
+  ownedItemIds: Set<string>;
+  xpLevel: number;
+}): { vehicle: string; tagStyle: string } {
+  let vehicle = "airplane";
+  const requestedVehicleId = inputs.requestedVehicleId;
+
+  if (requestedVehicleId) {
+    const isLevelUnlocked = ITEM_UNLOCK_LEVELS[requestedVehicleId] && inputs.xpLevel >= ITEM_UNLOCK_LEVELS[requestedVehicleId];
+    if (
+      requestedVehicleId === "airplane" ||
+      requestedVehicleId === "raid_helicopter" ||
+      requestedVehicleId === "vehicle_tank" ||
+      requestedVehicleId === "raid_b2_bomber" ||
+      inputs.ownedItemIds.has(requestedVehicleId) ||
+      isLevelUnlocked
+    ) {
+      vehicle = requestedVehicleId;
+    }
+  } else {
+    const saved = inputs.savedVehicle ?? "airplane";
+    const isSavedLevelUnlocked = ITEM_UNLOCK_LEVELS[saved] && inputs.xpLevel >= ITEM_UNLOCK_LEVELS[saved];
+    vehicle =
+      saved === "airplane" ||
+      saved === "raid_helicopter" ||
+      saved === "vehicle_tank" ||
+      saved === "raid_b2_bomber" ||
+      inputs.ownedItemIds.has(saved) ||
+      isSavedLevelUnlocked
+        ? saved
+        : "airplane";
+  }
+
+  const savedTag = inputs.savedTag ?? "default";
+  const isTagLevelUnlocked = ITEM_UNLOCK_LEVELS[savedTag] && inputs.xpLevel >= ITEM_UNLOCK_LEVELS[savedTag];
+  const tagStyle = savedTag === "default" || inputs.ownedItemIds.has(savedTag) || isTagLevelUnlocked ? savedTag : "default";
+
+  return { vehicle, tagStyle };
+}
+
+export function resolveRaidConsumableSelection(inputs: {
+  consumableItemId?: string | null;
+  boostPurchaseId?: number;
+  consumableRow?: RaidConsumableRow | null;
+  boostPurchase?: RaidPurchaseRow | null;
+  raidWeekStart: string;
+  attackerXpLevel: number;
+}): {
+  boostBonus: number;
+  boostItemId: string | null;
+  boostPurchaseIdToConsume: number | null;
+  attackerConsumableItemId: string | null;
+} {
+  const consumableItemId = inputs.consumableItemId ?? undefined;
+  let boostBonus = 0;
+  let boostItemId: string | null = null;
+  let boostPurchaseIdToConsume: number | null = null;
+  let attackerConsumableItemId: string | null = null;
+
+  if (consumableItemId) {
+    const consumable = inputs.consumableRow;
+    const resetWeekStr = consumable?.last_reset_week ? getUtcDateString(consumable.last_reset_week) : null;
+
+    if (consumable && consumable.quantity > 0) {
+      let currentUses = consumable.weekly_uses;
+      if (inputs.raidWeekStart !== resetWeekStr) currentUses = 0;
+      if (currentUses < 3) attackerConsumableItemId = consumableItemId;
+    } else {
+      const reqLevel = ITEM_UNLOCK_LEVELS[consumableItemId];
+      const isLevelUnlocked = reqLevel && inputs.attackerXpLevel >= reqLevel;
+      if (isLevelUnlocked || consumableItemId === "scouting_satellite") {
+        if (!consumable || consumable.weekly_uses < 3 || resetWeekStr !== inputs.raidWeekStart) {
+          attackerConsumableItemId = consumableItemId;
+        }
+      }
+    }
+  } else if (inputs.boostPurchaseId) {
+    const boostPurchase = inputs.boostPurchase;
+    if (boostPurchase) {
+      const meta = (boostPurchase.items as unknown as { metadata: { type: string; bonus: number } })?.metadata;
+      if (meta?.type === "raid_boost" && meta.bonus > 0) {
+        boostBonus = meta.bonus;
+        boostItemId = boostPurchase.item_id;
+        boostPurchaseIdToConsume = boostPurchase.id;
+      }
+    }
+  }
+
+  return { boostBonus, boostItemId, boostPurchaseIdToConsume, attackerConsumableItemId };
+}
+
+export function resolveRaidDefenses(inputs: {
+  defenderActiveDefenses: unknown;
+  availableDefenses?: RaidDefenseRow[] | null;
+  attackerConsumableItemId: string | null;
+  raidWeekStart: string;
+}): {
+  activeDefenses: string[];
+  defenderItemUsed: boolean;
+  defenderEffectiveDefense: string | null;
+} {
+  let activeDefenses: string[] = Array.isArray(inputs.defenderActiveDefenses) ? inputs.defenderActiveDefenses : [];
+  let defenderItemUsed = false;
+
+  if (activeDefenses.length > 0) {
+    defenderItemUsed = true;
+  } else if (inputs.availableDefenses && inputs.availableDefenses.length > 0) {
+    for (const defense of inputs.availableDefenses) {
+      let currentUses = defense.weekly_uses;
+      if (!defense.last_reset_week || getUtcDateString(defense.last_reset_week) !== inputs.raidWeekStart) currentUses = 0;
+      if (currentUses < 3) {
+        activeDefenses = [defense.item_id];
+        defenderItemUsed = true;
+        break;
+      }
+    }
+  }
+
+  const isEmpDevice = inputs.attackerConsumableItemId === "emp_device";
+  let defenderEffectiveDefense = activeDefenses.length > 0 ? activeDefenses[0] : null;
+  if (isEmpDevice && defenderEffectiveDefense) defenderEffectiveDefense = null;
+
+  return { activeDefenses, defenderItemUsed, defenderEffectiveDefense };
+}
+
+export function buildRaidVehicleOptions(ownedVehicleIds: Set<string>): RaidVehicleOption[] {
+  return [
+    { item_id: "airplane", name: "Airplane", emoji: "✈️" },
+    { item_id: "raid_helicopter", name: "Helicopter", emoji: "🚁" },
+    { item_id: "vehicle_tank", name: "Heavy Tank", emoji: "🛡️" },
+    { item_id: "raid_b2_bomber", name: "B-2 Bomber", emoji: "🛩️" },
+    ...Array.from(ownedVehicleIds)
+      .filter((itemId) => RAID_VEHICLE_META[itemId] && !BASE_RAID_VEHICLE_IDS.has(itemId))
+      .map((itemId) => ({ item_id: itemId, ...RAID_VEHICLE_META[itemId] })),
+  ];
+}
+
+export function buildRaidOffensiveItems(
+  consumables: RaidDefenseRow[],
+  raidWeekStart: string,
+): RaidOffensiveItem[] {
+  return consumables
+    .filter((consumable) => {
+      if (consumable.quantity <= 0) return false;
+      const lastReset = consumable.last_reset_week ? new Date(consumable.last_reset_week).toISOString().split("T")[0] : null;
+      const weeklyUses = lastReset === raidWeekStart ? consumable.weekly_uses : 0;
+      return weeklyUses < 3;
+    })
+    .map((consumable) => {
+      const lastReset = consumable.last_reset_week ? new Date(consumable.last_reset_week).toISOString().split("T")[0] : null;
+      const weeklyUses = lastReset === raidWeekStart ? consumable.weekly_uses : 0;
+      return {
+        item_id: consumable.item_id,
+        quantity: consumable.quantity,
+        uses_left_this_week: 3 - weeklyUses,
+      };
+    });
+}

--- a/src/services/raid-post-execution.test.ts
+++ b/src/services/raid-post-execution.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { performRaidPostExecution } from "./raid-post-execution";
+
+const {
+  mockTouchLastActive,
+  mockTrackDailyMission,
+  mockSendRaidAlertNotification,
+} = vi.hoisted(() => ({
+  mockTouchLastActive: vi.fn(),
+  mockTrackDailyMission: vi.fn(),
+  mockSendRaidAlertNotification: vi.fn(),
+}));
+
+vi.mock("@/lib/notification-helpers", () => ({
+  touchLastActive: mockTouchLastActive,
+}));
+
+vi.mock("@/lib/dailies", () => ({
+  trackDailyMission: mockTrackDailyMission,
+}));
+
+vi.mock("@/lib/notification-senders/raid", () => ({
+  sendRaidAlertNotification: mockSendRaidAlertNotification,
+}));
+
+describe("performRaidPostExecution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTouchLastActive.mockResolvedValue(undefined);
+    mockTrackDailyMission.mockResolvedValue(undefined);
+    mockSendRaidAlertNotification.mockResolvedValue(undefined);
+  });
+
+  it("runs post-raid side effects in the expected order on success", async () => {
+    const calls: string[] = [];
+    const chain = {
+      eq(...args: [string, string | number | boolean]) {
+        calls.push(`eq:${args[0]}:${String(args[1])}`);
+        return chain;
+      },
+      insert(values: Record<string, unknown>) {
+        calls.push(`insert:${JSON.stringify(values)}`);
+        return Promise.resolve({ error: null });
+      },
+      upsert(values: Record<string, unknown>) {
+        calls.push(`upsert:${JSON.stringify(values)}`);
+        return Promise.resolve({ error: null });
+      },
+      select() {
+        return chain;
+      },
+      update(values: Record<string, unknown>) {
+        calls.push(`update:${JSON.stringify(values)}`);
+        return chain;
+      },
+      gt() {
+        return chain;
+      },
+    };
+    const admin = {
+      from(table: string) {
+        calls.push(`from:${table}`);
+        return {
+          ...chain,
+        };
+      },
+      async rpc(fn: string, args: Record<string, unknown>) {
+        calls.push(`rpc:${fn}:${JSON.stringify(args)}`);
+        if (fn === "increment_relic_progress") {
+          return { data: 1, error: null };
+        }
+        if (fn === "consume_consumable") {
+          return { data: true, error: null };
+        }
+        return { data: null, error: null };
+      },
+    };
+
+    await performRaidPostExecution(
+      admin as never,
+      { id: 1, github_login: "attacker" } as never,
+      { id: 2, github_login: "defender" } as never,
+      {
+        boostPurchaseIdToConsume: 99,
+        defenderItemUsed: true,
+        activeDefenses: ["emp_shield"],
+        success: true,
+        raidId: "raid-1",
+        vehicle: "airplane",
+        tagStyle: "default",
+        attack: { total: 12, breakdown: { commits: 0, streak: 0, kudos: 0 } },
+        defense: { total: 10, breakdown: { commits: 0, streak: 0, kudos: 0 } },
+        attackerConsumableItemId: "emp_device",
+        defenderEffectiveDefense: null,
+      },
+      "2026-08-03",
+    );
+
+    expect(calls).toContain('from:purchases');
+    expect(calls).toContain('update:{"status":"consumed"}');
+    expect(calls).toContain('rpc:consume_consumable:{"p_developer_id":2,"p_item_id":"emp_shield","p_week_start":"2026-08-03"}');
+    expect(calls).toContain('from:raid_tags');
+    expect(calls.some((entry) => entry.startsWith('insert:{"raid_id":"raid-1"'))).toBe(true);
+    expect(calls).toContain('from:activity_feed');
+    expect(mockTouchLastActive).toHaveBeenCalledWith(1);
+    expect(mockTrackDailyMission).toHaveBeenCalledWith(1, "attempt_battle");
+    expect(mockTrackDailyMission).toHaveBeenCalledWith(1, "win_battle");
+    expect(mockSendRaidAlertNotification).toHaveBeenCalledWith(2, "defender", "attacker", "raid-1", true, 12, 10);
+  });
+});

--- a/src/services/raid-post-execution.ts
+++ b/src/services/raid-post-execution.ts
@@ -1,0 +1,116 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { touchLastActive } from "@/lib/notification-helpers";
+import { sendRaidAlertNotification } from "@/lib/notification-senders/raid";
+import { trackDailyMission } from "@/lib/dailies";
+import { RAID_TAG_DURATION_DAYS, XP_WIN_ATTACKER, XP_WIN_DEFENDER, XP_LOSE_DEFENDER, type ScoreBreakdown } from "@/lib/raid";
+import type { RaidDeveloper } from "@/lib/raid-planner";
+
+export type RaidPostExecutionDetails = {
+  boostPurchaseIdToConsume: number | null;
+  defenderItemUsed: boolean;
+  activeDefenses: string[];
+  success: boolean;
+  raidId?: string;
+  vehicle: string;
+  tagStyle: string;
+  attack: { total: number; breakdown: ScoreBreakdown };
+  defense: { total: number; breakdown: ScoreBreakdown };
+  attackerConsumableItemId: string | null;
+  defenderEffectiveDefense: string | null;
+};
+
+type RaidAdminClient = Pick<SupabaseClient, "from" | "rpc">;
+
+async function consumeDeveloperItem(admin: RaidAdminClient, devId: number, itemId: string, raidWeekStart: string): Promise<boolean> {
+  const { data, error } = await admin.rpc("consume_consumable", {
+    p_developer_id: devId,
+    p_item_id: itemId,
+    p_week_start: raidWeekStart,
+  });
+
+  if (error) {
+    console.error("[raid/execute] consume_consumable RPC error:", error);
+    return false;
+  }
+
+  return data === true;
+}
+
+export async function performRaidPostExecution(
+  admin: RaidAdminClient,
+  attacker: RaidDeveloper,
+  defender: RaidDeveloper,
+  details: RaidPostExecutionDetails,
+  raidWeekStart: string,
+): Promise<void> {
+  if (details.boostPurchaseIdToConsume) {
+    await admin.from("purchases").update({ status: "consumed" }).eq("id", details.boostPurchaseIdToConsume);
+  }
+
+  if (details.defenderItemUsed && details.activeDefenses.length > 0) {
+    await consumeDeveloperItem(admin, defender.id, details.activeDefenses[0], raidWeekStart);
+  }
+
+  if (details.success) {
+    await admin.from("raid_tags").update({ active: false }).eq("building_id", defender.id).eq("active", true);
+    await admin.from("raid_tags").insert({
+      raid_id: details.raidId,
+      building_id: defender.id,
+      attacker_id: attacker.id,
+      attacker_login: attacker.github_login,
+      tag_style: details.tagStyle,
+      expires_at: new Date(Date.now() + RAID_TAG_DURATION_DAYS * 86400000).toISOString(),
+    });
+
+    await Promise.all([
+      admin.rpc("increment_raid_xp", { p_developer_id: attacker.id, p_amount: XP_WIN_ATTACKER }),
+      admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_WIN_DEFENDER }),
+    ]);
+    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
+
+    try {
+      const { data: newWins, error: relicErr } = await admin.rpc("increment_relic_progress", {
+        p_developer_id: attacker.id,
+        p_field: "raid_wins",
+      });
+
+      if (relicErr) {
+        console.error("[raid/execute] increment_relic_progress error:", relicErr);
+      } else if ((newWins ?? 0) >= 1) {
+        await admin.from("developer_relics").upsert(
+          {
+            developer_id: attacker.id,
+            relic_id: "relic_requiem_void_core",
+            is_equipped: false,
+            created_at: new Date().toISOString(),
+          },
+          { onConflict: "developer_id,relic_id" },
+        );
+      }
+    } catch (error) {
+      console.error("[raid/execute] Failed to track raid win for relic:", error);
+    }
+  } else {
+    await admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_LOSE_DEFENDER });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
+    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
+  }
+
+  await admin.from("activity_feed").insert({
+    event_type: details.success ? "raid_success" : "raid_failed",
+    actor_id: attacker.id,
+    target_id: defender.id,
+    metadata: {
+      attacker_login: attacker.github_login,
+      defender_login: defender.github_login,
+      attack_score: details.attack.total,
+      defense_score: details.defense.total,
+    },
+  });
+
+  await touchLastActive(attacker.id);
+  await trackDailyMission(attacker.id, "attempt_battle");
+  if (details.success) await trackDailyMission(attacker.id, "win_battle");
+  sendRaidAlertNotification(defender.id, defender.github_login, attacker.github_login, details.raidId ?? 0, details.success, details.attack.total, details.defense.total);
+}

--- a/src/services/raidService.ts
+++ b/src/services/raidService.ts
@@ -1,55 +1,25 @@
-import { coordinateRewardSideEffects } from "@/lib/rewardCoordinator";
-import { touchLastActive } from "@/lib/notification-helpers";
-import { sendRaidAlertNotification } from "@/lib/notification-senders/raid";
-import { trackDailyMission } from "@/lib/dailies";
 import {
   calculateAttackScore,
   calculateDefenseScore,
   getRaidTitle,
-  RAID_TAG_DURATION_DAYS,
   XP_WIN_ATTACKER,
   XP_WIN_DEFENDER,
   XP_LOSE_DEFENDER,
   type RaidExecuteResponse,
-  type ScoreBreakdown,
 } from "@/lib/raid";
 import { findRaidAttackerForUser } from "@/lib/raid-attacker";
-import { ITEM_UNLOCK_LEVELS } from "@/lib/zones";
-import { getUtcDateString } from "@/lib/week";
+import { coordinateRewardSideEffects } from "@/lib/rewardCoordinator";
+import {
+  getRaidColumns,
+  loadRaidDefender,
+  resolveRaidConsumableSelection,
+  resolveRaidDefenses,
+  resolveRaidLoadoutSelection,
+  type RaidDeveloper,
+  type RaidExecutionPayload,
+} from "@/lib/raid-planner";
+import { performRaidPostExecution } from "@/services/raid-post-execution";
 import type { SupabaseClient, User } from "@supabase/supabase-js";
-
-export type RaidExecutionPayload = {
-  target_login: string;
-  boost_purchase_id?: number;
-  consumable_item_id?: string;
-  offensive_item_id?: string;
-  vehicle_id?: string;
-};
-
-export type RaidDeveloper = {
-  id: number;
-  claimed?: boolean | null;
-  github_login: string;
-  avatar_url?: string | null;
-  contributions?: number | null;
-  public_repos?: number | null;
-  total_stars?: number | null;
-  kudos_count?: number | null;
-  app_streak?: number | null;
-  raid_xp?: number | null;
-  xp_level?: number | null;
-  current_week_contributions?: number | null;
-  current_week_kudos_given?: number | null;
-  current_week_kudos_received?: number | null;
-  last_raided_at?: string | null;
-  active_defenses?: unknown;
-  easy_solved?: number | null;
-  medium_solved?: number | null;
-  hard_solved?: number | null;
-  contest_rating?: number | null;
-  lc_streak?: number | null;
-  total_prs?: number | null;
-};
 
 export class RaidServiceError extends Error {
   status: number;
@@ -76,8 +46,8 @@ export class RaidService {
 
   async execute(): Promise<{ status: number; body: RaidExecuteResponse }> {
     const [attacker, defender] = await Promise.all([
-      findRaidAttackerForUser(this.admin, this.user, this.getRaidColumns()),
-      this.loadDefender(),
+      findRaidAttackerForUser(this.admin, this.user, getRaidColumns()),
+      loadRaidDefender(this.admin, this.payload.target_login),
     ]);
 
     if (!attacker || !attacker.claimed) {
@@ -90,8 +60,21 @@ export class RaidService {
       throw this.createError("Cannot raid yourself", 409);
     }
 
-    const { vehicle, tagStyle } = await this.resolveLoadout(attacker);
-    const { boostBonus, boostItemId, boostPurchaseIdToConsume, attackerConsumableItemId } = await this.resolveConsumables(attacker);
+    const [raidLoadout, ownedVehicleIds, consumableResolution] = await Promise.all([
+      this.loadRaidLoadout(attacker.id),
+      this.loadOwnedVehicleIds(attacker.id),
+      this.resolveConsumables(attacker),
+    ]);
+
+    const { vehicle, tagStyle } = resolveRaidLoadoutSelection({
+      requestedVehicleId: this.payload.vehicle_id,
+      savedVehicle: raidLoadout?.vehicle ?? "airplane",
+      savedTag: raidLoadout?.tag ?? "default",
+      ownedItemIds: ownedVehicleIds,
+      xpLevel: attacker.xp_level ?? 1,
+    });
+
+    const { boostBonus, boostItemId, boostPurchaseIdToConsume, attackerConsumableItemId } = consumableResolution;
     const { activeDefenses, defenderItemUsed, defenderEffectiveDefense } = await this.resolveDefenses(defender, attackerConsumableItemId);
 
     const isEmpDevice = attackerConsumableItemId === "emp_device";
@@ -163,7 +146,13 @@ export class RaidService {
 
     const raidId = result.raid_id ?? "";
 
-    await this.handlePostExecution(attacker, defender, { boostPurchaseIdToConsume, defenderItemUsed, activeDefenses, success, raidId, vehicle, tagStyle, attack, defense, attackerConsumableItemId, defenderEffectiveDefense });
+    await performRaidPostExecution(
+      this.admin,
+      attacker,
+      defender,
+      { boostPurchaseIdToConsume, defenderItemUsed, activeDefenses, success, raidId, vehicle, tagStyle, attack, defense, attackerConsumableItemId, defenderEffectiveDefense },
+      this.raidWeekStart,
+    );
 
     const [updatedAttackerResult, updatedDefenderResult] = await Promise.all([
       this.admin.from("developers").select("raid_xp").eq("id", attacker.id).maybeSingle(),
@@ -259,213 +248,90 @@ export class RaidService {
     };
   }
 
-  private getRaidColumns(): string {
-    return "id, claimed, github_login, avatar_url, contributions, public_repos, total_stars, kudos_count, app_streak, raid_xp, xp_level, current_week_contributions, current_week_kudos_given, current_week_kudos_received, last_raided_at, active_defenses, easy_solved, medium_solved, hard_solved, contest_rating, lc_streak, total_prs";
+  private async loadRaidLoadout(developerId: number): Promise<{ vehicle?: string; tag?: string } | null> {
+    const { data } = await this.admin
+      .from("developer_customizations")
+      .select("config")
+      .eq("developer_id", developerId)
+      .eq("item_id", "raid_loadout")
+      .maybeSingle();
+
+    return (data?.config as { vehicle?: string; tag?: string } | null) ?? null;
   }
 
-  private async loadDefender(): Promise<RaidDeveloper | null> {
-    const { data: defender } = await this.admin.from("developers").select(this.getRaidColumns()).ilike("github_login", this.payload.target_login).limit(1).maybeSingle();
-    return defender as RaidDeveloper | null;
-  }
-
-  private async resolveLoadout(attacker: RaidDeveloper): Promise<{ vehicle: string; tagStyle: string }> {
-    const [{ data: raidLoadoutRow }, { data: ownedVehiclePurchases }] = await Promise.all([
-      this.admin.from("developer_customizations").select("config").eq("developer_id", attacker.id).eq("item_id", "raid_loadout").maybeSingle(),
-      this.admin.from("purchases").select("item_id, items!inner(metadata)").eq("developer_id", attacker.id).eq("status", "completed"),
+  private async loadOwnedVehicleIds(developerId: number): Promise<Set<string>> {
+    const [ownedPurchases, giftedPurchases] = await Promise.all([
+      this.admin
+        .from("purchases")
+        .select("item_id")
+        .eq("developer_id", developerId)
+        .is("gifted_to", null)
+        .eq("status", "completed"),
+      this.admin
+        .from("purchases")
+        .select("item_id")
+        .eq("gifted_to", developerId)
+        .eq("status", "completed"),
     ]);
 
-    const ownedSet = new Set((ownedVehiclePurchases ?? []).map((p: { item_id: string }) => p.item_id));
-    const savedLoadout = (raidLoadoutRow?.config as { vehicle?: string; tag?: string } | null) ?? {};
-    const xpLevel = attacker.xp_level ?? 1;
+    const itemIds = [
+      ...(ownedPurchases.data ?? []).map((purchase: { item_id: string }) => purchase.item_id),
+      ...(giftedPurchases.data ?? []).map((purchase: { item_id: string }) => purchase.item_id),
+    ];
 
-    let vehicle = "airplane";
-    if (this.payload.vehicle_id) {
-      const isLevelUnlocked = ITEM_UNLOCK_LEVELS[this.payload.vehicle_id] && xpLevel >= ITEM_UNLOCK_LEVELS[this.payload.vehicle_id];
-      if (
-        this.payload.vehicle_id === "airplane" ||
-        this.payload.vehicle_id === "raid_helicopter" ||
-        this.payload.vehicle_id === "vehicle_tank" ||
-        this.payload.vehicle_id === "raid_b2_bomber" ||
-        ownedSet.has(this.payload.vehicle_id) ||
-        isLevelUnlocked
-      ) {
-        vehicle = this.payload.vehicle_id;
-      }
-    } else {
-      const saved = savedLoadout.vehicle ?? "airplane";
-      const isSavedLevelUnlocked = ITEM_UNLOCK_LEVELS[saved] && xpLevel >= ITEM_UNLOCK_LEVELS[saved];
-      vehicle =
-        saved === "airplane" ||
-        saved === "raid_helicopter" ||
-        saved === "vehicle_tank" ||
-        saved === "raid_b2_bomber" ||
-        ownedSet.has(saved) ||
-        isSavedLevelUnlocked
-          ? saved
-          : "airplane";
-    }
-
-    let tagStyle = "default";
-    const savedTag = savedLoadout.tag ?? "default";
-    const isTagLevelUnlocked = ITEM_UNLOCK_LEVELS[savedTag] && xpLevel >= ITEM_UNLOCK_LEVELS[savedTag];
-    tagStyle = savedTag === "default" || ownedSet.has(savedTag) || isTagLevelUnlocked ? savedTag : "default";
-
-    return { vehicle, tagStyle };
+    return new Set(itemIds);
   }
 
   private async resolveConsumables(attacker: RaidDeveloper): Promise<{ boostBonus: number; boostItemId: string | null; boostPurchaseIdToConsume: number | null; attackerConsumableItemId: string | null }> {
-    const consumable_item_id = this.payload.offensive_item_id ?? this.payload.consumable_item_id;
-    let boostBonus = 0;
-    let boostItemId: string | null = null;
-    let boostPurchaseIdToConsume: number | null = null;
-    let attackerConsumableItemId: string | null = null;
+    const consumableItemId = this.payload.offensive_item_id ?? this.payload.consumable_item_id;
+    let consumableRow: { id?: string; quantity: number; weekly_uses: number; last_reset_week: string | null } | null = null;
+    let boostPurchase: { id: number; item_id: string; items?: unknown } | null = null;
 
-    if (consumable_item_id) {
-      const { data: consumable } = await this.admin.from("developer_consumables").select("id, quantity, weekly_uses, last_reset_week").eq("developer_id", attacker.id).eq("item_id", consumable_item_id).single();
-      const resetWeekStr = consumable?.last_reset_week ? getUtcDateString(consumable.last_reset_week) : null;
-
-      if (consumable && consumable.quantity > 0) {
-        let currentUses = consumable.weekly_uses;
-        if (this.raidWeekStart !== resetWeekStr) currentUses = 0;
-        if (currentUses < 3) attackerConsumableItemId = consumable_item_id;
-      } else {
-        const reqLevel = ITEM_UNLOCK_LEVELS[consumable_item_id];
-        const isLevelUnlocked = reqLevel && (attacker.xp_level ?? 1) >= reqLevel;
-        if (isLevelUnlocked || consumable_item_id === "scouting_satellite") {
-          if (!consumable || consumable.weekly_uses < 3 || resetWeekStr !== this.raidWeekStart) {
-            attackerConsumableItemId = consumable_item_id;
-          }
-        }
-      }
+    if (consumableItemId) {
+      const { data } = await this.admin
+        .from("developer_consumables")
+        .select("id, quantity, weekly_uses, last_reset_week")
+        .eq("developer_id", attacker.id)
+        .eq("item_id", consumableItemId)
+        .single();
+      consumableRow = (data as { id?: string; quantity: number; weekly_uses: number; last_reset_week: string | null } | null) ?? null;
     } else if (this.payload.boost_purchase_id) {
-      const { data: boostPurchase } = await this.admin.from("purchases").select("id, item_id, status, items!inner(metadata)").eq("id", this.payload.boost_purchase_id).eq("developer_id", attacker.id).eq("status", "completed").single();
-      if (boostPurchase) {
-        const meta = (boostPurchase.items as unknown as { metadata: { type: string; bonus: number } })?.metadata;
-        if (meta?.type === "raid_boost" && meta.bonus > 0) {
-          boostBonus = meta.bonus;
-          boostItemId = boostPurchase.item_id;
-          boostPurchaseIdToConsume = boostPurchase.id;
-        }
-      }
+      const { data } = await this.admin
+        .from("purchases")
+        .select("id, item_id, status, items!inner(metadata)")
+        .eq("id", this.payload.boost_purchase_id)
+        .eq("developer_id", attacker.id)
+        .eq("status", "completed")
+        .single();
+      boostPurchase = (data as { id: number; item_id: string; items?: unknown } | null) ?? null;
     }
 
-    return { boostBonus, boostItemId, boostPurchaseIdToConsume, attackerConsumableItemId };
+    return resolveRaidConsumableSelection({
+      consumableItemId,
+      boostPurchaseId: this.payload.boost_purchase_id,
+      consumableRow,
+      boostPurchase,
+      raidWeekStart: this.raidWeekStart,
+      attackerXpLevel: attacker.xp_level ?? 1,
+    });
   }
 
   private async resolveDefenses(defender: RaidDeveloper, attackerConsumableItemId: string | null): Promise<{ activeDefenses: string[]; defenderItemUsed: boolean; defenderEffectiveDefense: string | null }> {
-    let activeDefenses: string[] = Array.isArray(defender.active_defenses) ? defender.active_defenses : [];
-    let defenderItemUsed = false;
+    const activeDefenses = Array.isArray(defender.active_defenses) ? defender.active_defenses : [];
+    const availableDefenses = activeDefenses.length > 0
+      ? null
+      : ((await this.admin
+        .from("developer_consumables")
+        .select("item_id, quantity, weekly_uses, last_reset_week")
+        .eq("developer_id", defender.id)
+        .gt("quantity", 0)).data as Array<{ item_id: string; quantity: number; weekly_uses: number; last_reset_week: string | null }> | null);
 
-    if (activeDefenses.length > 0) {
-      defenderItemUsed = true;
-    } else {
-      const { data: availableDefenses } = await this.admin.from("developer_consumables").select("item_id, quantity, weekly_uses, last_reset_week").eq("developer_id", defender.id).gt("quantity", 0);
-
-      if (availableDefenses && availableDefenses.length > 0) {
-        for (const def of availableDefenses) {
-          let currentUses = def.weekly_uses;
-          if (getUtcDateString(def.last_reset_week) !== this.raidWeekStart) currentUses = 0;
-          if (currentUses < 3) {
-            activeDefenses = [def.item_id];
-            defenderItemUsed = true;
-            break;
-          }
-        }
-      }
-    }
-
-    const isEmpDevice = attackerConsumableItemId === "emp_device";
-    let defenderEffectiveDefense = activeDefenses.length > 0 ? activeDefenses[0] : null;
-    if (isEmpDevice && defenderEffectiveDefense) defenderEffectiveDefense = null;
-
-    return { activeDefenses, defenderItemUsed, defenderEffectiveDefense };
-  }
-
-  private async handlePostExecution(attacker: RaidDeveloper, defender: RaidDeveloper, details: { boostPurchaseIdToConsume: number | null; defenderItemUsed: boolean; activeDefenses: string[]; success: boolean; raidId?: string; vehicle: string; tagStyle: string; attack: { total: number; breakdown: ScoreBreakdown }; defense: { total: number; breakdown: ScoreBreakdown }; attackerConsumableItemId: string | null; defenderEffectiveDefense: string | null }): Promise<void> {
-    if (details.boostPurchaseIdToConsume) {
-      await this.admin.from("purchases").update({ status: "consumed" }).eq("id", details.boostPurchaseIdToConsume);
-    }
-    if (details.defenderItemUsed && details.activeDefenses.length > 0) {
-      await this.consumeDeveloperItem(defender.id, details.activeDefenses[0]);
-    }
-
-    if (details.success) {
-      await this.admin.from("raid_tags").update({ active: false }).eq("building_id", defender.id).eq("active", true);
-      await this.admin.from("raid_tags").insert({
-        raid_id: details.raidId,
-        building_id: defender.id,
-        attacker_id: attacker.id,
-        attacker_login: attacker.github_login,
-        tag_style: details.tagStyle,
-        expires_at: new Date(Date.now() + RAID_TAG_DURATION_DAYS * 86400000).toISOString(),
-      });
-
-      await Promise.all([
-        this.admin.rpc("increment_raid_xp", { p_developer_id: attacker.id, p_amount: XP_WIN_ATTACKER }),
-        this.admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_WIN_DEFENDER }),
-      ]);
-      await this.admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
-      await this.admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
-
-      try {
-        const { data: newWins, error: relicErr } = await this.admin.rpc("increment_relic_progress", {
-          p_developer_id: attacker.id,
-          p_field: "raid_wins",
-        });
-
-        if (relicErr) {
-          console.error("[raid/execute] increment_relic_progress error:", relicErr);
-        } else if ((newWins ?? 0) >= 1) {
-          await this.admin.from("developer_relics").upsert(
-            {
-              developer_id: attacker.id,
-              relic_id: "relic_requiem_void_core",
-              is_equipped: false,
-              created_at: new Date().toISOString(),
-            },
-            { onConflict: "developer_id,relic_id" },
-          );
-        }
-      } catch (err) {
-        console.error("[raid/execute] Failed to track raid win for relic:", err);
-      }
-    } else {
-      await this.admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_LOSE_DEFENDER });
-      await this.admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
-      await this.admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
-    }
-
-    await this.admin.from("activity_feed").insert({
-      event_type: details.success ? "raid_success" : "raid_failed",
-      actor_id: attacker.id,
-      target_id: defender.id,
-      metadata: {
-        attacker_login: attacker.github_login,
-        defender_login: defender.github_login,
-        attack_score: details.attack.total,
-        defense_score: details.defense.total,
-      },
+    return resolveRaidDefenses({
+      defenderActiveDefenses: defender.active_defenses,
+      availableDefenses,
+      attackerConsumableItemId,
+      raidWeekStart: this.raidWeekStart,
     });
-
-    await touchLastActive(attacker.id);
-    await trackDailyMission(attacker.id, "attempt_battle");
-    if (details.success) await trackDailyMission(attacker.id, "win_battle");
-    sendRaidAlertNotification(defender.id, defender.github_login, attacker.github_login, details.raidId ?? 0, details.success, details.attack.total, details.defense.total);
-  }
-
-  private async consumeDeveloperItem(devId: number, itemId: string): Promise<boolean> {
-    const { data, error } = await this.admin.rpc("consume_consumable", {
-      p_developer_id: devId,
-      p_item_id: itemId,
-      p_week_start: this.raidWeekStart,
-    });
-
-    if (error) {
-      console.error("[raid/execute] consume_consumable RPC error:", error);
-      return false;
-    }
-
-    return data === true;
   }
 
   private createError(message: string, status: number): RaidServiceError {


### PR DESCRIPTION
## What does this PR do?

This PR refactors the raid execution pipeline by modularizing core domain responsibilities into reusable components while preserving existing gameplay behavior, API contracts, and response formats.

### Changes

* Extracted shared raid planning logic into `raid-planner`

  * Loadout resolution
  * Consumable resolution
  * Defense resolution
  * Shared planning logic used by preview and execution
* Extracted post-execution side effects into `raid-post-execution`

  * Reward processing
  * Raid XP updates
  * Raid tags
  * Relic progression
  * Daily mission tracking
  * Activity feed updates
  * Notification dispatch
* Simplified `RaidService` into an orchestration layer responsible for:

  * Input validation
  * Planner invocation
  * Raid RPC execution
  * Post-execution coordination
  * Reward coordination
  * Returning the existing `RaidExecuteResponse`
* Updated the raid preview route to reuse the shared planner where appropriate.
* Added focused unit tests for the newly extracted modules.

This is a behavior-preserving refactor. No gameplay mechanics, RPC contracts, database logic, or client-facing response formats were changed.

## Related issue

Fixes #1419

## Screenshots

N/A (Backend refactor with no UI changes)

## Checklist

* [x] `npm run lint` passes
* [x] Tested locally
* [x] No secrets or .env values committed
* [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
* [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
