### PR TITLE
feat(api): standardize Zod validation across public API routes

### DIFF
--- a/src/app/api/arcade/rooms/[slug]/route.ts
+++ b/src/app/api/arcade/rooms/[slug]/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { z } from "zod";
-import { validateParams } from "@/lib/validation";
+import { slugSchema, validateParams } from "@/lib/validation";
 
 import fs from "fs/promises";
 import path from "path";
 
 const paramsSchema = z.object({
-  slug: z.string().trim().min(1, "Slug is required"),
+  slug: slugSchema,
 });
 
 // GET /api/arcade/rooms/[slug] — get room with full map_json + track visit

--- a/src/app/api/arena/challenge/[id]/route.ts
+++ b/src/app/api/arena/challenge/[id]/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getAuthenticatedDeveloper } from "@/lib/arena";
+import { uuidSchema, validateParams } from "@/lib/validation";
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
 
 interface ProblemRow {
   id: number;
@@ -19,6 +25,12 @@ export async function GET(
   props: { params: Promise<{ id: string }> }
 ) {
   const params = await props.params;
+  const paramVal = validateParams(params, paramsSchema);
+  if (!paramVal.success) {
+    return paramVal.response;
+  }
+  const challengeId = paramVal.data.id;
+
   // Authenticate user (supporting extension API key or browser cookie)
   const dev = await getAuthenticatedDeveloper(request);
   if (!dev) {
@@ -26,7 +38,6 @@ export async function GET(
   }
 
   const sb = getSupabaseAdmin();
-  const challengeId = params.id;
 
   // Fetch the challenge
   const { data: challenge, error } = await sb

--- a/src/app/api/arena/leaderboard/route.ts
+++ b/src/app/api/arena/leaderboard/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { limitParamSchema, offsetParamSchema, validateQuery } from "@/lib/validation";
+
+const querySchema = z.object({
+  limit: limitParamSchema.optional().default(100),
+  offset: offsetParamSchema.optional().default(0),
+});
 
 function getRankTitle(rating: number, index: number): { title: string; badge: string; rarity: string } {
   if (index <= 10) return { title: "The Sentinel", badge: "badge_legendary", rarity: "legendary" };
@@ -13,10 +20,11 @@ function getRankTitle(rating: number, index: number): { title: string; badge: st
 export async function GET(request: NextRequest) {
   const sb = getSupabaseAdmin();
   const { searchParams } = new URL(request.url);
-  const rawLimit = parseInt(searchParams.get("limit") ?? "", 10);
-  const rawOffset = parseInt(searchParams.get("offset") ?? "", 10);
-  const limit = Number.isNaN(rawLimit) ? 100 : Math.min(100, Math.max(1, rawLimit));
-  const offset = Number.isNaN(rawOffset) ? 0 : Math.max(0, rawOffset);
+  const queryVal = validateQuery(searchParams, querySchema);
+  if (!queryVal.success) {
+    return queryVal.response;
+  }
+  const { limit, offset } = queryVal.data;
 
   // Query ratings table, ordering by ELO rating desc
   const { data: leaderboard, error } = await sb

--- a/src/app/api/arena/stats/[username]/route.ts
+++ b/src/app/api/arena/stats/[username]/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
 import { getAuthenticatedDeveloper } from "@/lib/arena";
+import { usernameSchema, validateParams } from "@/lib/validation";
+
+const paramsSchema = z.object({
+  username: usernameSchema,
+});
 
 function getRankTitle(rating: number, rank: number): { title: string; badge: string; rarity: string } {
   if (rank > 0 && rank <= 10) return { title: "The Sentinel", badge: "badge_legendary", rarity: "legendary" };
@@ -17,7 +23,11 @@ export async function GET(
   props: { params: Promise<{ username: string }> }
 ) {
   const params = await props.params;
-  const username = params.username.toLowerCase();
+  const paramVal = validateParams(params, paramsSchema);
+  if (!paramVal.success) {
+    return paramVal.response;
+  }
+  const username = paramVal.data.username.toLowerCase();
   const sb = getSupabaseAdmin();
 
   // 1. Fetch developer by username

--- a/src/app/api/dailies/route.ts
+++ b/src/app/api/dailies/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { getTodayStr } from "@/lib/dailies";
 import { DailyMissionService } from "@/services/dailyMissionService";
 import { resolveAuthenticatedDeveloper } from "@/lib/authenticated-developer";
+import { booleanFlagSchema, validateQuery } from "@/lib/validation";
+
+const querySchema = z.object({
+  mobile: booleanFlagSchema,
+});
 
 export async function GET(request: Request) {
   const authDev = await resolveAuthenticatedDeveloper({
@@ -25,7 +31,11 @@ export async function GET(request: Request) {
   const today = getTodayStr();
 
   const { searchParams } = new URL(request.url);
-  const isMobile = searchParams.get("mobile") === "1";
+  const queryVal = validateQuery(searchParams, querySchema);
+  if (!queryVal.success) {
+    return queryVal.response;
+  }
+  const isMobile = queryVal.data.mobile;
 
   const summary = await service.loadMissionSummary(
     {

--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { checkAchievements, countGifts } from "@/lib/achievements";
-import { validateParams, validateQuery } from "@/lib/validation";
+import { booleanFlagSchema, usernameSchema, validateParams, validateQuery } from "@/lib/validation";
 import { logApiError, newReqId } from "@/lib/api-logger";
 import { OwnershipResolver } from "@/services/ownershipResolver";
 import { CityReadModel } from "@/services/cityReadModel";
@@ -10,11 +10,11 @@ import { CityReadModel } from "@/services/cityReadModel";
 export const dynamic = "force-dynamic";
 
 const paramsSchema = z.object({
-  username: z.string().trim().min(1, "Username is required"),
+  username: usernameSchema,
 });
 
 const querySchema = z.object({
-  refresh: z.string().optional(),
+  refresh: booleanFlagSchema,
 });
 
 interface LeetCodeProfile {
@@ -209,7 +209,7 @@ export async function GET(
   if (!queryVal.success) {
     return queryVal.response;
   }
-  const forceRefresh = queryVal.data.refresh === "true";
+  const forceRefresh = queryVal.data.refresh;
   const sb = getSupabaseAdmin();
 
   let cachedRecord = null;

--- a/src/app/api/gitc/swap/price/route.ts
+++ b/src/app/api/gitc/swap/price/route.ts
@@ -1,5 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { fetchZeroxSwap, is0xEnabled } from "@/lib/gitc-server";
+import { evmAddressSchema, positiveAmountStringSchema, validateQuery } from "@/lib/validation";
+
+const querySchema = z.object({
+  sellToken: z.string().trim().min(1, "sellToken is required"),
+  sellAmount: positiveAmountStringSchema,
+  taker: evmAddressSchema.optional(),
+  slippageBps: z
+    .string()
+    .regex(/^\d+$/, "slippageBps must be a string of digits")
+    .optional(),
+});
 
 /**
  * Indicative price for a USDC|ETH → GITC swap on Base (0x Swap API v2).
@@ -11,11 +23,16 @@ export async function GET(req: NextRequest) {
   if (!is0xEnabled()) return NextResponse.json({ disabled: true });
 
   const sp = req.nextUrl.searchParams;
+  const queryVal = validateQuery(sp, querySchema);
+  if (!queryVal.success) {
+    return queryVal.response;
+  }
+  const { sellToken, sellAmount, taker, slippageBps } = queryVal.data;
   const result = await fetchZeroxSwap("price", {
-    sellToken: sp.get("sellToken") ?? "",
-    sellAmount: sp.get("sellAmount") ?? "",
-    taker: sp.get("taker") ?? undefined,
-    slippageBps: sp.get("slippageBps") ?? undefined,
+    sellToken,
+    sellAmount,
+    taker,
+    slippageBps,
   });
 
   if (!result.ok) {

--- a/src/app/api/gitc/swap/quote/route.ts
+++ b/src/app/api/gitc/swap/quote/route.ts
@@ -1,5 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { fetchZeroxSwap, is0xEnabled } from "@/lib/gitc-server";
+import { evmAddressSchema, positiveAmountStringSchema, validateQuery } from "@/lib/validation";
+
+const querySchema = z.object({
+  sellToken: z.string().trim().min(1, "sellToken is required"),
+  sellAmount: positiveAmountStringSchema,
+  taker: evmAddressSchema.optional(),
+  slippageBps: z
+    .string()
+    .regex(/^\d+$/, "slippageBps must be a string of digits")
+    .optional(),
+});
 
 /**
  * Firm quote for a USDC|ETH → GITC swap on Base (0x Swap API v2). Returns a
@@ -11,11 +23,16 @@ export async function GET(req: NextRequest) {
   if (!is0xEnabled()) return NextResponse.json({ disabled: true });
 
   const sp = req.nextUrl.searchParams;
+  const queryVal = validateQuery(sp, querySchema);
+  if (!queryVal.success) {
+    return queryVal.response;
+  }
+  const { sellToken, sellAmount, taker, slippageBps } = queryVal.data;
   const result = await fetchZeroxSwap("quote", {
-    sellToken: sp.get("sellToken") ?? "",
-    sellAmount: sp.get("sellAmount") ?? "",
-    taker: sp.get("taker") ?? undefined,
-    slippageBps: sp.get("slippageBps") ?? undefined,
+    sellToken,
+    sellAmount,
+    taker,
+    slippageBps,
   });
 
   if (!result.ok) {

--- a/src/app/api/github/[username]/route.ts
+++ b/src/app/api/github/[username]/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { validateParams } from "@/lib/validation";
+import { usernameSchema, validateParams } from "@/lib/validation";
 
 const paramsSchema = z.object({
-  username: z.string().trim().min(1, "Username is required"),
+  username: usernameSchema,
 });
 
 export async function GET(

--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -1,27 +1,26 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { usernameSchema, validateQuery } from "@/lib/validation";
 
 const VALID_TABS = ["solved", "lc_rank", "streak", "contest", "xp", "achievers"] as const;
-type Tab = (typeof VALID_TABS)[number];
+
+const querySchema = z.object({
+  tab: z.enum(VALID_TABS).optional().default("solved"),
+  login: usernameSchema,
+});
 
 /**
  * @param {import('next/server').NextRequest} request
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const tab = searchParams.get("tab") ?? "solved";
-  const login = searchParams.get("login")?.toLowerCase();
-
-  if (!VALID_TABS.includes(tab as Tab)) {
-    return NextResponse.json(
-      { error: `Invalid tab value: "${tab}". Must be one of: ${VALID_TABS.join(", ")}` },
-      { status: 400 }
-    );
+  const queryVal = validateQuery(searchParams, querySchema);
+  if (!queryVal.success) {
+    return queryVal.response;
   }
-
-  if (!login) {
-    return NextResponse.json({ error: "Missing login" }, { status: 400 });
-  }
+  const { tab } = queryVal.data;
+  const login = queryVal.data.login.toLowerCase();
 
   const sb = getSupabaseAdmin();
 

--- a/src/lib/__tests__/validation-schemas.test.ts
+++ b/src/lib/__tests__/validation-schemas.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  booleanFlagSchema,
+  evmAddressSchema,
+  limitParamSchema,
+  offsetParamSchema,
+  pageParamSchema,
+  paginationSchema,
+  positiveAmountStringSchema,
+  slugSchema,
+  sortDirectionSchema,
+  usernameSchema,
+  uuidSchema,
+  validateQuery,
+  validationErrorResponse,
+} from "../validation";
+
+const parse = (schema: z.ZodSchema<unknown>, value: unknown) => schema.safeParse(value);
+
+describe("reusable validation schemas", () => {
+  describe("usernameSchema", () => {
+    it("accepts valid GitHub/LeetCode-style usernames", () => {
+      expect(parse(usernameSchema, "octocat").success).toBe(true);
+      expect(parse(usernameSchema, "my-user_1").success).toBe(true);
+      expect(parse(usernameSchema, "  AdaLovelace  ").success).toBe(true);
+    });
+
+    it("trims surrounding whitespace", () => {
+      const result = usernameSchema.safeParse("  octocat  ");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("octocat");
+      }
+    });
+
+    it("rejects empty, oversized, and invalid-character usernames", () => {
+      expect(parse(usernameSchema, "").success).toBe(false);
+      expect(parse(usernameSchema, "   ").success).toBe(false);
+      expect(parse(usernameSchema, "a".repeat(40)).success).toBe(false);
+      expect(parse(usernameSchema, "user name").success).toBe(false);
+      expect(parse(usernameSchema, "user%name").success).toBe(false);
+      expect(parse(usernameSchema, "user@github").success).toBe(false);
+      expect(parse(usernameSchema, 42).success).toBe(false);
+    });
+  });
+
+  describe("pagination param schemas", () => {
+    it("pageParamSchema accepts positive integers, coerces numeric strings", () => {
+      expect(parse(pageParamSchema, 1).success).toBe(true);
+      expect(parse(pageParamSchema, "3").success).toBe(true);
+    });
+
+    it("pageParamSchema rejects 0, negatives, floats, and non-numbers", () => {
+      expect(parse(pageParamSchema, 0).success).toBe(false);
+      expect(parse(pageParamSchema, -1).success).toBe(false);
+      expect(parse(pageParamSchema, 1.5).success).toBe(false);
+      expect(parse(pageParamSchema, "abc").success).toBe(false);
+    });
+
+    it("limitParamSchema rejects out-of-range and invalid limits", () => {
+      expect(parse(limitParamSchema, 1).success).toBe(true);
+      expect(parse(limitParamSchema, 100).success).toBe(true);
+      expect(parse(limitParamSchema, 0).success).toBe(false);
+      expect(parse(limitParamSchema, 101).success).toBe(false);
+      expect(parse(limitParamSchema, "abc").success).toBe(false);
+    });
+
+    it("offsetParamSchema accepts zero but rejects negatives", () => {
+      expect(parse(offsetParamSchema, 0).success).toBe(true);
+      expect(parse(offsetParamSchema, 50).success).toBe(true);
+      expect(parse(offsetParamSchema, -1).success).toBe(false);
+    });
+
+    it("sortDirectionSchema only accepts asc/desc", () => {
+      expect(parse(sortDirectionSchema, "asc").success).toBe(true);
+      expect(parse(sortDirectionSchema, "desc").success).toBe(true);
+      expect(parse(sortDirectionSchema, "ascending").success).toBe(false);
+    });
+
+    it("paginationSchema applies sensible defaults when params are missing", () => {
+      const result = paginationSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ page: 1, limit: 20, offset: 0, sort: "desc" });
+      }
+    });
+
+    it("paginationSchema keeps provided values and validates ranges", () => {
+      const result = paginationSchema.safeParse({ page: 2, limit: 50, sort: "asc" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ page: 2, limit: 50, offset: 0, sort: "asc" });
+      }
+      expect(paginationSchema.safeParse({ limit: 0 }).success).toBe(false);
+    });
+  });
+
+  describe("booleanFlagSchema", () => {
+    it("coerces accepted string values to booleans", () => {
+      expect(booleanFlagSchema.parse("1")).toBe(true);
+      expect(booleanFlagSchema.parse("true")).toBe(true);
+      expect(booleanFlagSchema.parse("0")).toBe(false);
+      expect(booleanFlagSchema.parse("false")).toBe(false);
+    });
+
+    it("defaults to false when missing", () => {
+      expect(booleanFlagSchema.parse(undefined)).toBe(false);
+    });
+
+    it("rejects unknown values", () => {
+      expect(parse(booleanFlagSchema, "yes").success).toBe(false);
+      expect(parse(booleanFlagSchema, 1).success).toBe(false);
+    });
+  });
+
+  describe("uuidSchema", () => {
+    it("accepts valid UUIDs", () => {
+      expect(parse(uuidSchema, "f47ac10b-58cc-4372-a567-0e02b2c3d479").success).toBe(true);
+    });
+
+    it("rejects malformed ids", () => {
+      expect(parse(uuidSchema, "not-a-uuid").success).toBe(false);
+      expect(parse(uuidSchema, "").success).toBe(false);
+      expect(parse(uuidSchema, 123).success).toBe(false);
+    });
+  });
+
+  describe("slugSchema", () => {
+    it("accepts lowercase alphanumeric slugs with hyphens and underscores", () => {
+      expect(parse(slugSchema, "ixotopia").success).toBe(true);
+      expect(parse(slugSchema, "open-map-v2").success).toBe(true);
+      expect(parse(slugSchema, "trading_floor").success).toBe(true);
+    });
+
+    it("rejects invalid slugs", () => {
+      expect(parse(slugSchema, "").success).toBe(false);
+      expect(parse(slugSchema, "Ixotopia!").success).toBe(false);
+      expect(parse(slugSchema, "has space").success).toBe(false);
+    });
+  });
+
+  describe("evmAddressSchema", () => {
+    it("accepts a well-formed 0x-prefixed address", () => {
+      expect(parse(evmAddressSchema, "0x0000000000000000000000000000000000000000").success).toBe(true);
+      expect(parse(evmAddressSchema, "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").success).toBe(true);
+    });
+
+    it("rejects malformed addresses", () => {
+      expect(parse(evmAddressSchema, "0x123").success).toBe(false);
+      expect(parse(evmAddressSchema, "1234567890").success).toBe(false);
+      expect(parse(evmAddressSchema, "0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").success).toBe(false);
+    });
+  });
+
+  describe("positiveAmountStringSchema", () => {
+    it("accepts non-zero digit strings", () => {
+      expect(parse(positiveAmountStringSchema, "1").success).toBe(true);
+      expect(parse(positiveAmountStringSchema, "1000000000000000000").success).toBe(true);
+    });
+
+    it("rejects zero, decimals, and non-digits", () => {
+      expect(parse(positiveAmountStringSchema, "0").success).toBe(false);
+      expect(parse(positiveAmountStringSchema, "12.5").success).toBe(false);
+      expect(parse(positiveAmountStringSchema, "abc").success).toBe(false);
+      expect(parse(positiveAmountStringSchema, 123).success).toBe(false);
+    });
+  });
+});
+
+describe("validation error response shape", () => {
+  it("returns a 400 with field-level details and no stack trace", async () => {
+    const schema = z.object({ username: usernameSchema });
+    const result = validateQuery(new URLSearchParams("username=%25"), schema);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const json = await result.response.json();
+      expect(result.response.status).toBe(400);
+      expect(json.error).toBe("Invalid request parameters");
+      expect(Array.isArray(json.details)).toBe(true);
+      expect(json.details[0]).toEqual(
+        expect.objectContaining({ path: "username", message: expect.any(String) })
+      );
+      expect(JSON.stringify(json)).not.toContain("at ");
+      expect(json.stack).toBeUndefined();
+    }
+  });
+
+  it("reports multiple invalid fields at once", async () => {
+    const result = validateQuery(
+      new URLSearchParams("limit=0&offset=-5"),
+      z.object({ limit: limitParamSchema.optional(), offset: offsetParamSchema.optional() })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const json = await result.response.json();
+      expect(json.details.map((d: { path: string }) => d.path).sort()).toEqual(["limit", "offset"]);
+    }
+  });
+
+  it("produces an identical shape via validationErrorResponse directly", async () => {
+    const response = validationErrorResponse(new z.ZodError([]));
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json).toEqual({ error: "Invalid request parameters", details: [] });
+  });
+});

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { z, ZodSchema } from "zod";
 
+export * from "./schemas";
+export type { ZodSchema };
+
 /**
  * Formats Zod validation errors into a standard 400 Bad Request response.
  */

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+/**
+ * Reusable Zod schemas for common API input patterns.
+ *
+ * These keep route handlers focused on business logic: malformed params,
+ * query strings and bodies are rejected at the boundary with a consistent
+ * 400 response (see `validationErrorResponse` in ./index.ts).
+ *
+ * Constraint-only schemas (no defaults) are composed per-route with
+ * `.optional().default(...)` so each endpoint decides its own defaults.
+ */
+
+/** GitHub/LeetCode-style username: trimmed, 1–39 chars, no spaces or LIKE wildcards. */
+export const usernameSchema = z
+  .string({ message: "Username must be a string" })
+  .trim()
+  .min(1, "Username is required")
+  .max(39, "Username must be 39 characters or fewer")
+  .regex(
+    /^[a-zA-Z0-9_-]+$/,
+    "Username may only contain letters, numbers, hyphens and underscores"
+  );
+
+/** Positive integer page number (starts at 1). */
+export const pageParamSchema = z.coerce
+  .number({ message: "Invalid page parameter: must be a number" })
+  .int("page must be an integer")
+  .min(1, "page must be at least 1");
+
+/** Result count per request/page. */
+export const limitParamSchema = z.coerce
+  .number({ message: "Invalid limit parameter: must be a number" })
+  .int("limit must be an integer")
+  .min(1, "limit must be at least 1")
+  .max(100, "limit must be 100 or fewer");
+
+/** Zero-based skip offset. */
+export const offsetParamSchema = z.coerce
+  .number({ message: "Invalid offset parameter: must be a number" })
+  .int("offset must be an integer")
+  .min(0, "offset must be 0 or greater");
+
+/** Sort direction for list endpoints. */
+export const sortDirectionSchema = z.enum(["asc", "desc"], {
+  message: "sort must be 'asc' or 'desc'",
+});
+
+/** Standard pagination query object with sensible defaults. */
+export const paginationSchema = z.object({
+  page: pageParamSchema.optional().default(1),
+  limit: limitParamSchema.optional().default(20),
+  offset: offsetParamSchema.optional().default(0),
+  sort: sortDirectionSchema.optional().default("desc"),
+});
+
+/**
+ * Boolean-ish query flag ("0" | "1" | "true" | "false") coerced to a real
+ * boolean. Missing values default to `false`.
+ */
+export const booleanFlagSchema = z
+  .enum(["0", "1", "true", "false"], {
+    message: "flag must be '0', '1', 'true' or 'false'",
+  })
+  .optional()
+  .default("0")
+  .transform((value) => value === "1" || value === "true");
+
+/** UUID route/query param (e.g. `id`, cursors). */
+export const uuidSchema = z.string().uuid("Invalid id: must be a valid UUID");
+
+/** Lowercase alphanumeric slug with hyphens/underscores (e.g. room slugs). */
+export const slugSchema = z
+  .string({ message: "Slug must be a string" })
+  .trim()
+  .min(1, "Slug is required")
+  .max(64, "Slug must be 64 characters or fewer")
+  .regex(
+    /^[a-z0-9_-]+$/,
+    "Slug may only contain lowercase letters, numbers, hyphens and underscores"
+  );
+
+/** EVM address: `0x` followed by 40 hex chars. */
+export const evmAddressSchema = z
+  .string({ message: "Address must be a string" })
+  .regex(
+    /^0x[a-fA-F0-9]{40}$/,
+    "Address must be a 0x-prefixed, 40-hex-character address"
+  );
+
+/** Non-zero whole number expressed as a decimal digit string (e.g. wei amounts). */
+export const positiveAmountStringSchema = z
+  .string({ message: "Amount must be a string" })
+  .regex(/^\d+$/, "Amount must be a string of digits")
+  .refine((value) => value !== "0", "Amount must be greater than zero");


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->
**1. Shared validation library under `src/lib/validation/`**
- `index.ts` — `validateParams`, `validateBody`, `validateQuery` helpers plus a
  consistent error formatter (`validationErrorResponse`) that always returns
  HTTP 400 with a structured, field-level payload:
  ```json
  { "error": "Invalid request parameters", "details": [{ "path": "limit", "message": "..." }] }
  ```
  Validation failures never return 500 and never leak internal stack traces.
- `schemas.ts` — reusable schemas for common patterns:
  - `usernameSchema` — trimmed, 1–39 chars, `[a-zA-Z0-9_-]` (blocks spaces and
    SQL `LIKE` wildcards such as `%`)
  - `pageParamSchema` / `limitParamSchema` / `offsetParamSchema` /
    `sortDirectionSchema` / `paginationSchema`
  - `booleanFlagSchema` ("0" | "1" | "true" | "false" → boolean)
  - `uuidSchema`, `slugSchema`, `evmAddressSchema`, `positiveAmountStringSchema`
 
**2. Validation applied before DB/service calls**
- `GET /api/dev/[username]` — path param + `refresh` query validated (the
  primary endpoint from the issue)
- Newly validated public routes: `/api/arena/stats/[username]`,
  `/api/arena/leaderboard` (limit/offset), `/api/arena/challenge/[id]` (UUID),
  `/api/dailies` (mobile flag), `/api/gitc/swap/price` & `/api/gitc/swap/quote`
  (sellToken / sellAmount / taker / slippageBps), `/api/leaderboard-position`
  (tab enum + login)
- Existing routes standardized on the shared schemas: `/api/github/[username]`,
  `/api/arcade/rooms/[slug]`
 
**3. Tests** (`src/lib/__tests__/validation-schemas.test.ts` + existing)
- Valid requests, invalid path params, invalid query types/ranges, and the
  exact expected error response shape (400 + field details + no stack leak)
 

## Related issue

<!-- Link to issue: Fixes #ISSUE_NUMBER -->
fixes: #1095 
## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
