### PR TITLE
fix(raidAudio): guard takeoff sound to prevent duplicate play on intro phase

### DIFF
--- a/src/lib/raidAudio.ts
+++ b/src/lib/raidAudio.ts
@@ -52,3 +52,9 @@ export function stopAllRaidSounds() {
     s.stop();
   }
 }
+
+// NEW: Safe guard — checks if a sound is currently playing
+// Used by useRaidSequence to prevent double-trigger on rapid phase transitions
+export function isRaidSoundPlaying(name: string): boolean {
+  return raidSounds?.[name]?.playing() ?? false;
+}

--- a/src/lib/useRaidSequence.ts
+++ b/src/lib/useRaidSequence.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { CityBuilding } from "@/lib/github";
 import type { RaidPreviewResponse, RaidExecuteResponse } from "@/lib/raid";
-import { preloadRaidAudio, playRaidSound, stopRaidSound, fadeOutRaidSound, stopAllRaidSounds } from "@/lib/raidAudio";
+import { preloadRaidAudio, playRaidSound, stopRaidSound, fadeOutRaidSound, stopAllRaidSounds, isRaidSoundPlaying } from "@/lib/raidAudio";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -107,7 +107,9 @@ export function useRaidSequence(): [RaidState, RaidActions] {
     // Audio triggers
     switch (phase) {
       case "intro":
-        playRaidSound("takeoff");
+        if (!isRaidSoundPlaying("takeoff")) {
+          playRaidSound("takeoff");
+        }
         break;
       case "flight":
         playRaidSound("flight");


### PR DESCRIPTION
## What does this PR do?
Adds a guard to prevent the `takeoff` sound from playing twice when `setPhase("intro")` 
is triggered more than once in rapid succession (e.g. React Strict Mode double-invoke or 
concurrent execution). A new `isRaidSoundPlaying()` helper is exported from `raidAudio.ts` 
and used in `useRaidSequence.ts` to check if the sound is already playing before starting it.

## Related issue
Fixes #1434

## Screenshots
N/A — audio-only fix, no visual changes.

## Checklist
- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!**