### PR TITLE
strucuted api logger

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
 import { checkAchievements, countGifts } from "@/lib/achievements";
 import { getEnvNumber } from "@/lib/env";
 import { validateParams, validateQuery } from "@/lib/validation";
+import { logApiError, newReqId } from "@/lib/api-logger";
 import { OwnershipResolver } from "@/services/ownershipResolver";
 
 export const dynamic = "force-dynamic";
@@ -115,7 +116,7 @@ const LC_HEADERS = {
 import { parseMaxStreak } from "@/lib/leetcode";
 import { calculateLeetcodeXp, mergeBaseXp } from "@/lib/xp";
 
-async function fetchLeetCodeUser(username: string) {
+async function fetchLeetCodeUser(username: string, reqId: string) {
   const currentYear = new Date().getFullYear();
   const prevYear = currentYear - 1;
 
@@ -155,17 +156,17 @@ async function fetchLeetCodeUser(username: string) {
       body: JSON.stringify({ query, variables: { username } }),
     });
     if (!res.ok) {
-      console.error(`[/api/dev] LeetCode responded ${res.status} for user "${username}"`);
+      logApiError({ reqId, route: "/api/dev/[username]", error: `LeetCode responded ${res.status} for user "${username}"` });
       return null;
     }
     const rawText = await res.text();
     let json: LeetCodeApiResponse;
     try { json = JSON.parse(rawText); } catch (err) { 
-      console.error(`[/api/dev] LeetCode non-JSON response for "${username}": ${rawText.substring(0, 200)}`, err);
+      logApiError({ reqId, route: "/api/dev/[username]", error: err, message: `LeetCode non-JSON response for "${username}": ${rawText.substring(0, 200)}` });
       return null;
     }
     if (!json?.data?.matchedUser) {
-      console.error(`[/api/dev] LeetCode returned no matchedUser for "${username}". Status: ${res.status}. firstErr:`, json?.errors?.[0]?.message);
+      logApiError({ reqId, route: "/api/dev/[username]", error: json?.errors?.[0]?.message ?? "LeetCode returned no matchedUser", message: `LeetCode returned no matchedUser for "${username}". Status: ${res.status}.` });
     }
     const apiData = json.data;
     if (apiData?.matchedUser) {
@@ -196,6 +197,7 @@ export async function GET(
   { params }: { params: Promise<{ username: string }> }
 ) {
   const resolvedParams = await params;
+  const reqId = newReqId();
   const paramVal = validateParams(resolvedParams, paramsSchema);
   if (!paramVal.success) {
     return paramVal.response;
@@ -229,10 +231,12 @@ export async function GET(
   
   let rateLimitKey: string | null = null;
   let isAuthenticatedUser = false;
+  let authUserId: string | null = null;
   if (!cachedRecord) {
     const { resolveAuthenticatedDeveloper } = await import("@/lib/authenticated-developer");
     const auth = await resolveAuthenticatedDeveloper({ loadDeveloper: false });
     isAuthenticatedUser = !!auth.user;
+    authUserId = auth.user?.id ?? null;
     const key = auth.user ? `user:${auth.user.id}` : (
       request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
     );
@@ -252,7 +256,7 @@ export async function GET(
   let upserted = cachedRecord;
 
   if (!cachedRecord) {
-    const data = await fetchLeetCodeUser(username);
+    const data = await fetchLeetCodeUser(username, reqId);
     if (!data) {
       if (cached) {
         upserted = cached;
@@ -398,7 +402,7 @@ export async function GET(
           upserted.github_login,
         );
       } catch (err) {
-        console.error("[dev/[username]] achievement check failed:", err);
+        logApiError({ reqId, userId: authUserId, route: "/api/dev/[username]", error: err, message: "Achievement check failed" });
       }
     }
   }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { z } from "zod";
 import { validateQuery } from "@/lib/validation";
+import { logApiError, newReqId } from "@/lib/api-logger";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,7 @@ const querySchema = z.object({
 });
 
 export async function GET(req: NextRequest) {
+  const reqId = newReqId();
   const queryVal = validateQuery(req.nextUrl.searchParams, querySchema);
   if (!queryVal.success) {
     return queryVal.response;
@@ -30,7 +32,7 @@ export async function GET(req: NextRequest) {
     .limit(8);
 
   if (error) {
-    console.error("Search API error:", error);
+    logApiError({ reqId, route: "/api/search", error, message: "Search API error" });
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { logApiError, newReqId } from "@/lib/api-logger";
 
 /**
  * Public aggregate statistics for the LeetCode City.
@@ -7,6 +8,7 @@ import { getSupabaseAdmin } from "@/lib/supabase";
  * and tallest building metrics. No authentication required.
  */
 export async function GET() {
+  const reqId = newReqId();
   try {
     const sb = getSupabaseAdmin();
 
@@ -59,7 +61,7 @@ export async function GET() {
       }
     );
   } catch (error) {
-    console.error("[/api/stats] Error generating city stats:", error);
+    logApiError({ reqId, route: "/api/stats", error, message: "Error generating city stats" });
     return NextResponse.json(
       {
         totalDevelopers: 0,

--- a/src/lib/__tests__/api-logger.test.ts
+++ b/src/lib/__tests__/api-logger.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { logApiError, newReqId } from "../api-logger";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("newReqId", () => {
+  it("returns a non-empty string", () => {
+    expect(newReqId().length).toBeGreaterThan(0);
+  });
+
+  it("returns unique ids across calls", () => {
+    expect(newReqId()).not.toBe(newReqId());
+  });
+});
+
+describe("logApiError", () => {
+  function captureStdout(): { getWrittenLines: () => string[]; written: string } {
+    let written = "";
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      written += String(chunk);
+      return true;
+    });
+    return { getWrittenLines: () => written.split("\n").filter(Boolean), written };
+  }
+
+  it("writes a single structured JSON line to stdout", () => {
+    const { getWrittenLines } = captureStdout();
+    const error = new Error("boom");
+
+    logApiError({ reqId: "req-123", userId: "user-1", route: "/api/stats", error, message: "Stats failed" });
+
+    const lines = getWrittenLines();
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.level).toBe("error");
+    expect(entry.ts).toBeTruthy();
+    expect(entry.reqId).toBe("req-123");
+    expect(entry.userId).toBe("user-1");
+    expect(entry.route).toBe("/api/stats");
+    expect(entry.message).toBe("Stats failed");
+    expect(entry.error).toMatchObject({ name: "Error", message: "boom" });
+  });
+
+  it("generates a reqId when omitted", () => {
+    const { getWrittenLines } = captureStdout();
+    logApiError({ route: "/api/search", error: "bad query" });
+    const entry = JSON.parse(getWrittenLines()[0]);
+    expect(entry.reqId).toBeTruthy();
+  });
+
+  it("omits userId when not provided", () => {
+    const { getWrittenLines } = captureStdout();
+    logApiError({ route: "/api/stats", error: new Error("anon") });
+    const entry = JSON.parse(getWrittenLines()[0]);
+    expect(entry).not.toHaveProperty("userId");
+  });
+
+  it("serializes string errors into an error object", () => {
+    const { getWrittenLines } = captureStdout();
+    logApiError({ route: "/api/dev/[username]", error: "LeetCode responded 500" });
+    const entry = JSON.parse(getWrittenLines()[0]);
+    expect(entry.error).toEqual({ name: "Error", message: "LeetCode responded 500" });
+  });
+
+  it("includes error cause when present", () => {
+    const { getWrittenLines } = captureStdout();
+    const cause = new Error("upstream");
+    logApiError({ route: "/api/weather", error: new Error("fetch failed", { cause }) });
+    const entry = JSON.parse(getWrittenLines()[0]);
+    expect(entry.error.cause).toMatchObject({ name: "Error", message: "upstream" });
+  });
+
+  it("includes extra context fields", () => {
+    const { getWrittenLines } = captureStdout();
+    logApiError({ reqId: "req-9", route: "/api/dev/[username]", error: new Error("x"), username: "alice", status: 502 });
+    const entry = JSON.parse(getWrittenLines()[0]);
+    expect(entry.username).toBe("alice");
+    expect(entry.status).toBe(502);
+  });
+});

--- a/src/lib/api-logger.ts
+++ b/src/lib/api-logger.ts
@@ -1,0 +1,95 @@
+/**
+ * Structured JSON logging for API routes.
+ *
+ * Bare `console.error("...", error)` calls are hard to parse and lack
+ * context (which request, which user, which route). This helper emits a
+ * single JSON line to stdout so logs can be correlated and analyzed in
+ * log aggregation tools (Datadog, Vercel Logs, Grafana, etc.).
+ *
+ * Usage:
+ *   import { logApiError, newReqId } from "@/lib/api-logger";
+ *
+ *   export async function GET(request: NextRequest) {
+ *     const reqId = newReqId(); // generate once per request
+ *     try {
+ *       // ...
+ *     } catch (error) {
+ *       logApiError({ reqId, route: "/api/stats", error });
+ *     }
+ *   }
+ *
+ * Output shape (single line):
+ *   {"level":"error","ts":"2026-08-08T12:00:00.000Z","reqId":"...","route":"/api/stats","message":"...","error":{"name":"Error","message":"..."}}
+ */
+
+export interface ApiLogErrorInput {
+  /** Request ID used to correlate all log lines for a single request. */
+  reqId?: string;
+  /** Authenticated user id, when available. Omitted from the log if absent. */
+  userId?: string | number | null;
+  /** Route identifier, e.g. "/api/stats" or "/api/dev/[username]". */
+  route: string;
+  /** The error to log (Error instance, message string, or any value). */
+  error: unknown;
+  /** Optional human-readable summary of what failed. */
+  message?: string;
+  /** Any additional context fields to include (status, username, ...). */
+  [key: string]: unknown;
+}
+
+/**
+ * Returns a fresh request ID. Call once at the top of a route handler and
+ * reuse it across every log call so all lines for a request share the same
+ * `reqId`.
+ */
+export function newReqId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without the Web Crypto API.
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function serializeError(error: unknown): unknown {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(error.stack ? { stack: error.stack } : {}),
+      ...(error.cause !== undefined ? { cause: serializeError(error.cause) } : {}),
+    };
+  }
+  if (typeof error === "string") {
+    return { name: "Error", message: error };
+  }
+  return error;
+}
+
+/**
+ * Logs an API error as a single structured JSON line to stdout.
+ * A `reqId` is generated automatically when not provided.
+ */
+export function logApiError(input: ApiLogErrorInput): void {
+  const { reqId = newReqId(), userId, route, error, message, ...extra } = input;
+
+  const entry: Record<string, unknown> = {
+    level: "error",
+    ts: new Date().toISOString(),
+    reqId,
+    ...(userId !== undefined && userId !== null ? { userId: String(userId) } : {}),
+    route,
+    ...(message ? { message } : {}),
+    error: serializeError(error),
+    ...extra,
+  };
+
+  try {
+    process.stdout.write(`${JSON.stringify(entry)}\n`);
+  } catch {
+    // Never let logging itself take down the request — fall back to a
+    // minimal, still-structured line and flag the serialization failure.
+    process.stdout.write(
+      `${JSON.stringify({ level: "error", ts: new Date().toISOString(), reqId, route, serializationFailed: true })}\n`
+    );
+  }
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->
Many API routes log errors with bare `console.error(...)` calls that lack structured context (request ID, user ID, route), making logs hard to parse, correlate, and analyze in aggregation tools (Vercel Logs, Datadog, etc.).
 
This PR introduces a shared structured logger and migrates a few representative routes to it.

## Related issue
Link to issue: Fixes #1104

## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [X] `npm run lint` passes
- [X] Tested locally
- [X] No secrets or .env values committed
- [X] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [X] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
