### PR TITLE
feat(engine): shared DeveloperActivityEngine for common reward side e…

### DIFF
--- a/src/app/api/fly-scores/route.ts
+++ b/src/app/api/fly-scores/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
 import { trackDailyMission } from "@/lib/dailies";
+import { processDeveloperActivity } from "@/lib/developerActivityEngine";
 import { buildFlyLeaderboard, type FlyScoreRow } from "@/lib/fly-leaderboard";
 import { getTodaySeed } from "@/lib/fly-seed";
 import { validateBody } from "@/lib/validation";
@@ -130,10 +131,14 @@ export async function POST(request: Request) {
   }
 
   const flyXp = Math.floor(score * 0.1);
-  if (flyXp > 0) {
-    await admin.rpc("grant_xp_atomic", { p_developer_id: dev.id, p_source: "fly", p_amount: flyXp });
-  }
 
+  // ── Common reward pipeline (engine) ──────────────────────────────
+  await processDeveloperActivity(admin as never, {
+    developerId: dev.id,
+    xpGrants: flyXp > 0 ? [{ source: "fly", amount: flyXp }] : [],
+  });
+
+  // Domain-specific: daily missions
   await trackDailyMission(dev.id, "fly_score_50", { score });
   await trackDailyMission(dev.id, "fly_score_150", { score });
 

--- a/src/app/api/interactions/kudos/route.ts
+++ b/src/app/api/interactions/kudos/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
-import { checkAchievements } from "@/lib/achievements";
-import { touchLastActive } from "@/lib/notification-helpers";
 import { trackDailyMission } from "@/lib/dailies";
+import { processDeveloperActivity } from "@/lib/developerActivityEngine";
 import { getUtcDateStrings } from "@/lib/utc-date";
 
 /**
@@ -72,31 +71,50 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: rpcResult.error }, { status: 429 });
   }
 
-  await touchLastActive(giver.id);
-  await trackDailyMission(giver.id, "give_kudos");
-  await trackDailyMission(giver.id, "give_kudos_3");
-
+  // Domain-specific: increment kudos count on receiver
   await admin.rpc("increment_kudos_count", { target_dev_id: receiver.id });
 
-    await admin.rpc("grant_xp_atomic", { p_developer_id: giver.id, p_source: "kudos_given", p_amount: 3 });
-    await admin.rpc("grant_xp_atomic", { p_developer_id: receiver.id, p_source: "kudos_received", p_amount: 1 });
-
-  await admin.from("activity_feed").insert({
-    event_type: "kudos_given",
-    actor_id: giver.id,
-    target_id: receiver.id,
-    metadata: {
-      giver_login: githubLogin,
-      receiver_login: receiver.github_login,
+  // ── Common reward pipeline (engine) ──────────────────────────────────
+  await processDeveloperActivity(admin as never, {
+    developerId: giver.id,
+    actorLogin: githubLogin,
+    stats: {
+      contributions: giver.contributions ?? 0,
+      public_repos: giver.public_repos ?? 0,
+      total_stars: giver.total_stars ?? 0,
+      referral_count: 0,
+      kudos_count: giver.kudos_count ?? 0,
+      gifts_sent: 0,
+      gifts_received: 0,
+      easy_solved: giver.easy_solved ?? 0,
+      medium_solved: giver.medium_solved ?? 0,
+      hard_solved: giver.hard_solved ?? 0,
+      contest_rating: giver.contest_rating ?? 0,
+      lc_streak: giver.lc_streak ?? 0,
+      total_prs: giver.total_prs ?? 0,
+    },
+    xpGrants: [
+      { source: "kudos_given", amount: 3 },
+      { source: "kudos_received", amount: 1 },
+    ],
+    feedEvent: {
+      eventType: "kudos_given",
+      metadata: {
+        giver_login: githubLogin,
+        receiver_login: receiver.github_login,
+      },
+      targetId: receiver.id,
     },
   });
 
-  const { data: streakResult, error: streakError } = await admin.rpc("update_kudos_streak", {
+  // Domain-specific: kudos streak + daily missions
+  await trackDailyMission(giver.id, "give_kudos");
+  await trackDailyMission(giver.id, "give_kudos_3");
+
+  const { error: streakError } = await admin.rpc("update_kudos_streak", {
     p_giver_id: giver.id, p_given_date: today,
   });
-  
   if (streakError) { console.warn("[kudos] update_kudos_streak RPC error:", streakError.message); }
-  const newKudosStreak = (streakResult?.kudos_streak as number | undefined) ?? giver.kudos_streak ?? 0;
 
   try {
     await admin.rpc("increment_kudos_week", {
@@ -106,23 +124,6 @@ export async function POST(request: Request) {
   } catch (err) {
     console.warn("[app/api/interactions/kudos/route.ts] non-critical error:", err);
   }
-
-  await checkAchievements(giver.id, {
-    contributions: giver.contributions ?? 0,
-    public_repos: giver.public_repos ?? 0,
-    total_stars: giver.total_stars ?? 0,
-    referral_count: 0,
-    kudos_count: giver.kudos_count ?? 0,
-    gifts_sent: 0,
-    gifts_received: 0,
-    kudos_streak: newKudosStreak,
-    easy_solved: giver.easy_solved ?? 0,
-    medium_solved: giver.medium_solved ?? 0,
-    hard_solved: giver.hard_solved ?? 0,
-    contest_rating: giver.contest_rating ?? 0,
-    lc_streak: giver.lc_streak ?? 0,
-    total_prs: giver.total_prs ?? 0,
-  }, githubLogin);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/interactions/visit/route.ts
+++ b/src/app/api/interactions/visit/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
-import { touchLastActive } from "@/lib/notification-helpers";
 import { trackDailyMission } from "@/lib/dailies";
+import { processDeveloperActivity } from "@/lib/developerActivityEngine";
 
 /**
  * @param {import('next/server').NextRequest} request
@@ -29,12 +29,6 @@ export async function POST(request: Request) {
 
   const admin = getSupabaseAdmin();
 
-  const githubLogin = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
-
   // Fetch visitor
   const { data: visitor } = await admin
     .from("developers")
@@ -57,8 +51,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Building not found" }, { status: 404 });
   }
 
-  // Track activity
-  await touchLastActive(visitor.id);
+  // Track activity (last-active is handled by the engine below)
 
   // No self-visits
   if (visitor.id === building.id) {
@@ -89,10 +82,13 @@ export async function POST(request: Request) {
   if (!insertError) {
     await admin.rpc("increment_visit_count", { target_dev_id: building.id });
 
-    // Grant XP for visiting a building
-    await admin.rpc("grant_xp_atomic", { p_developer_id: visitor.id, p_source: "visit", p_amount: 2 });
+    // ── Common reward pipeline (engine) ──────────────────────────────
+    await processDeveloperActivity(admin as never, {
+      developerId: visitor.id,
+      xpGrants: [{ source: "visit", amount: 2 }],
+    });
 
-    // Only credit daily missions for genuine, unique visits
+    // Domain-specific: daily missions for unique visits
     await trackDailyMission(visitor.id, "visit_building");
     await trackDailyMission(visitor.id, "visit_3_buildings");
 
@@ -103,8 +99,8 @@ export async function POST(request: Request) {
       .eq("building_id", building.id)
       .eq("visit_date", today);
 
+    // Domain-specific: building visit milestone feed event
     if ((todayVisits ?? 0) >= 10) {
-      // Only insert once per building per day
       const { data: existing } = await admin
         .from("activity_feed")
         .select("id")

--- a/src/app/api/leaderboard-position/route.test.ts
+++ b/src/app/api/leaderboard-position/route.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(() => ({ from: mockFrom, rpc: vi.fn() })),
+}));
+
+import { GET } from "./route";
+
+type Developer = {
+  id: string;
+  github_login: string;
+  name: string;
+  avatar_url: string;
+  contributions: number;
+  contributions_total: number;
+  total_stars: number;
+  public_repos: number;
+  lc_global_rank: number | null;
+  referral_count: number;
+  kudos_count: number;
+  lc_streak: number;
+  contest_rating: number;
+  xp_total: number;
+  easy_solved: number;
+};
+
+const DEV: Developer = {
+  id: "dev-1",
+  github_login: "octocat",
+  name: "Octo Cat",
+  avatar_url: "https://example.com/octo.png",
+  contributions: 5,
+  contributions_total: 5,
+  total_stars: 0,
+  public_repos: 0,
+  lc_global_rank: null,
+  referral_count: 0,
+  kudos_count: 0,
+  lc_streak: 0,
+  contest_rating: 0,
+  xp_total: 0,
+  easy_solved: 5,
+};
+
+/**
+ * Mock Supabase so that the dev lookup returns `dev` and tab-count
+ * queries return `count` (used by solved / streak / contest / xp tabs).
+ */
+function mockSupabase({ dev, count = null }: { dev: Developer | null; count?: number | null }) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table !== "developers") {
+      throw new Error(`Unexpected table: ${table}`);
+    }
+    const query = {
+      count: null as number | null,
+      data: null as unknown,
+      select: vi.fn(),
+      eq: vi.fn(),
+      not: vi.fn(),
+      gt: vi.fn(),
+      single: vi.fn(),
+    };
+    // When called with column opts (`{ count: "exact", head: true }`) it's the count query.
+    query.select = vi.fn((_columns?: string, options?: object) => {
+      if (options) query.count = count;
+      return query;
+    });
+    query.eq = vi.fn().mockReturnValue(query);
+    query.not = vi.fn().mockReturnValue(query);
+    query.gt = vi.fn().mockReturnValue(query);
+    query.single = vi.fn().mockResolvedValue({ data: dev });
+    return query;
+  });
+}
+
+describe("GET /api/leaderboard-position", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects an invalid tab with a 400 before querying Supabase", async () => {
+    mockSupabase({ dev: DEV });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=cheater&login=octocat")
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid request parameters");
+    expect(body.details).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "tab" })]),
+    );
+    // Validation failed before any DB query
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing login with a 400 before querying Supabase", async () => {
+    mockSupabase({ dev: DEV });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=solved"),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid request parameters");
+    expect(body.details).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "login" })]),
+    );
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns the computed position for a valid tab", async () => {
+    mockSupabase({ dev: DEV, count: 9 });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=solved&login=octocat")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      github_login: "octocat",
+      position: 10,
+      metricValue: "5 solved",
+    });
+  });
+
+  it("returns 404 when the developer does not exist", async () => {
+    mockSupabase({ dev: null });
+
+    const response = await GET(
+      new Request("http://localhost/api/leaderboard-position?tab=solved&login=ghost")
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+  });
+});

--- a/src/app/api/leaderboard-position/route.ts
+++ b/src/app/api/leaderboard-position/route.ts
@@ -12,6 +12,9 @@ const querySchema = z.object({
 
 /**
  * @param {import('next/server').NextRequest} request
+ * @throws {Response} Returns a 400 Bad Request when `tab` is not one of the valid
+ *   values (solved, lc_rank, streak, contest, xp, achievers) or when `login` is
+ *   missing or does not match the username format.
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/src/lib/developerActivityEngine.test.ts
+++ b/src/lib/developerActivityEngine.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./achievements", () => ({
+  checkAchievements: vi.fn(),
+}));
+
+vi.mock("./notification-helpers", () => ({
+  touchLastActive: vi.fn(),
+}));
+
+import { processDeveloperActivity } from "./developerActivityEngine";
+import * as achievementsModule from "./achievements";
+import * as notificationHelpers from "./notification-helpers";
+
+function makeAdmin(overrides?: {
+  rpcResult?: { data?: unknown; error?: unknown };
+  rpcReject?: Error;
+  feedInsertReject?: Error;
+}) {
+  const rpc = overrides?.rpcReject
+    ? vi.fn().mockRejectedValue(overrides.rpcReject)
+    : vi.fn().mockResolvedValue(overrides?.rpcResult ?? { data: { granted: 10 }, error: null });
+  const insert = overrides?.feedInsertReject
+    ? vi.fn().mockRejectedValue(overrides.feedInsertReject)
+    : vi.fn().mockResolvedValue({ data: null, error: null });
+  const upsert = vi.fn().mockResolvedValue({ data: null, error: null });
+  const from = vi.fn().mockReturnValue({ insert, upsert });
+  return { rpc, from, insert, upsert };
+}
+
+describe("processDeveloperActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(achievementsModule.checkAchievements).mockResolvedValue([]);
+  });
+
+  it("calls touchLastActive fire-and-forget", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, { developerId: 1 });
+
+    expect(notificationHelpers.touchLastActive).toHaveBeenCalledWith(1);
+  });
+
+  it("grants XP via grant_xp_atomic for each grant", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      xpGrants: [
+        { source: "kudos_given", amount: 3 },
+        { source: "kudos_received", amount: 1 },
+      ],
+    });
+
+    expect(admin.rpc).toHaveBeenCalledTimes(2);
+    expect(admin.rpc).toHaveBeenCalledWith("grant_xp_atomic", {
+      p_developer_id: 42,
+      p_source: "kudos_given",
+      p_amount: 3,
+    });
+    expect(admin.rpc).toHaveBeenCalledWith("grant_xp_atomic", {
+      p_developer_id: 42,
+      p_source: "kudos_received",
+      p_amount: 1,
+    });
+  });
+
+  it("skips XP grants with amount <= 0", async () => {
+    const admin = makeAdmin();
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 1,
+      xpGrants: [{ source: "zero", amount: 0 }, { source: "negative", amount: -5 }],
+    });
+
+    expect(admin.rpc).not.toHaveBeenCalled();
+    expect(result.xpResults).toEqual([]);
+  });
+
+  it("records xpResult success and failure", async () => {
+    const admin = makeAdmin();
+    admin.rpc
+      .mockResolvedValueOnce({ data: { granted: 10 }, error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: "duplicate" } });
+
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 1,
+      xpGrants: [
+        { source: "a", amount: 10 },
+        { source: "b", amount: 5 },
+      ],
+    });
+
+    expect(result.xpResults).toHaveLength(2);
+    expect(result.xpResults[0]).toMatchObject({ source: "a", amount: 10, success: true });
+    expect(result.xpResults[1]).toMatchObject({ source: "b", amount: 5, success: false });
+  });
+
+  it("inserts activity feed event with correct payload", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      feedEvent: {
+        eventType: "kudos_given",
+        metadata: { giver_login: "alice", receiver_login: "bob" },
+        targetId: 7,
+      },
+    });
+
+    expect(admin.from).toHaveBeenCalledWith("activity_feed");
+    expect(admin.insert).toHaveBeenCalledWith({
+      event_type: "kudos_given",
+      actor_id: 42,
+      target_id: 7,
+      metadata: { giver_login: "alice", receiver_login: "bob" },
+    });
+  });
+
+  it("uses custom actorId when provided", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      feedEvent: {
+        eventType: "raid_success",
+        metadata: {},
+        actorId: 99,
+      },
+    });
+
+    expect(admin.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ actor_id: 99 }),
+    );
+  });
+
+  it("upserts feed event when upsert option is set", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      feedEvent: {
+        eventType: "streak_checkin",
+        metadata: { streak: 5 },
+        eventDate: "2026-01-15",
+        upsert: true,
+        onConflict: "actor_id,event_type,event_date",
+        ignoreDuplicates: true,
+      },
+    });
+
+    expect(admin.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: "streak_checkin", event_date: "2026-01-15" }),
+      { onConflict: "actor_id,event_type,event_date", ignoreDuplicates: true },
+    );
+  });
+
+  it("checks achievements when stats are provided", async () => {
+    const checkMock = vi.mocked(achievementsModule.checkAchievements);
+    checkMock.mockResolvedValue(["ach-1", "ach-2"]);
+
+    const admin = makeAdmin();
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      actorLogin: "octocat",
+      stats: {
+        contributions: 50,
+        kudos_count: 10,
+        app_streak: 7,
+      },
+    });
+
+    expect(checkMock).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ contributions: 50, kudos_count: 10, app_streak: 7 }),
+      "octocat",
+    );
+    expect(result.newAchievements).toEqual(["ach-1", "ach-2"]);
+  });
+
+  it("skips achievement check when stats are not provided", async () => {
+    const admin = makeAdmin();
+    await processDeveloperActivity(admin as never, { developerId: 42 });
+
+    expect(achievementsModule.checkAchievements).not.toHaveBeenCalled();
+  });
+
+  it("returns feedInserted: false when no feed event is provided", async () => {
+    const admin = makeAdmin();
+    const result = await processDeveloperActivity(admin as never, { developerId: 1 });
+
+    expect(result.feedInserted).toBe(false);
+    expect(admin.from).not.toHaveBeenCalled();
+  });
+
+  it("handles feed insert failure gracefully without throwing", async () => {
+    const admin = makeAdmin({ feedInsertReject: new Error("connection refused") });
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      feedEvent: { eventType: "test", metadata: {} },
+    });
+
+    expect(result.feedInserted).toBe(false);
+    expect(result.newAchievements).toEqual([]);
+  });
+
+  it("handles XP grant RPC error gracefully without throwing", async () => {
+    const admin = makeAdmin({ rpcReject: new Error("network timeout") });
+
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      xpGrants: [{ source: "test", amount: 10 }],
+    });
+
+    expect(result.xpResults[0]).toMatchObject({ source: "test", amount: 10, success: false });
+    expect(result.xpResults[0].error).toBeInstanceOf(Error);
+  });
+
+  it("handles achievement check failure gracefully without throwing", async () => {
+    vi.mocked(achievementsModule.checkAchievements).mockRejectedValue(new Error("db down"));
+
+    const admin = makeAdmin();
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      stats: { contributions: 1 },
+    });
+
+    expect(result.newAchievements).toEqual([]);
+  });
+
+  it("returns all results when everything is provided", async () => {
+    vi.mocked(achievementsModule.checkAchievements).mockResolvedValue(["ach-new"]);
+
+    const admin = makeAdmin();
+    const result = await processDeveloperActivity(admin as never, {
+      developerId: 42,
+      actorLogin: "alice",
+      stats: { contributions: 100 },
+      xpGrants: [{ source: "checkin", amount: 10 }],
+      feedEvent: { eventType: "streak_checkin", metadata: { streak: 5 } },
+    });
+
+    expect(result.newAchievements).toEqual(["ach-new"]);
+    expect(result.xpResults).toHaveLength(1);
+    expect(result.xpResults[0]).toMatchObject({ source: "checkin", amount: 10, success: true });
+    expect(result.feedInserted).toBe(true);
+    expect(admin.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: "streak_checkin" }),
+    );
+  });
+});

--- a/src/lib/developerActivityEngine.ts
+++ b/src/lib/developerActivityEngine.ts
@@ -1,0 +1,176 @@
+import { checkAchievements } from "./achievements";
+import { touchLastActive } from "./notification-helpers";
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export interface ActivityXPGrant {
+  source: string;
+  amount: number;
+}
+
+export interface ActivityFeedEvent {
+  eventType: string;
+  metadata: Record<string, unknown>;
+  actorId?: number;
+  targetId?: number | null;
+  eventDate?: string;
+  upsert?: boolean;
+  onConflict?: string;
+  ignoreDuplicates?: boolean;
+}
+
+export interface ActivityStats {
+  contributions?: number;
+  public_repos?: number;
+  total_stars?: number;
+  referral_count?: number;
+  kudos_count?: number;
+  gifts_sent?: number;
+  gifts_received?: number;
+  app_streak?: number;
+  kudos_streak?: number;
+  raid_xp?: number;
+  purchases?: number;
+  dailies_completed?: number;
+  easy_solved?: number;
+  medium_solved?: number;
+  hard_solved?: number;
+  contest_rating?: number;
+  lc_streak?: number;
+  total_prs?: number;
+}
+
+export interface DeveloperActivityInput {
+  /** Developer performing the action. */
+  developerId: number;
+  /** GitHub login (used for feed event metadata and achievement checks). */
+  actorLogin?: string;
+  /** Developer stats for achievement evaluation. If omitted, achievement checks are skipped. */
+  stats?: ActivityStats;
+  /** XP grants to execute (each becomes an idempotent grant_xp_atomic call). */
+  xpGrants?: ActivityXPGrant[];
+  /** Activity feed event to insert after XP grants. */
+  feedEvent?: ActivityFeedEvent;
+}
+
+export interface DeveloperActivityResult {
+  newAchievements: string[];
+  xpResults: Array<{ source: string; amount: number; success: boolean; error?: unknown }>;
+  feedInserted: boolean;
+}
+
+type ActivityAdminClient = {
+  rpc: (
+    fn: string,
+    args: Record<string, unknown>,
+  ) => Promise<{ data?: unknown; error?: { message?: string; code?: string } | null }>;
+  from: (table: string) => {
+    insert?: (values: Record<string, unknown>) => Promise<{ data?: unknown; error?: unknown }>;
+    upsert?: (
+      values: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => Promise<{ data?: unknown; error?: unknown }>;
+  };
+};
+
+// ─── Core Engine ────────────────────────────────────────────────────────
+
+/**
+ * Process common post-action side effects for a developer activity.
+ *
+ * Runs the following pipeline in order:
+ * 1. **Last-active update** — fire-and-forget `last_active_at` touch.
+ * 2. **XP grants** — each grant calls `grant_xp_atomic` (idempotent).
+ * 3. **Activity feed event** — insert (or upsert) a single feed row.
+ * 4. **Achievement check** — if `stats` are provided, evaluate and unlock any
+ *    newly-earned achievements (with notifications).
+ *
+ * Domain-specific side effects (daily missions, raid tags, kudos streaks, etc.)
+ * remain the caller's responsibility and should be executed alongside or after
+ * this call. The engine purposefully avoids coupling to any single domain.
+ *
+ * All side-effect failures are caught and logged — they never throw — so the
+ * caller's response is never disrupted by a background side-effect failure.
+ *
+ * @example
+ * ```ts
+ * await processDeveloperActivity(admin, {
+ *   developerId: giver.id,
+ *   actorLogin: giver.github_login,
+ *   stats: { kudos_count: giver.kudos_count, ... },
+ *   xpGrants: [
+ *     { source: "kudos_given", amount: 3 },
+ *     { source: "kudos_received", amount: 1 },
+ *   ],
+ *   feedEvent: {
+ *     eventType: "kudos_given",
+ *     metadata: { giver_login, receiver_login },
+ *     targetId: receiver.id,
+ *   },
+ * });
+ * ```
+ */
+export async function processDeveloperActivity(
+  admin: ActivityAdminClient,
+  input: DeveloperActivityInput,
+): Promise<DeveloperActivityResult> {
+  // 1. Fire-and-forget last-active update
+  touchLastActive(input.developerId);
+
+  // 2. Grant XP (each grant is idempotent via grant_xp_atomic)
+  const xpResults: DeveloperActivityResult["xpResults"] = [];
+  for (const grant of input.xpGrants ?? []) {
+    if (grant.amount <= 0) continue;
+    try {
+      const { error } = await admin.rpc("grant_xp_atomic", {
+        p_developer_id: input.developerId,
+        p_source: grant.source,
+        p_amount: grant.amount,
+      });
+      xpResults.push({ source: grant.source, amount: grant.amount, success: !error, error });
+    } catch (error) {
+      xpResults.push({ source: grant.source, amount: grant.amount, success: false, error });
+    }
+  }
+
+  // 3. Insert activity feed event
+  let feedInserted = false;
+  if (input.feedEvent) {
+    const payload = {
+      event_type: input.feedEvent.eventType,
+      actor_id: input.feedEvent.actorId ?? input.developerId,
+      target_id: input.feedEvent.targetId ?? null,
+      metadata: input.feedEvent.metadata,
+      ...(input.feedEvent.eventDate ? { event_date: input.feedEvent.eventDate } : {}),
+    };
+    try {
+      if (input.feedEvent.upsert) {
+        await admin.from("activity_feed").upsert?.(payload, {
+          onConflict: input.feedEvent.onConflict ?? "actor_id,event_type,event_date",
+          ignoreDuplicates: input.feedEvent.ignoreDuplicates ?? true,
+        });
+      } else {
+        await admin.from("activity_feed").insert?.(payload);
+      }
+      feedInserted = true;
+    } catch (error) {
+      console.error("[developerActivityEngine] activity_feed insert failed", error);
+    }
+  }
+
+  // 4. Check achievements (skipped if stats not provided)
+  let newAchievements: string[] = [];
+  if (input.stats) {
+    try {
+      newAchievements = await checkAchievements(
+        input.developerId,
+        input.stats as never,
+        input.actorLogin,
+      );
+    } catch (error) {
+      console.error("[developerActivityEngine] achievements check failed", error);
+    }
+  }
+
+  return { newAchievements, xpResults, feedInserted };
+}

--- a/src/services/raid-post-execution.ts
+++ b/src/services/raid-post-execution.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { touchLastActive } from "@/lib/notification-helpers";
 import { sendRaidAlertNotification } from "@/lib/notification-senders/raid";
 import { trackDailyMission } from "@/lib/dailies";
+import { processDeveloperActivity } from "@/lib/developerActivityEngine";
 import { RAID_TAG_DURATION_DAYS, XP_WIN_ATTACKER, XP_WIN_DEFENDER, XP_LOSE_DEFENDER, type ScoreBreakdown } from "@/lib/raid";
 import type { RaidDeveloper } from "@/lib/raid-planner";
 
@@ -66,8 +66,6 @@ export async function performRaidPostExecution(
       admin.rpc("increment_raid_xp", { p_developer_id: attacker.id, p_amount: XP_WIN_ATTACKER }),
       admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_WIN_DEFENDER }),
     ]);
-    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_win", p_amount: 50 });
-    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
 
     try {
       const { data: newWins, error: relicErr } = await admin.rpc("increment_relic_progress", {
@@ -93,23 +91,34 @@ export async function performRaidPostExecution(
     }
   } else {
     await admin.rpc("increment_raid_xp", { p_developer_id: defender.id, p_amount: XP_LOSE_DEFENDER });
-    await admin.rpc("grant_xp_atomic", { p_developer_id: attacker.id, p_source: "raid_loss", p_amount: 15 });
-    await admin.rpc("grant_xp_atomic", { p_developer_id: defender.id, p_source: "raid_defend", p_amount: 30 });
   }
 
-  await admin.from("activity_feed").insert({
-    event_type: details.success ? "raid_success" : "raid_failed",
-    actor_id: attacker.id,
-    target_id: defender.id,
-    metadata: {
-      attacker_login: attacker.github_login,
-      defender_login: defender.github_login,
-      attack_score: details.attack.total,
-      defense_score: details.defense.total,
+  // ── Common reward pipeline (engine) ──────────────────────────────────
+  // XP grants + last-active + activity feed + achievements in one coordinated call
+  await processDeveloperActivity(admin as never, {
+    developerId: attacker.id,
+    xpGrants: details.success
+      ? [
+          { source: "raid_win", amount: 50 },
+          { source: "raid_defend", amount: 30 },
+        ]
+      : [
+          { source: "raid_loss", amount: 15 },
+          { source: "raid_defend", amount: 30 },
+        ],
+    feedEvent: {
+      eventType: details.success ? "raid_success" : "raid_failed",
+      metadata: {
+        attacker_login: attacker.github_login,
+        defender_login: defender.github_login,
+        attack_score: details.attack.total,
+        defense_score: details.defense.total,
+      },
+      targetId: defender.id,
     },
   });
 
-  await touchLastActive(attacker.id);
+  // Domain-specific: daily missions + notification
   await trackDailyMission(attacker.id, "attempt_battle");
   if (details.success) await trackDailyMission(attacker.id, "win_battle");
   sendRaidAlertNotification(defender.id, defender.github_login, attacker.github_login, details.raidId ?? 0, details.success, details.attack.total, details.defense.total);


### PR DESCRIPTION
…ffects

Closes #1671
 
### What's new
 
**New: `src/lib/developerActivityEngine.ts`**
 
A shared activity/reward engine that centralizes the post-action side-effect
pipeline previously duplicated across multiple routes and services.
 
`processDeveloperActivity(admin, input)` runs the following in order:
 
1. **Last-active update** — fire-and-forget `last_active_at` touch.
2. **XP grants** — each grant calls `grant_xp_atomic` (idempotent, amount ≤ 0
   skipped). Results are returned so callers can inspect success/failure.
3. **Activity feed event** — insert (or upsert with `onConflict`) a single feed
   row.
4. **Achievement check** — if `stats` are provided, evaluate and unlock any
   newly-earned achievements via the existing `checkAchievements` utility.
 
All side-effect failures are caught and logged — they never throw — so the
caller's response is never disrupted by a background pipeline failure.
 
**Key design decisions:**
- The engine is deliberately agnostic to domain-specific side effects (daily
  missions, raid tags, kudos streaks, notifications). Those remain the
  caller's responsibility.
- `stats` is optional: routes that don't load full developer stats (e.g. visit)
  can skip the achievement check while still running XP/feed/last-active.
- The engine reuses the existing `grant_xp_atomic`, `checkAchievements`,
  `touchLastActive`, and `activity_feed` mechanisms — no parallel implementations.
 
### Routes refactored
 
| Route | Common side effects → engine | Domain-specific (unchanged) |
|-------|------------------------------|----------------------------|
| `POST /api/interactions/kudos` | `touchLastActive`, 2× XP grant, feed event, achievement check | `increment_kudos_count`, `update_kudos_streak`, `increment_kudos_week`, daily missions |
| `POST /api/interactions/visit` | `touchLastActive`, XP grant | `increment_visit_count`, daily missions, building milestone feed |
| `POST /api/fly-scores` | `touchLastActive`, XP grant | Daily missions |
| `performRaidPostExecution` | `touchLastActive`, 2× XP grant (win/loss), feed event | `increment_raid_xp`, `increment_relic_progress`, raid tags, notifications, daily missions |
 
### XP amounts and sources remain unchanged
 
- Kudos: giver +3 (`kudos_given`), receiver +1 (`kudos_received`)
- Visit: visitor +2 (`visit`)
- Fly: `floor(score * 0.1)` (`fly`)
- Raid win: attacker +50 (`raid_win`), defender +30 (`raid_defend`)
- Raid loss: attacker +15 (`raid_loss`), defender +30 (`raid_defend`)
 
### Activity feed event types and metadata remain unchanged
 
All event types, actor/target IDs, and metadata payloads are preserved exactly
as before — only the call site moved from inline to the engine.
 
### Tests
 
- **14 new unit tests** for the engine covering: XP grants (success/failure),
  feed insert/upsert, achievement checks (with/without stats), error resilience
  (RPC failures, feed insert failures, achievement check failures), and skip
  paths (zero-amount XP, no feed event, no stats).
- **4 existing tests** (raid-post-execution, rewardCoordinator, raidService)
  continue to pass, confirming the refactored routes preserve behavior.
 
### Validation
- `tsc --noEmit` clean · `eslint` clean (0 errors) · `vitest` 18/18 passing
 
## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
- [x] I acknowledge that an automated AI Reviewer will perform a preliminary review of this PR.
- [x] ⭐ **I have starred this repository!** (We prioritize PRs and assignments for stargazers)
