### PR TITLE
docs: add JSDoc to re-engagement cron route

### DIFF
--- a/src/app/api/cron/re-engagement/route.ts
+++ b/src/app/api/cron/re-engagement/route.ts
@@ -5,6 +5,12 @@ import { buildButton } from "@/lib/email-template";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://theleetcodecity.tech";
 
+/**
+ * Defines the configuration for a re-engagement email tier.
+ *
+ * Each tier specifies how long a developer must be inactive,
+ * along with the email content to send when the tier is triggered.
+ */
 interface ReEngagementTier {
   daysInactive: number;
   tier: string;
@@ -12,7 +18,12 @@ interface ReEngagementTier {
   body: (login: string) => string;
   html: (login: string, extraInfo: string) => string;
 }
-
+/**
+ * Re-engagement email tiers based on the number of days a developer has been inactive.
+ *
+ * Each tier defines the inactivity period and the email content
+ * used to re-engage inactive developers.
+ */
 const TIERS: ReEngagementTier[] = [
   {
     daysInactive: 7,


### PR DESCRIPTION
## What does this PR do?

Adds JSDoc documentation to the re-engagement cron route.

## Changes

- Added JSDoc documentation for the `ReEngagementTier` interface.
- Added JSDoc documentation for the re-engagement email tiers.
- Documented the cron route behavior and authorization requirements.

## Related issue

Fixes #1301

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] My changes are limited to the scope of this issue.