### PR TITLE
fix(api): return 400 for invalid tab in leaderboard-position route

### DIFF
--- a/src/app/api/leaderboard-position/route.test.ts
+++ b/src/app/api/leaderboard-position/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(() => ({ from: mockFrom, rpc: vi.fn() })),
+}));
+
+import { GET } from "./route";
+
+type Developer = {
+  id: string;
+  github_login: string;
+  name: string;
+  avatar_url: string;
+  contributions: number;
+  contributions_total: number;
+  total_stars: number;
+  public_repos: number;
+  lc_global_rank: number | null;
+  referral_count: number;
+  kudos_count: number;
+  lc_streak: number;
+  contest_rating: number;
+  xp_total: number;
+  easy_solved: number;
+};
+
+const DEV: Developer = {
+  id: "dev-1",
+  github_login: "octocat",
+  name: "Octo Cat",
+  avatar_url: "https://example.com/octo.png",
+  contributions: 5,
+  contributions_total: 5,
+  total_stars: 0,
+  public_repos: 0,
+  lc_global_rank: null,
+  referral_count: 0,
+  kudos_count: 0,
+  lc_streak: 0,
+  contest_rating: 0,
+  xp_total: 0,
+  easy_solved: 5,
+};
+
+function mockSupabase({ dev, count = null }: { dev: Developer | null; count?: number | null }) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table !== "developers") {
+      throw new Error(`Unexpected table: ${table}`);
+    }
+    const query = {
+      count: null as number | null,
+      data: null as unknown,
+      select: vi.fn(),
+      eq: vi.fn(),
+      not: vi.fn(),
+      gt: vi.fn(),
+      single: vi.fn(),
+    };
+    // `select("id", { count: "exact", head: true })` is the count query.
+    query.select = vi.fn((_columns?: string, options?: object) => {
+      if (options) query.count = count;
+      return query;
+    });
+    query.eq = vi.fn().mockReturnValue(query);
+    query.not = vi.fn().mockReturnValue(query);
+    query.gt = vi.fn().mockReturnValue(query);
+    query.single = vi.fn().mockResolvedValue({ data: dev });
+    return query;
+  });
+}
+
+describe("GET /api/leaderboard-position", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects an invalid tab with a 400 and descriptive message before querying Supabase", async () => {
+    mockSupabase({ dev: DEV });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=cheater&login=octocat")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid tab. Must be one of: solved, lc_rank, streak, contest, xp, achievers.",
+    });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when login is missing", async () => {
+    mockSupabase({ dev: DEV });
+
+    const response = await GET(new Request("http://localhost/api/leaderboard-position?tab=solved"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Missing login" });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns the position for a valid tab", async () => {
+    mockSupabase({ dev: DEV, count: 9 });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=solved&login=octocat")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      github_login: "octocat",
+      position: 10,
+      metricValue: "5 solved",
+    });
+  });
+
+  it("returns 404 when the developer does not exist", async () => {
+    mockSupabase({ dev: null });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=solved&login=ghost")
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+  });
+});

--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -6,6 +6,8 @@ type Tab = (typeof VALID_TABS)[number];
 
 /**
  * @param {import('next/server').NextRequest} request
+ * @throws {Response} Returns a 400 Bad Request when `tab` is not one of the valid
+ *   values (solved, lc_rank, streak, contest, xp, achievers) or when `login` is missing.
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -14,7 +16,7 @@ export async function GET(request: Request) {
 
   if (!VALID_TABS.includes(tab as Tab)) {
     return NextResponse.json(
-      { error: `Invalid tab value: "${tab}". Must be one of: ${VALID_TABS.join(", ")}` },
+      { error: `Invalid tab. Must be one of: ${VALID_TABS.join(", ")}.` },
       { status: 400 }
     );
   }


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of changes -->
**`src/app/api/leaderboard-position/route.ts`**
- Invalid `tab` values now return a **400 Bad Request** with a descriptive,
  field-level message:
  ```json
  { "error": "Invalid tab. Must be one of: solved, lc_rank, streak, contest, xp, achievers." }
  ```
  (message is derived from the `VALID_TABS` const so it can't drift)
- The message is now the exact spec from the issue. The old message echoed the
  offending value; the new one matches the agreed contract.
- Added `@throws` to the GET handler's JSDoc documenting the 400 responses.
 
> Note on the requested `else` branch: the route already rejects invalid tabs
> with an early-return guard (from #1264), which is functionally equivalent to
> (and stronger than) an `else` fallback — an invalid tab can never fall through
> to the position logic. This PR keeps that guard and standardizes the response.
 
**New: `src/app/api/leaderboard-position/route.test.ts`**
- Rejects invalid tab → 400 with exact error message, and verifies Supabase is
  never queried for a bad tab
- Returns 400 when `login` is missing
- Returns the computed position for a valid tab (happy path)
- Returns 404 for a developer that doesn't exist

## Related issue

<!-- Link to issue: Fixes #ISSUE_NUMBER -->
fixes: #1329
## Screenshots

<!-- Before/after if visual changes -->

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
