### PR TITLE
fix: add adjacent page discovery to hourly LeetCode fetcher

### DIFF
--- a/src/app/api/cron/lc-refresh/route.ts
+++ b/src/app/api/cron/lc-refresh/route.ts
@@ -308,11 +308,19 @@ export async function GET(request: NextRequest) {
   const sb = getSupabaseAdmin();
   const results = { refreshed: 0, skipped: 0, failed: 0, users: [] as string[] };
 
-  // ── Discovery: insert new users from ranking page ──
-  // Rotate through pages using Unix hour as cursor — no DB state needed
-  const discoveryPage = (Math.floor(Date.now() / 3_600_000) % 50) + 1;
-  const discovered = await discoverAndInsertNewUsers(sb, discoveryPage);
-  console.log(`[lc-refresh] Discovery: ${discovered} new users inserted from page ${discoveryPage}`);
+  // ── Discovery: insert new users from ranking pages ──
+  // Rotate through pages using Unix hour as cursor — check current and next page
+  const page1 = (Math.floor(Date.now() / 3_600_000) % 50) + 1;
+  const page2 = (page1 % 50) + 1;
+
+  const discovered1 = await discoverAndInsertNewUsers(sb, page1);
+  const discovered2 = await discoverAndInsertNewUsers(sb, page2);
+
+  const totalDiscovered = discovered1 + discovered2;
+
+  console.log(
+    `[lc-refresh] Discovery: ${totalDiscovered} new users inserted from pages ${page1} and ${page2}`
+  );
 
   // ── Pick most-stale developers (claimed first, then unclaimed) ──
   const staleClaimedCutoff = new Date(Date.now() - 6 * 3600_000).toISOString();   // 6h


### PR DESCRIPTION
## What does this PR do?

This PR improves the hourly LeetCode user discovery process by scanning two adjacent ranking pages instead of a single page during each cron execution.

### Changes made
- Updated the discovery logic in `src/app/api/cron/lc-refresh/route.ts` to scan both the current ranking page and the next adjacent page.
- Aggregated the number of newly discovered users from both pages.
- Updated the discovery log message to display the combined discovery count and the pages that were scanned.
- Kept the existing refresh workflow and profile update logic unchanged.

## Related issue

Fixes #1116

## Screenshots

N/A (Backend logic change)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or `.env` values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)