### PR TITLE
fix: bind GITC quote confirmation to owning developer (#1664)

### DIFF
--- a/src/app/api/pixels/checkout/gitc-confirm/route.ts
+++ b/src/app/api/pixels/checkout/gitc-confirm/route.ts
@@ -59,6 +59,23 @@ export async function POST(request: NextRequest) {
 
   const sb = getSupabaseAdmin();
 
+  // Bind the caller to their developer row. A quote may only be confirmed by
+  // the developer who owns it (IDOR prevention).
+  const githubLogin = (
+    user.user_metadata?.user_name ??
+    user.user_metadata?.preferred_username ??
+    ""
+  ).toLowerCase();
+  const { data: callerDev } = await sb
+    .from("developers")
+    .select("id, claimed, claimed_by")
+    .eq("github_login", githubLogin)
+    .single<{ id: number; claimed: boolean; claimed_by: string | null }>();
+
+  if (!callerDev || !callerDev.claimed || callerDev.claimed_by !== user.id) {
+    return NextResponse.json({ error: "You must claim your building first" }, { status: 403 });
+  }
+
   const { data: payment, error: payErr } = await sb
     .from("pixel_gitc_payments")
     .select("id, pixel_purchase_id, developer_id, package_id, wallet_address, gitc_amount_wei, quote_block_number, status, expires_at, tx_hash")
@@ -67,6 +84,10 @@ export async function POST(request: NextRequest) {
 
   if (payErr || !payment) {
     return NextResponse.json({ error: "Quote not found" }, { status: 404 });
+  }
+
+  if (payment.developer_id !== callerDev.id) {
+    return NextResponse.json({ error: "This quote does not belong to you" }, { status: 403 });
   }
 
   if (payment.status === "confirmed" && payment.tx_hash === txHash.toLowerCase()) {

--- a/src/lib/cashfree.ts
+++ b/src/lib/cashfree.ts
@@ -52,12 +52,12 @@ export async function createCashfreeOrder(opts: {
     amountINR: opts.amountINR,
     customerPhone: opts.customerPhone,
   });
+  // SECURITY: never log CASHFREE_SECRET_KEY (or any substring of it).
+  // Payment secrets must not reach logs, log drains, or aggregation pipelines.
   console.log("[createCashfreeOrder] Config:", {
     env: (process.env.NEXT_PUBLIC_CASHFREE_ENV ?? "").replace(/['"]/g, "").trim(),
     apiUrl: getApiUrl(),
     appId: getAppId(),
-    // Log first/last 4 chars of secret key for security validation
-    secretPrefix: getSecretKey().substring(0, 12),
   });
 
   const env = (process.env.NEXT_PUBLIC_CASHFREE_ENV ?? "SANDBOX").replace(/['"]/g, "").trim();


### PR DESCRIPTION
Closes #1664

## What changed
`POST /api/pixels/checkout/gitc-confirm` now resolves the caller's developer row (via `github_login` + `claimed_by` binding, same pattern as `gitc-quote`) and requires `payment.developer_id === callerDev.id`.

## Why
Fix IDOR: any authenticated user who obtained another user's quoteId could drive that quote's confirmation state machine (verify, race, disrupt).

## Verification
- Cross-user quote -> 403 `This quote does not belong to you`
- Owner -> proceeds as before
- `npx eslint` on changed file: clean
- `npm run build`: passes