### PR TITLE
fix(search): escape LIKE wildcard characters

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -21,8 +21,8 @@ export async function GET(req: NextRequest) {
   }
 
   const supabase = getSupabaseAdmin();
-  // Escape LIKE special characters (% _ \) to prevent wildcard injection
-  const escapedQ = q.replace(/[%_\\]/g, (c) => (c === "\\" ? "\\\\" : `\\${c}`));
+  // Escape LIKE wildcard characters so user input is treated literally.
+  const escapedQ = q.replace(/[\\%_]/g, "\\$&");
   const { data, error } = await supabase
     .from("developers")
     .select("github_login, avatar_url, name, easy_solved, medium_solved, hard_solved, lc_global_rank")


### PR DESCRIPTION
## What does this PR do?

This PR escapes SQL LIKE wildcard characters (`%`, `_`, and `\`) in the search query before passing it to Supabase's `.ilike()` method. This ensures user input is treated literally and prevents unintended wildcard matching while preserving existing search functionality.

## Related issue

Fixes #1387

## Screenshots

N/A (Backend/API change)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)