### PR TITLE
fix: add try-catch error handling around sendNotificationAsync in streak-broken.ts

### DIFF
--- a/src/lib/notification-senders/streak-broken.ts
+++ b/src/lib/notification-senders/streak-broken.ts
@@ -9,26 +9,30 @@ export function sendStreakBrokenNotification(
   previousStreak: number,
   date: string, // YYYY-MM-DD
 ) {
-  sendNotificationAsync({
-    type: "streak_broken",
-    category: "streak_reminders",
-    developerId: devId,
-    dedupKey: `streak_broken:${devId}:${date}`,
-    title: `Your ${previousStreak}-day streak ended. Start fresh!`,
-    body: `Your ${previousStreak}-day streak has ended. Check in today to start a new one!`,
-    html: `
-      <div style="text-align: center;">
-        <p style="color: #f0f0f0; font-size: 16px;">
-          Your <strong style="color: #ff6b6b;">${previousStreak}-day</strong> streak ended.
-        </p>
-        <p style="color: #f0f0f0;">
-          Every streak starts with day 1. Check in now to begin again!
-        </p>
-      </div>
-      ${buildButton("Start Fresh", BASE_URL)}
-    `,
-    actionUrl: BASE_URL,
-    priority: "high",
-    channels: ["email"],
-  });
+  try {
+    sendNotificationAsync({
+      type: "streak_broken",
+      category: "streak_reminders",
+      developerId: devId,
+      dedupKey: `streak_broken:${devId}:${date}`,
+      title: `Your ${previousStreak}-day streak ended. Start fresh!`,
+      body: `Your ${previousStreak}-day streak has ended. Check in today to start a new one!`,
+      html: `
+        <div style="text-align: center;">
+          <p style="color: #f0f0f0; font-size: 16px;">
+            Your <strong style="color: #ff6b6b;">${previousStreak}-day</strong> streak ended.
+          </p>
+          <p style="color: #f0f0f0;">
+            Every streak starts with day 1. Check in now to begin again!
+          </p>
+        </div>
+        ${buildButton("Start Fresh", BASE_URL)}
+      `,
+      actionUrl: BASE_URL,
+      priority: "high",
+      channels: ["email"],
+    });
+  } catch (err: unknown) {
+    console.error(`[streak-broken] notification failed for devId ${devId}:`, err);
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Wraps the `sendNotificationAsync` call in `src/lib/notification-senders/streak-broken.ts` inside a `try-catch` block and logs a `console.error` with the developer ID and error details on failure, matching the resilient notification handling pattern used in `streak.ts`.

## Related issue

Fixes #1151

## Screenshots

N/A (Backend / Logic changes only)

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
