### PR TITLE
fix: remove Cashfree secret key prefix from logs (#1665)

### DIFF
--- a/src/lib/cashfree.ts
+++ b/src/lib/cashfree.ts
@@ -52,12 +52,12 @@ export async function createCashfreeOrder(opts: {
     amountINR: opts.amountINR,
     customerPhone: opts.customerPhone,
   });
+  // SECURITY: never log CASHFREE_SECRET_KEY (or any substring of it).
+  // Payment secrets must not reach logs, log drains, or aggregation pipelines.
   console.log("[createCashfreeOrder] Config:", {
     env: (process.env.NEXT_PUBLIC_CASHFREE_ENV ?? "").replace(/['"]/g, "").trim(),
     apiUrl: getApiUrl(),
     appId: getAppId(),
-    // Log first/last 4 chars of secret key for security validation
-    secretPrefix: getSecretKey().substring(0, 12),
   });
 
   const env = (process.env.NEXT_PUBLIC_CASHFREE_ENV ?? "SANDBOX").replace(/['"]/g, "").trim();


### PR DESCRIPTION
Closes #1665

## What changed
Removed the `secretPrefix` field (first 12 chars of `CASHFREE_SECRET_KEY`) from the `[createCashfreeOrder] Config:` log in `src/lib/cashfree.ts`.

## Why
Logging even a substring of the payment secret leaks credential material into log drains, Vercel/runtime logs, and log aggregation pipelines. Audited `nowpayments.ts`, `abacatepay.ts`, and `stripe.ts` — no other payment provider logs secret material.

## Verification
- `grep -rn "secretPrefix" src/` → only reference removed
- Log now contains non-secret metadata only (env, apiUrl, appId)