### PR TITLE
fix: dotenv file check in add-leetcode-items

### DIFF
--- a/scripts/add-leetcode-items.ts
+++ b/scripts/add-leetcode-items.ts
@@ -1,7 +1,18 @@
 import { createClient } from "@supabase/supabase-js";
+import { existsSync } from "fs";
 import { resolve } from "path";
 import dotenv from "dotenv";
-dotenv.config({ path: resolve(__dirname, "../.env.local") });
+
+const envPath = resolve(__dirname, "../.env.local");
+if (existsSync(envPath)) {
+    try {
+        dotenv.config({ path: envPath });
+    } catch (err) {
+        console.warn("Warning: failed to load .env.local:", err);
+    }
+} else {
+    console.warn("Warning: .env.local not found. Ensure environment variables are set.");
+}
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->

`scripts/add-leetcode-items.ts` called `dotenv.config({ path: resolve(__dirname, "../.env.local") })` unconditionally. When `.env.local` is missing or unreadable, the script kept running and later failed with a confusing `Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY` error, making setup problems hard to debug.
 
This PR guards the env-file load with an existence check and a clear warning.
 
## Changes
- Import `existsSync` from `fs`.
- Compute the env path once (`resolve(__dirname, "../.env.local")`).
- If the file exists, load it with `dotenv.config()`, wrapped in a `try/catch`  that warns on load failure (e.g. unreadable or malformed file).
- If the file is missing, print  `Warning: .env.local not found. Ensure environment variables are set.`
- The existing `Missing NEXT_PUBLIC_SUPABASE_URL...` validation remains as a  final safety net.

## Related issue

<!-- Link to issue: Fixes #ISSUE_NUMBER -->
fixes: #1433 
## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
