### PR TITLE
fix(cron): add explicit null guard to re-engagement query

### DIFF
--- a/src/app/api/cron/re-engagement/route.ts
+++ b/src/app/api/cron/re-engagement/route.ts
@@ -90,6 +90,7 @@ export async function GET(request: NextRequest) {
         .select("id, github_login")
         .eq("claimed", true)
         .not("email", "is", null)
+        .not("last_active_at", "is", null)
         .lte("last_active_at", inactiveBefore)
         .gte("last_active_at", inactiveAfter)
         .range(offset, offset + batchSize - 1);


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->
Added an explicit null guard (`.not("last_active_at", "is", null)`) to the re-engagement cron job query to prevent errors when evaluating inactive developers whose `last_active_at` timestamp is null.

## Related issue

<!-- Link to issue: Fixes #ISSUE_NUMBER -->
Fixes #1389

## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
