### PR TITLE
fix: don't public-cache city error responses (#1659)

### DIFF
--- a/src/app/api/city/route.ts
+++ b/src/app/api/city/route.ts
@@ -30,11 +30,19 @@ export async function GET(request: Request) {
   const service = new CityService();
   const result = await service.loadCityData({ from, to });
 
+  // Only healthy payloads are cacheable. Error responses must keep their
+  // original Cache-Control (e.g. no-store) so CDNs/browsers never cache
+  // failed or empty bodies as if they were valid city data (#1659).
+  const cacheControl =
+    result.status >= 200 && result.status < 300
+      ? "public, max-age=60, stale-while-revalidate=300"
+      : result.headers["Cache-Control"] ?? "no-store";
+
   return NextResponse.json(result.body, {
     status: result.status,
     headers: {
       ...result.headers,
-      "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+      "Cache-Control": cacheControl,
     },
   });
 }


### PR DESCRIPTION
Closes #1659

## What changed
`GET /api/city` now applies the public cache policy only for 2xx responses. Error responses keep the `Cache-Control` returned by `CityService` (`no-store`), so failed/empty bodies are never cached by CDNs/browsers.

## Verification
- Existing route tests pass (2/2): success -> public cache, error -> no-store